### PR TITLE
Add MiniCPM test fixtures and verification tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ build/
 # Data directories
 data/
 models/
+!app/src/test/resources/models/
+!app/src/test/resources/models/**
 
 # Large files
 *.dylib

--- a/app/src/test/kotlin/com/example/coupontracker/llm/ModelDownloadManagerTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/llm/ModelDownloadManagerTest.kt
@@ -1,0 +1,179 @@
+package com.example.coupontracker.llm
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.example.coupontracker.util.SecurePreferencesManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+import java.security.MessageDigest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class ModelDownloadManagerTest {
+
+    private lateinit var context: Context
+    private lateinit var securePreferencesManager: SecurePreferencesManager
+    private lateinit var modelDownloadManager: ModelDownloadManager
+
+    private lateinit var originalRequiredFiles: Map<String, String>
+    private lateinit var goodFixtureChecksums: Map<String, String>
+
+    private val fixtureFileNames = listOf(
+        "minicpm_llm_q4f16_1.so",
+        "mlc-chat-config.json",
+        "tokenizer.json",
+        "params_shard_0.bin",
+        "params_shard_1.bin",
+        "ndarray-cache.json",
+        "vocab.txt"
+    )
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        securePreferencesManager = SecurePreferencesManager(context)
+
+        originalRequiredFiles = readRequiredFiles()
+        goodFixtureChecksums = loadFixtureChecksums("good")
+        overrideRequiredFiles(goodFixtureChecksums)
+
+        modelDownloadManager = ModelDownloadManager(context)
+
+        securePreferencesManager.setLlmModelDownloaded(true)
+        securePreferencesManager.setLlmModelVersion("test-fixture")
+    }
+
+    @After
+    fun tearDown() {
+        overrideRequiredFiles(originalRequiredFiles)
+        securePreferencesManager.setLlmModelDownloaded(false)
+        securePreferencesManager.setLlmModelVersion("")
+        securePreferencesManager.setLlmModelSizeMB(0f)
+        securePreferencesManager.setLlmModelChecksum("")
+        getModelDir().deleteRecursively()
+    }
+
+    @Test
+    fun refreshModelStatus_withValidFixture_marksFilesPresent() = runTest {
+        copyFixtureFiles("good")
+
+        val status = modelDownloadManager.refreshModelStatus(force = true)
+
+        kotlin.test.assertTrue(status.filesPresent, "Expected valid MiniCPM fixture to be accepted")
+    }
+
+    @Test
+    fun refreshModelStatus_withTamperedFixture_detectsChecksumMismatch() = runTest {
+        copyFixtureFiles("tampered")
+
+        val status = modelDownloadManager.refreshModelStatus(force = true)
+
+        kotlin.test.assertFalse(status.filesPresent, "Expected tampered MiniCPM fixture to be rejected")
+    }
+
+    private fun copyFixtureFiles(fixtureName: String) {
+        val modelDir = getModelDir()
+        if (modelDir.exists()) {
+            modelDir.deleteRecursively()
+        }
+        modelDir.mkdirs()
+
+        val classLoader = javaClass.classLoader ?: error("Missing class loader")
+
+        fixtureFileNames.forEach { fileName ->
+            val resourcePath = "models/minicpm/$fixtureName/$fileName"
+            val targetFile = File(modelDir, fileName)
+
+            classLoader.getResourceAsStream(resourcePath)?.use { input ->
+                targetFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            } ?: error("Fixture resource not found: $resourcePath")
+        }
+
+        val totalBytes = modelDir.walkTopDown()
+            .filter { it.isFile }
+            .sumOf { it.length() }
+
+        securePreferencesManager.setLlmModelSizeMB(totalBytes / (1024f * 1024f))
+        securePreferencesManager.setLlmModelDownloaded(true)
+        securePreferencesManager.setLlmModelChecksum(calculateAggregateChecksum(modelDir))
+    }
+
+    private fun loadFixtureChecksums(fixtureName: String): Map<String, String> {
+        val classLoader = javaClass.classLoader ?: error("Missing class loader")
+        return fixtureFileNames.associateWith { fileName ->
+            val resourcePath = "models/minicpm/$fixtureName/$fileName"
+            classLoader.getResourceAsStream(resourcePath)?.use { input ->
+                calculateChecksum(input)
+            } ?: error("Fixture resource not found: $resourcePath")
+        }
+    }
+
+    private fun calculateAggregateChecksum(modelDir: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        modelDir.walkTopDown()
+            .filter { it.isFile }
+            .sortedBy { it.name }
+            .forEach { file ->
+                val checksum = file.inputStream().use { input ->
+                    calculateChecksum(input)
+                }
+                digest.update(checksum.toByteArray())
+            }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun calculateChecksum(inputStream: InputStream): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val read = inputStream.read(buffer)
+            if (read == -1) break
+            digest.update(buffer, 0, read)
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun readRequiredFiles(): Map<String, String> {
+        val companion = getCompanionInstance()
+        val field = companion.javaClass.getDeclaredField("REQUIRED_FILES")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return (field.get(companion) as Map<String, String>).toMap()
+    }
+
+    private fun overrideRequiredFiles(newValue: Map<String, String>) {
+        val companion = getCompanionInstance()
+        val field = companion.javaClass.getDeclaredField("REQUIRED_FILES")
+        field.isAccessible = true
+
+        removeFinalModifier(field)
+        field.set(companion, newValue)
+    }
+
+    private fun getCompanionInstance(): Any {
+        val companionField = ModelDownloadManager::class.java.getDeclaredField("Companion")
+        companionField.isAccessible = true
+        return companionField.get(null)
+    }
+
+    private fun removeFinalModifier(field: Field) {
+        val modifiersField = Field::class.java.getDeclaredField("modifiers")
+        modifiersField.isAccessible = true
+        modifiersField.setInt(field, field.modifiers and Modifier.FINAL.inv())
+    }
+
+    private fun getModelDir(): File = File(context.filesDir, "models")
+}

--- a/app/src/test/resources/models/minicpm/good/minicpm_llm_q4f16_1.so
+++ b/app/src/test/resources/models/minicpm/good/minicpm_llm_q4f16_1.so
@@ -1,0 +1,1 @@
+MiniCPM shared object fixture - good version

--- a/app/src/test/resources/models/minicpm/good/mlc-chat-config.json
+++ b/app/src/test/resources/models/minicpm/good/mlc-chat-config.json
@@ -1,0 +1,5 @@
+{
+  "model": "MiniCPM-Llama3-V2.5",
+  "quantization": "q4f16_1",
+  "description": "Good config fixture"
+}

--- a/app/src/test/resources/models/minicpm/good/ndarray-cache.json
+++ b/app/src/test/resources/models/minicpm/good/ndarray-cache.json
@@ -1,0 +1,4 @@
+{
+  "cache": [1, 2, 3],
+  "description": "Good ndarray cache"
+}

--- a/app/src/test/resources/models/minicpm/good/params_shard_0.bin
+++ b/app/src/test/resources/models/minicpm/good/params_shard_0.bin
@@ -1,0 +1,1 @@
+MiniCPM parameters shard 0 - good data

--- a/app/src/test/resources/models/minicpm/good/params_shard_1.bin
+++ b/app/src/test/resources/models/minicpm/good/params_shard_1.bin
@@ -1,0 +1,1 @@
+MiniCPM parameters shard 1 - good data

--- a/app/src/test/resources/models/minicpm/good/tokenizer.json
+++ b/app/src/test/resources/models/minicpm/good/tokenizer.json
@@ -1,0 +1,4 @@
+{
+  "tokenizer": "minicpm-tokenizer",
+  "version": 1
+}

--- a/app/src/test/resources/models/minicpm/good/vocab.txt
+++ b/app/src/test/resources/models/minicpm/good/vocab.txt
@@ -1,0 +1,3 @@
+coupon
+store
+savings

--- a/app/src/test/resources/models/minicpm/tampered/minicpm_llm_q4f16_1.so
+++ b/app/src/test/resources/models/minicpm/tampered/minicpm_llm_q4f16_1.so
@@ -1,0 +1,1 @@
+MiniCPM shared object fixture - good version

--- a/app/src/test/resources/models/minicpm/tampered/mlc-chat-config.json
+++ b/app/src/test/resources/models/minicpm/tampered/mlc-chat-config.json
@@ -1,0 +1,5 @@
+{
+  "model": "MiniCPM-Llama3-V2.5",
+  "quantization": "q4f16_1",
+  "description": "Good config fixture"
+}

--- a/app/src/test/resources/models/minicpm/tampered/ndarray-cache.json
+++ b/app/src/test/resources/models/minicpm/tampered/ndarray-cache.json
@@ -1,0 +1,4 @@
+{
+  "cache": [1, 2, 3],
+  "description": "Good ndarray cache"
+}

--- a/app/src/test/resources/models/minicpm/tampered/params_shard_0.bin
+++ b/app/src/test/resources/models/minicpm/tampered/params_shard_0.bin
@@ -1,0 +1,1 @@
+MiniCPM parameters shard 0 - good data

--- a/app/src/test/resources/models/minicpm/tampered/params_shard_1.bin
+++ b/app/src/test/resources/models/minicpm/tampered/params_shard_1.bin
@@ -1,0 +1,1 @@
+MiniCPM parameters shard 1 - tampered data

--- a/app/src/test/resources/models/minicpm/tampered/tokenizer.json
+++ b/app/src/test/resources/models/minicpm/tampered/tokenizer.json
@@ -1,0 +1,4 @@
+{
+  "tokenizer": "minicpm-tokenizer",
+  "version": 1
+}

--- a/app/src/test/resources/models/minicpm/tampered/vocab.txt
+++ b/app/src/test/resources/models/minicpm/tampered/vocab.txt
@@ -1,0 +1,3 @@
+coupon
+store
+savings


### PR DESCRIPTION
## Summary
- add MiniCPM model fixture directories under the app module's test resources
- add a Robolectric ModelDownloadManager test that loads fixtures via the class loader and validates checksum handling
- update .gitignore so the new test fixtures are included in version control

## Testing
- ./gradlew test --tests "com.example.coupontracker.llm.ModelDownloadManagerTest" *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ea5327ec8328aa2411d247642b6f