### PR TITLE
Improve model download error propagation

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
-import java.io.InputStream
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 import java.security.MessageDigest
@@ -120,15 +120,16 @@ class ModelDownloadManager(
             val tempFile = File(context.cacheDir, "temp_$MODEL_ZIP_NAME")
             
             // Download model zip
-            val downloadSuccess = downloadFile(
+            val downloadResult = downloadFile(
                 url = "$MODEL_BASE_URL/$MODEL_ZIP_NAME",
                 outputFile = tempFile,
                 progressCallback = progressCallback
             )
-            
-            if (!downloadSuccess) {
+
+            downloadResult.getOrElse { error ->
                 tempFile.delete()
-                return@withContext DownloadResult.Error("Download failed")
+                val reason = error.message?.takeIf { it.isNotBlank() } ?: error::class.java.simpleName
+                return@withContext DownloadResult.Error("Download failed: $reason")
             }
             
             // Verify downloaded file
@@ -173,68 +174,82 @@ class ModelDownloadManager(
             
         } catch (e: Exception) {
             Log.e(TAG, "Model download failed", e)
-            DownloadResult.Error("Download failed: ${e.message}")
+            val reason = e.message?.takeIf { it.isNotBlank() } ?: e::class.java.simpleName
+            DownloadResult.Error("Download failed: $reason")
         }
     }
-    
+
     /**
      * Download a file with progress tracking
      */
-    private suspend fun downloadFile(
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal suspend fun downloadFile(
         url: String,
         outputFile: File,
         progressCallback: (DownloadProgress) -> Unit
-    ): Boolean = withContext(Dispatchers.IO) {
+    ): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             val connection = URL(url).openConnection() as HttpURLConnection
             connection.connectTimeout = DOWNLOAD_TIMEOUT_MS.toInt()
             connection.readTimeout = DOWNLOAD_TIMEOUT_MS.toInt()
-            connection.connect()
-            
-            if (connection.responseCode != HttpURLConnection.HTTP_OK) {
-                Log.e(TAG, "Download failed with response code: ${connection.responseCode}")
-                return@withContext false
-            }
-            
-            val fileSize = connection.contentLength
-            var totalBytesRead = 0L
-            var lastProgressUpdate = 0L
-            
-            connection.inputStream.use { input ->
-                FileOutputStream(outputFile).use { output ->
-                    val buffer = ByteArray(BUFFER_SIZE)
-                    var bytesRead: Int
-                    
-                    while (input.read(buffer).also { bytesRead = it } != -1) {
-                        output.write(buffer, 0, bytesRead)
-                        totalBytesRead += bytesRead
-                        
-                        // Update progress periodically
-                        if (totalBytesRead - lastProgressUpdate >= PROGRESS_UPDATE_INTERVAL) {
-                            val progressPercent = if (fileSize > 0) {
-                                ((totalBytesRead * 100) / fileSize).toInt()
-                            } else {
-                                -1 // Unknown progress
+
+            try {
+                connection.connect()
+
+                if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+                    val statusMessage = connection.responseMessage?.takeIf { it.isNotBlank() }
+                    val errorMessage = if (statusMessage != null) {
+                        "HTTP ${connection.responseCode} $statusMessage"
+                    } else {
+                        "HTTP ${connection.responseCode}"
+                    }
+                    Log.e(TAG, "Download failed with response code: $errorMessage")
+                    return@withContext Result.failure(IOException(errorMessage))
+                }
+
+                val fileSize = connection.contentLengthLong
+                var totalBytesRead = 0L
+                var lastProgressUpdate = 0L
+
+                connection.inputStream.use { input ->
+                    FileOutputStream(outputFile).use { output ->
+                        val buffer = ByteArray(BUFFER_SIZE)
+                        var bytesRead: Int
+
+                        while (input.read(buffer).also { bytesRead = it } != -1) {
+                            output.write(buffer, 0, bytesRead)
+                            totalBytesRead += bytesRead
+
+                            // Update progress periodically
+                            if (totalBytesRead - lastProgressUpdate >= PROGRESS_UPDATE_INTERVAL) {
+                                val progressPercent = if (fileSize > 0) {
+                                    ((totalBytesRead * 100) / fileSize).toInt()
+                                } else {
+                                    -1 // Unknown progress
+                                }
+
+                                progressCallback(
+                                    DownloadProgress(
+                                        progressPercent,
+                                        "Downloading... ${formatBytes(totalBytesRead)}" +
+                                            if (fileSize > 0) " / ${formatBytes(fileSize)}" else ""
+                                    )
+                                )
+
+                                lastProgressUpdate = totalBytesRead
                             }
-                            
-                            progressCallback(DownloadProgress(
-                                progressPercent,
-                                "Downloading... ${formatBytes(totalBytesRead)}" +
-                                if (fileSize > 0) " / ${formatBytes(fileSize.toLong())}" else ""
-                            ))
-                            
-                            lastProgressUpdate = totalBytesRead
                         }
                     }
                 }
+
+                Log.d(TAG, "Download completed: ${formatBytes(totalBytesRead)}")
+                Result.success(Unit)
+            } finally {
+                connection.disconnect()
             }
-            
-            Log.d(TAG, "Download completed: ${formatBytes(totalBytesRead)}")
-            true
-            
         } catch (e: Exception) {
             Log.e(TAG, "File download failed", e)
-            false
+            Result.failure(e)
         }
     }
     

--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/SettingsScreen.kt
@@ -665,7 +665,7 @@ private fun LlmStatusCard(securePreferencesManager: SecurePreferencesManager) {
                                                         }
                                                     }
                                                     is com.example.coupontracker.llm.DownloadResult.Error -> {
-                                                        Toast.makeText(context, "Download failed: ${result.message}", Toast.LENGTH_LONG).show()
+                                                        Toast.makeText(context, result.message, Toast.LENGTH_LONG).show()
                                                         downloadStatusMessage = "Download failed"
                                                     }
                                                 }

--- a/app/src/test/kotlin/com/example/coupontracker/llm/ModelDownloadManagerTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/llm/ModelDownloadManagerTest.kt
@@ -5,6 +5,13 @@ import androidx.test.core.app.ApplicationProvider
 import com.example.coupontracker.util.SecurePreferencesManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import io.mockk.Runs
+import io.mockk.anyConstructed
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -13,6 +20,8 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.File
 import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
 import java.security.MessageDigest
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -52,6 +61,7 @@ class ModelDownloadManagerTest {
         securePreferencesManager.setLlmModelSizeMB(0f)
         securePreferencesManager.setLlmModelChecksum("")
         getModelDir().deleteRecursively()
+        runCatching { unmockkConstructor(URL::class) }
     }
 
     @Test
@@ -90,6 +100,39 @@ class ModelDownloadManagerTest {
 
         val status = modelDownloadManager.refreshModelStatus(force = true)
         kotlin.test.assertFalse(status.filesPresent, "Expected status to report missing tokenizer.json")
+    }
+
+    @Test
+    fun downloadFile_whenHttpError_returnsDetailedFailure() = runTest {
+        mockkConstructor(URL::class)
+        val connection = mockk<HttpURLConnection>()
+
+        every { anyConstructed<URL>().openConnection() } returns connection
+        every { connection.connectTimeout = any() } just Runs
+        every { connection.readTimeout = any() } just Runs
+        every { connection.connect() } just Runs
+        every { connection.responseCode } returns 503
+        every { connection.responseMessage } returns "Service Unavailable"
+        every { connection.disconnect() } just Runs
+
+        val tempFile = File.createTempFile("download-test", ".zip")
+        tempFile.deleteOnExit()
+
+        try {
+            val result = modelDownloadManager.downloadFile(
+                url = "https://example.com/model.zip",
+                outputFile = tempFile,
+                progressCallback = { }
+            )
+
+            kotlin.test.assertTrue(result.isFailure, "Expected download to fail for non-200 response")
+            val message = result.exceptionOrNull()?.message ?: ""
+            kotlin.test.assertTrue(message.contains("503"), "Expected error message to include status code, but was: $message")
+            kotlin.test.assertTrue(message.contains("Service Unavailable"), "Expected error message to include response message, but was: $message")
+        } finally {
+            tempFile.delete()
+            unmockkConstructor(URL::class)
+        }
     }
 
     private fun copyFixtureFiles(fixtureName: String) {


### PR DESCRIPTION
## Summary
- capture detailed HTTP/exception information during model downloads and propagate it via `DownloadResult.Error`
- display the propagated error text in the settings download toast for clearer feedback
- add a unit test that mocks a non-200 HTTP response and asserts the error message includes the status code and reason

## Testing
- Not run (Android SDK is not available in the CI environment)

------
https://chatgpt.com/codex/tasks/task_e_68d7c0c88b9c83289531c97571946c0a