### PR TITLE
Ensure auto-unload handler callbacks are single and cleared

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/llm/LlmRuntimeManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/LlmRuntimeManager.kt
@@ -2,6 +2,8 @@ package com.example.coupontracker.llm
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -47,6 +49,7 @@ class LlmRuntimeManager private constructor(private val context: Context) {
     
     // Native interface and model state
     private val nativeInterface = MlcLlmNative()
+    private val mainHandler = Handler(Looper.getMainLooper())
     private var modelHandle: Long = 0
     private val isModelLoaded = AtomicBoolean(false)
     private val referenceCount = AtomicInteger(0)
@@ -208,9 +211,11 @@ class LlmRuntimeManager private constructor(private val context: Context) {
      * Release model reference, unload if no more references
      */
     fun releaseModel() {
+        mainHandler.removeCallbacks(autoUnloadRunnable)
+
         val newCount = referenceCount.decrementAndGet()
         Log.d(TAG, "Released model reference, count: $newCount")
-        
+
         if (newCount <= 0) {
             unloadModel()
         }
@@ -221,6 +226,8 @@ class LlmRuntimeManager private constructor(private val context: Context) {
      */
     private fun unloadModel() {
         synchronized(this) {
+            mainHandler.removeCallbacks(autoUnloadRunnable)
+
             if (isModelLoaded.get() && modelHandle != 0L) {
                 try {
                     nativeInterface.releaseModel(modelHandle)
@@ -254,14 +261,8 @@ class LlmRuntimeManager private constructor(private val context: Context) {
      * Schedule auto-unload check
      */
     private fun scheduleAutoUnloadCheck() {
-        // Remove any existing callbacks
-        android.os.Handler(android.os.Looper.getMainLooper()).removeCallbacks(autoUnloadRunnable)
-        
-        // Schedule new check
-        android.os.Handler(android.os.Looper.getMainLooper()).postDelayed(
-            autoUnloadRunnable, 
-            AUTO_UNLOAD_DELAY_MS
-        )
+        mainHandler.removeCallbacks(autoUnloadRunnable)
+        mainHandler.postDelayed(autoUnloadRunnable, AUTO_UNLOAD_DELAY_MS)
     }
     
     /**

--- a/app/src/test/kotlin/com/example/coupontracker/llm/LlmRuntimeManagerHandlerTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/llm/LlmRuntimeManagerHandlerTest.kt
@@ -1,0 +1,54 @@
+package com.example.coupontracker.llm
+
+import android.content.Context
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class LlmRuntimeManagerHandlerTest {
+
+    private lateinit var context: Context
+    private lateinit var llmRuntimeManager: LlmRuntimeManager
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        llmRuntimeManager = LlmRuntimeManager.getInstance(context)
+    }
+
+    @Test
+    fun `scheduleAutoUnloadCheck only keeps one pending runnable`() {
+        val scheduleMethod = llmRuntimeManager.javaClass.getDeclaredMethod("scheduleAutoUnloadCheck").apply {
+            isAccessible = true
+        }
+
+        val shadowLooper = Shadows.shadowOf(Looper.getMainLooper())
+        val scheduler = shadowLooper.scheduler
+
+        // Invoke twice and ensure only one runnable is queued
+        scheduleMethod.invoke(llmRuntimeManager)
+        assertEquals(1, scheduler.size())
+
+        scheduleMethod.invoke(llmRuntimeManager)
+        assertEquals(1, scheduler.size())
+
+        // Simulate releasing the model and ensure callbacks are cleared
+        val referenceCountField = llmRuntimeManager.javaClass.getDeclaredField("referenceCount").apply {
+            isAccessible = true
+        }
+        val referenceCount = referenceCountField.get(llmRuntimeManager) as AtomicInteger
+        referenceCount.set(1)
+
+        llmRuntimeManager.releaseModel()
+        assertEquals(0, scheduler.size())
+    }
+}


### PR DESCRIPTION
## Summary
- update `LlmRuntimeManager` to share a main-thread `Handler` for auto-unload logic and clear callbacks when releasing or unloading
- add a Robolectric unit test that verifies only one auto-unload runnable is scheduled and that it is removed on release

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e55c5cd083289bd037c2b68d19ba