### PR TITLE
Refactor model verification to run asynchronously

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.example.coupontracker.util.SecurePreferencesManager
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -19,7 +21,10 @@ import java.util.zip.ZipInputStream
 /**
  * Manages downloading and verification of MiniCPM-Llama3-V2.5 model files
  */
-class ModelDownloadManager(private val context: Context) {
+class ModelDownloadManager(
+    private val context: Context,
+    private val verificationDispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
     
     companion object {
         private const val TAG = "ModelDownloadManager"
@@ -55,6 +60,14 @@ class ModelDownloadManager(private val context: Context) {
     
     private val securePrefs = SecurePreferencesManager(context)
     private val modelDir = File(context.filesDir, "models")
+
+    private data class VerificationCache(val version: String?, val result: Boolean)
+
+    @Volatile
+    private var verificationCache: VerificationCache? = null
+
+    @Volatile
+    private var verificationListener: (() -> Unit)? = null
     
     init {
         // Ensure model directory exists
@@ -152,7 +165,8 @@ class ModelDownloadManager(private val context: Context) {
             securePrefs.setLlmModelVersion(MODEL_VERSION)
             securePrefs.setLlmModelSizeMB(modelSizeMB)
             securePrefs.setLlmModelChecksum(calculateModelChecksum())
-            
+
+            verificationCache = VerificationCache(MODEL_VERSION, true)
             Log.d(TAG, "Model download completed successfully")
             progressCallback(DownloadProgress(100, "Download complete"))
             
@@ -400,7 +414,9 @@ class ModelDownloadManager(private val context: Context) {
                 securePrefs.setLlmModelVersion("")
                 securePrefs.setLlmModelSizeMB(0f)
                 securePrefs.setLlmModelChecksum("")
-                
+
+                verificationCache = null
+
                 Log.d(TAG, "Model files deleted successfully")
             }
             
@@ -419,15 +435,88 @@ class ModelDownloadManager(private val context: Context) {
         val isDownloaded = securePrefs.getLlmModelDownloaded()
         val modelVersion = securePrefs.getLlmModelVersion()
         val sizeMB = if (isDownloaded) securePrefs.getLlmModelSizeMB() else 0f
-        val filesPresent = if (isDownloaded) verifyModelFiles() else false
-        
-        return ModelStatus(
+
+        val cache = verificationCache
+        val cacheMatches = isDownloaded && cache != null && cache.version == modelVersion
+        val filesPresent = if (cacheMatches) cache.result else false
+
+        if (!isDownloaded) {
+            verificationCache = null
+        }
+
+        return updateCachedStatus(
             isDownloaded = isDownloaded,
             filesPresent = filesPresent,
             version = modelVersion ?: "Unknown",
             sizeMB = sizeMB,
+            verificationUpToDate = cacheMatches
+        )
+    }
+
+    suspend fun refreshModelStatus(force: Boolean = false): ModelStatus {
+        val isDownloaded = securePrefs.getLlmModelDownloaded()
+        val modelVersion = securePrefs.getLlmModelVersion()
+        val sizeMB = if (isDownloaded) securePrefs.getLlmModelSizeMB() else 0f
+
+        if (!isDownloaded) {
+            verificationCache = null
+            return updateCachedStatus(
+                isDownloaded = false,
+                filesPresent = false,
+                version = modelVersion ?: "Unknown",
+                sizeMB = 0f,
+                verificationUpToDate = false
+            )
+        }
+
+        val cache = verificationCache
+        val cacheMatches = !force && cache != null && cache.version == modelVersion
+        if (cacheMatches) {
+            return updateCachedStatus(
+                isDownloaded = true,
+                filesPresent = cache.result,
+                version = modelVersion ?: "Unknown",
+                sizeMB = sizeMB,
+                verificationUpToDate = true
+            )
+        }
+
+        val filesPresent = withContext(verificationDispatcher) {
+            verificationListener?.invoke()
+            verifyModelFiles()
+        }
+
+        verificationCache = VerificationCache(modelVersion, filesPresent)
+
+        return updateCachedStatus(
+            isDownloaded = true,
+            filesPresent = filesPresent,
+            version = modelVersion ?: "Unknown",
+            sizeMB = sizeMB,
+            verificationUpToDate = true
+        )
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun setVerificationListener(listener: (() -> Unit)?) {
+        verificationListener = listener
+    }
+
+    private fun updateCachedStatus(
+        isDownloaded: Boolean,
+        filesPresent: Boolean,
+        version: String,
+        sizeMB: Float,
+        verificationUpToDate: Boolean
+    ): ModelStatus {
+        return ModelStatus(
+            isDownloaded = isDownloaded,
+            filesPresent = filesPresent,
+            version = version,
+            sizeMB = sizeMB,
             downloadUrl = "$MODEL_BASE_URL/$MODEL_ZIP_NAME",
-            requiredFiles = REQUIRED_FILES.keys.toList()
+            requiredFiles = REQUIRED_FILES.keys.toList(),
+            isVerificationUpToDate = verificationUpToDate
         )
     }
     
@@ -469,5 +558,6 @@ data class ModelStatus(
     val version: String,
     val sizeMB: Float,
     val downloadUrl: String,
-    val requiredFiles: List<String>
+    val requiredFiles: List<String>,
+    val isVerificationUpToDate: Boolean
 )

--- a/app/src/main/kotlin/com/example/coupontracker/ui/fragment/AddFragment.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/fragment/AddFragment.kt
@@ -41,6 +41,8 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.datepicker.MaterialDatePicker
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.*
@@ -61,6 +63,7 @@ class AddFragment : Fragment() {
     private lateinit var sharedPreferences: SharedPreferences
     private lateinit var securePreferencesManager: SecurePreferencesManager
     private lateinit var modelDownloadManager: ModelDownloadManager
+    private var modelStatusJob: Job? = null
 
     companion object {
         private const val TAG = "AddFragment"
@@ -346,25 +349,87 @@ class AddFragment : Fragment() {
     
     private fun updateLlmUiState() {
         val llmSettings = securePreferencesManager.getLlmSettings()
-        val modelStatus = modelDownloadManager.getModelStatus()
-        
+        val cachedStatus = modelDownloadManager.getModelStatus()
+
         // Update switch states
         binding.llmOcrSwitch.isChecked = llmSettings.useLocalLlm
         binding.llmWifiOnlySwitch.isChecked = llmSettings.downloadWifiOnly
-        
+
         // Update controls visibility
         updateLlmControlsVisibility(llmSettings.useLocalLlm)
-        
-        // Update status and buttons
-        updateLlmStatusDisplay(modelStatus)
+
+        // Update status and buttons with cached data
+        updateLlmStatusDisplay(cachedStatus)
+
+        modelStatusJob?.cancel()
+
+        val shouldShowVerification =
+            cachedStatus.isDownloaded && !cachedStatus.isVerificationUpToDate
+        if (shouldShowVerification) {
+            showVerificationLoading(true)
+        } else {
+            showVerificationLoading(false)
+        }
+
+        modelStatusJob = viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val refreshedStatus = modelDownloadManager.refreshModelStatus(
+                    force = !cachedStatus.isVerificationUpToDate
+                )
+                if (isAdded) {
+                    updateLlmStatusDisplay(refreshedStatus)
+                }
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to refresh model status", e)
+            } finally {
+                if (isAdded) {
+                    showVerificationLoading(false)
+                }
+            }
+        }
     }
     
     private fun updateLlmControlsVisibility(enabled: Boolean) {
         binding.llmControlsLayout.visibility = if (enabled) View.VISIBLE else View.GONE
     }
-    
+
+    private fun showVerificationLoading(show: Boolean) {
+        if (!isAdded) return
+
+        if (show) {
+            if (binding.llmDownloadProgress.visibility != View.VISIBLE) {
+                binding.llmDownloadProgress.visibility = View.VISIBLE
+            }
+            binding.llmDownloadProgress.isIndeterminate = true
+            binding.llmProgressText.visibility = View.VISIBLE
+            binding.llmProgressText.text = getString(R.string.llm_verifying_model)
+        } else {
+            val isShowingVerification =
+                binding.llmDownloadProgress.isIndeterminate &&
+                    binding.llmProgressText.text == getString(R.string.llm_verifying_model)
+
+            if (isShowingVerification) {
+                binding.llmDownloadProgress.isIndeterminate = false
+                binding.llmDownloadProgress.visibility = View.GONE
+                binding.llmProgressText.visibility = View.GONE
+                binding.llmProgressText.text = ""
+            }
+        }
+    }
+
     private fun updateLlmStatusDisplay(modelStatus: com.example.coupontracker.llm.ModelStatus) {
         when {
+            modelStatus.isDownloaded && !modelStatus.isVerificationUpToDate -> {
+                binding.llmStatusText.text = getString(R.string.llm_verifying_model)
+                binding.llmSizeText.text = ""
+                binding.llmDownloadButton.visibility = View.GONE
+                binding.llmDeleteButton.visibility = View.VISIBLE
+                binding.llmStatusText.setTextColor(
+                    ContextCompat.getColor(requireContext(), android.R.color.darker_gray)
+                )
+            }
             modelStatus.isDownloaded && modelStatus.filesPresent -> {
                 binding.llmStatusText.text = "Model ready (${modelStatus.version})"
                 binding.llmSizeText.text = String.format("%.1f MB", modelStatus.sizeMB)
@@ -417,6 +482,8 @@ class AddFragment : Fragment() {
         
         // Show progress UI
         binding.llmDownloadProgress.visibility = View.VISIBLE
+        binding.llmDownloadProgress.isIndeterminate = false
+        binding.llmDownloadProgress.setProgressCompat(0, false)
         binding.llmProgressText.visibility = View.VISIBLE
         binding.llmDownloadButton.isEnabled = false
         binding.llmDownloadButton.text = "Downloading..."
@@ -789,6 +856,7 @@ class AddFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         cameraExecutor.shutdown()
+        modelStatusJob?.cancel()
         _binding = null
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="export_data">Export Data</string>
     <string name="import_data">Import Data</string>
     <string name="clear_data">Clear All Data</string>
+    <string name="llm_verifying_model">Verifying model integrity…</string>
 </resources>

--- a/app/src/test/kotlin/com/example/coupontracker/llm/ModelDownloadManagerAsyncTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/llm/ModelDownloadManagerAsyncTest.kt
@@ -1,0 +1,72 @@
+package com.example.coupontracker.llm
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import com.example.coupontracker.util.SecurePreferencesManager
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.android.asCoroutineDispatcher
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class ModelDownloadManagerAsyncTest {
+
+    private lateinit var context: Context
+    private lateinit var securePreferencesManager: SecurePreferencesManager
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        securePreferencesManager = SecurePreferencesManager(context)
+        securePreferencesManager.setLlmModelDownloaded(true)
+        securePreferencesManager.setLlmModelVersion("test-version")
+    }
+
+    @Test
+    fun refreshModelStatus_runsVerificationOffMainThread() = runBlocking {
+        val manager = ModelDownloadManager(context)
+        val executedOnMain = CompletableDeferred<Boolean>()
+
+        manager.setVerificationListener {
+            executedOnMain.complete(Looper.myLooper() == Looper.getMainLooper())
+        }
+
+        val mainDispatcher = Handler(Looper.getMainLooper()).asCoroutineDispatcher()
+        try {
+            val job = async(mainDispatcher) {
+                manager.refreshModelStatus(force = true)
+            }
+            job.await()
+        } finally {
+            mainDispatcher.close()
+        }
+
+        assertFalse(executedOnMain.await(), "Verification should run off the main thread")
+    }
+
+    @Test
+    fun refreshModelStatus_cachesVerificationResult() = runBlocking {
+        val manager = ModelDownloadManager(context)
+        val invocationCount = AtomicInteger(0)
+
+        manager.setVerificationListener {
+            invocationCount.incrementAndGet()
+        }
+
+        manager.refreshModelStatus(force = true)
+        manager.refreshModelStatus()
+
+        assertEquals(1, invocationCount.get(), "Verification should be cached after the first refresh")
+    }
+}


### PR DESCRIPTION
## Summary
- make `ModelDownloadManager` cache verification results and expose a suspend `refreshModelStatus` that verifies files on a background dispatcher
- update `AddFragment` to refresh the status in a lifecycle-aware coroutine, surface a verification indicator, and add supporting string resources
- add Robolectric coverage that asserts verification runs off the main thread and cached results skip redundant hashing

## Testing
- ./gradlew test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e55f79648328a9f21c1cafe301da