### PR TITLE
Point model downloads to CDN

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
@@ -30,7 +30,7 @@ class ModelDownloadManager(
         private const val TAG = "ModelDownloadManager"
         
         // Model download configuration
-        private const val MODEL_BASE_URL = "https://huggingface.co/openbmb/MiniCPM-Llama3-V-2_5-int4/resolve/main"
+        private const val MODEL_BASE_URL = "https://cdn.coupontracker.ai/android/minicpm"
         private const val MODEL_ZIP_NAME = "minicpm_llama3_v25_android.zip"
         private const val MODEL_VERSION = "v2.5-q4-android"
         


### PR DESCRIPTION
## Summary
- point the MiniCPM model downloader at the new CDN base URL so the Android package resolves correctly

## Testing
- ./gradlew :app:testDebugUnitTest --tests "*ModelDownloadManager*" *(fails: Android SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c0c790588328a68ef0934f294163