### PR TITLE
Restore Hugging Face model download and document override

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -70,8 +70,8 @@ For team testing, deploy the mock artifacts to a simple web server:
 # Upload to your web server
 scp android_models/minicpm_llama3_v25_android.zip user@server:/var/www/html/
 
-# Update MODEL_BASE_URL in ModelDownloadManager.kt
-private const val MODEL_BASE_URL = "https://your-server.com"
+# Update the runtime override in ModelDownloadManager
+securePreferencesManager.setLlmModelBaseUrlOverride("https://your-server.com")
 ```
 
 ### **Option 2: Real MLC-LLM Deployment (Production)**
@@ -119,8 +119,9 @@ python scripts/update_model_checksums.py \
 aws s3 cp android_models/minicpm_llama3_v25_android.zip \
           s3://your-bucket/models/
 
-# Update MODEL_BASE_URL for production
-private const val MODEL_BASE_URL = "https://cdn.your-app.com/models"
+# Default distribution uses Hugging Face (no code changes required)
+# Optional: configure a runtime override once your CDN is live
+securePreferencesManager.setLlmModelBaseUrlOverride("https://cdn.your-app.com/android/minicpm")
 ```
 
 #### **4. Validation & Deployment**
@@ -140,19 +141,23 @@ private const val MODEL_BASE_URL = "https://cdn.your-app.com/models"
 #### **Development (Mock)**
 ```kotlin
 // ModelDownloadManager.kt
-private const val MODEL_BASE_URL = "http://127.0.0.1:8080"
+private const val DEFAULT_MODEL_BASE_URL = "https://huggingface.co/openbmb/MiniCPM-Llama3-V-2_5/resolve/main/android"
+securePreferencesManager.setLlmModelBaseUrlOverride("http://127.0.0.1:8080")
 private const val EXPECTED_ZIP_CHECKSUM = "7a45f222885f84fd0160eeac794ad56be91c6139c436724a56627f16a93d1a76"
 ```
 
 #### **Staging (Mock on Server)**
 ```kotlin
-private const val MODEL_BASE_URL = "https://staging-api.your-app.com/models"
+private const val DEFAULT_MODEL_BASE_URL = "https://huggingface.co/openbmb/MiniCPM-Llama3-V-2_5/resolve/main/android"
+securePreferencesManager.setLlmModelBaseUrlOverride("https://staging-api.your-app.com/models")
 private const val EXPECTED_ZIP_CHECKSUM = "7a45f222885f84fd0160eeac794ad56be91c6139c436724a56627f16a93d1a76"
 ```
 
 #### **Production (Real MLC-LLM)**
 ```kotlin
-private const val MODEL_BASE_URL = "https://cdn.your-app.com/models"
+private const val DEFAULT_MODEL_BASE_URL = "https://huggingface.co/openbmb/MiniCPM-Llama3-V-2_5/resolve/main/android"
+// Optional when CDN is healthy
+securePreferencesManager.setLlmModelBaseUrlOverride("https://cdn.your-app.com/android/minicpm")
 private const val EXPECTED_ZIP_CHECKSUM = "REAL_CHECKSUM_FROM_BUILD_RESULTS"
 ```
 
@@ -272,8 +277,8 @@ adb logcat | grep "mlc_llm_jni"
 ### **Production Deployment**
 - [ ] Real MLC-LLM environment provisioned
 - [ ] Model conversion completed successfully  
-- [ ] Real artifacts uploaded to production CDN
-- [ ] MODEL_BASE_URL updated for production
+- [ ] Real artifacts uploaded to Hugging Face (default) or production CDN
+- [ ] Base URL override configured for production CDN (if applicable)
 - [ ] Release build tested with real artifacts
 - [ ] Analytics/monitoring configured
 - [ ] Rollback plan prepared

--- a/MINICPM_BUILD_GUIDE.md
+++ b/MINICPM_BUILD_GUIDE.md
@@ -218,7 +218,7 @@ Checksums verified and synced with ModelDownloadManager.kt"
 If hosting externally:
 
 1. **Upload** `android_models/minicpm_llama3_v25_android.zip` to your storage
-2. **Update** `MODEL_BASE_URL` in `ModelDownloadManager.kt`
+2. **Configure** `SecurePreferencesManager.setLlmModelBaseUrlOverride(...)` for your distribution endpoint
 3. **Test** download from the new URL
 4. **Commit** the URL change
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -233,6 +233,7 @@ dependencies {
     testImplementation("androidx.arch.core:core-testing:2.2.0")
     testImplementation("app.cash.turbine:turbine:1.0.0")
     testImplementation("org.robolectric:robolectric:4.11.1")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 
     // Android Testing
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
@@ -30,7 +30,8 @@ class ModelDownloadManager(
         private const val TAG = "ModelDownloadManager"
         
         // Model download configuration
-        private const val MODEL_BASE_URL = "https://cdn.coupontracker.ai/android/minicpm"
+        private const val DEFAULT_MODEL_BASE_URL =
+            "https://huggingface.co/openbmb/MiniCPM-Llama3-V-2_5/resolve/main/android"
         private const val MODEL_ZIP_NAME = "minicpm_llama3_v25_android.zip"
         private const val MODEL_VERSION = "v2.5-q4-android"
         
@@ -89,7 +90,7 @@ class ModelDownloadManager(
      */
     private fun shouldProceedWithDownload(): Boolean {
         val wifiOnly = securePrefs.getLlmDownloadWifiOnly()
-        
+
         return if (wifiOnly) {
             isWifiAvailable()
         } else {
@@ -97,6 +98,17 @@ class ModelDownloadManager(
             val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
             connectivityManager.activeNetwork != null
         }
+    }
+
+    /**
+     * Resolve the model download base URL, allowing an override for testing or staged rollouts.
+     */
+    private fun resolveModelBaseUrl(): String {
+        val override = securePrefs.getLlmModelBaseUrlOverride()
+            ?.trim()
+            ?.trimEnd('/')
+
+        return (override?.takeIf { it.isNotEmpty() } ?: DEFAULT_MODEL_BASE_URL).trimEnd('/')
     }
     
     /**
@@ -121,7 +133,7 @@ class ModelDownloadManager(
             
             // Download model zip
             val downloadResult = downloadFile(
-                url = "$MODEL_BASE_URL/$MODEL_ZIP_NAME",
+                url = "${resolveModelBaseUrl()}/$MODEL_ZIP_NAME",
                 outputFile = tempFile,
                 progressCallback = progressCallback
             )
@@ -529,7 +541,7 @@ class ModelDownloadManager(
             filesPresent = filesPresent,
             version = version,
             sizeMB = sizeMB,
-            downloadUrl = "$MODEL_BASE_URL/$MODEL_ZIP_NAME",
+            downloadUrl = "${resolveModelBaseUrl()}/$MODEL_ZIP_NAME",
             requiredFiles = REQUIRED_FILES.keys.toList(),
             isVerificationUpToDate = verificationUpToDate
         )

--- a/app/src/main/kotlin/com/example/coupontracker/util/SecurePreferencesManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/SecurePreferencesManager.kt
@@ -51,6 +51,7 @@ class SecurePreferencesManager @Inject constructor(
         const val KEY_LLM_MODEL_CHECKSUM = "llm_model_checksum"
         const val KEY_LLM_AUTO_DOWNLOAD_ENABLED = "llm_auto_download_enabled"
         const val KEY_LLM_DOWNLOAD_WIFI_ONLY = "llm_download_wifi_only"
+        const val KEY_LLM_MODEL_BASE_URL_OVERRIDE = "llm_model_base_url_override"
 
         // Key rotation period in days
         private const val KEY_ROTATION_PERIOD_DAYS = 90
@@ -434,6 +435,26 @@ class SecurePreferencesManager @Inject constructor(
      */
     fun setLlmDownloadWifiOnly(wifiOnly: Boolean) {
         saveBoolean(KEY_LLM_DOWNLOAD_WIFI_ONLY, wifiOnly)
+    }
+
+    /**
+     * Get any override that should be used instead of the default model base URL.
+     */
+    fun getLlmModelBaseUrlOverride(): String? {
+        return securePrefs.getString(KEY_LLM_MODEL_BASE_URL_OVERRIDE, null)?.takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Persist an override for the model base URL or clear it when null/blank.
+     */
+    fun setLlmModelBaseUrlOverride(baseUrl: String?) {
+        securePrefs.edit().apply {
+            if (baseUrl.isNullOrBlank()) {
+                remove(KEY_LLM_MODEL_BASE_URL_OVERRIDE)
+            } else {
+                putString(KEY_LLM_MODEL_BASE_URL_OVERRIDE, baseUrl)
+            }
+        }.apply()
     }
     
     /**

--- a/app/src/test/kotlin/com/example/coupontracker/llm/ModelDownloadManagerTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/llm/ModelDownloadManagerTest.kt
@@ -1,6 +1,9 @@
 package com.example.coupontracker.llm
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
 import androidx.test.core.app.ApplicationProvider
 import com.example.coupontracker.util.SecurePreferencesManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -12,12 +15,16 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.unmockkConstructor
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.robolectric.Shadows.shadowOf
 import java.io.File
 import java.io.InputStream
 import java.net.HttpURLConnection
@@ -50,6 +57,8 @@ class ModelDownloadManagerTest {
 
         modelDownloadManager = ModelDownloadManager(context)
 
+        getModelDir().deleteRecursively()
+
         securePreferencesManager.setLlmModelDownloaded(true)
         securePreferencesManager.setLlmModelVersion("test-fixture")
     }
@@ -60,6 +69,7 @@ class ModelDownloadManagerTest {
         securePreferencesManager.setLlmModelVersion("")
         securePreferencesManager.setLlmModelSizeMB(0f)
         securePreferencesManager.setLlmModelChecksum("")
+        securePreferencesManager.setLlmModelBaseUrlOverride(null)
         getModelDir().deleteRecursively()
         runCatching { unmockkConstructor(URL::class) }
     }
@@ -133,6 +143,79 @@ class ModelDownloadManagerTest {
             tempFile.delete()
             unmockkConstructor(URL::class)
         }
+    }
+
+    @Test
+    fun downloadModel_withValidDistribution_succeedsAndExtracts() = runTest {
+        simulateWifiConnection()
+        securePreferencesManager.setLlmDownloadWifiOnly(true)
+
+        val server = MockWebServer()
+        val zipFile = locateDistributionZip()
+        val buffer = Buffer().write(zipFile.readBytes())
+
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Length", zipFile.length())
+                .setBody(buffer)
+        )
+
+        server.start()
+
+        try {
+            val overrideBaseUrl = server.url("/android/minicpm").toString().trimEnd('/')
+            securePreferencesManager.setLlmModelBaseUrlOverride(overrideBaseUrl)
+
+            val result = modelDownloadManager.downloadModel { }
+
+            kotlin.test.assertTrue(result is DownloadResult.Success, "Expected download to succeed: $result")
+
+            val modelDir = getModelDir()
+            val expectedFiles = listOf(
+                "model.bin",
+                "vision_config.json",
+                "minicpm_llm_q4f16_1.so",
+                "mlc-chat-config.json",
+                "tokenizer.model",
+                "tokenizer.json"
+            )
+
+            expectedFiles.forEach { fileName ->
+                kotlin.test.assertTrue(
+                    File(modelDir, fileName).exists(),
+                    "Expected $fileName to be extracted"
+                )
+            }
+        } finally {
+            securePreferencesManager.setLlmModelBaseUrlOverride(null)
+            server.shutdown()
+        }
+    }
+
+    private fun simulateWifiConnection() {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val shadowConnectivity = shadowOf(connectivityManager)
+        val network = Network(0)
+        shadowConnectivity.setActiveNetwork(network)
+
+        val capabilities = NetworkCapabilities.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+
+        shadowConnectivity.setNetworkCapabilities(network, capabilities)
+    }
+
+    private fun locateDistributionZip(): File {
+        val candidates = listOf(
+            File(System.getProperty("user.dir"), "android_models/minicpm_llama3_v25_android.zip"),
+            File("android_models/minicpm_llama3_v25_android.zip"),
+            File("../android_models/minicpm_llama3_v25_android.zip")
+        )
+
+        return candidates.firstOrNull { it.exists() }
+            ?: error("Unable to locate MiniCPM distribution zip")
     }
 
     private fun copyFixtureFiles(fixtureName: String) {

--- a/docs/MLC_DEPLOYMENT_GUIDE.md
+++ b/docs/MLC_DEPLOYMENT_GUIDE.md
@@ -97,7 +97,9 @@ For larger models (our case: ~2.4GB):
 
 ```kotlin
 // ModelDownloadManager configuration
-private val MODEL_DOWNLOAD_URL = "https://your-cdn.com/minicpm-android.zip"
+private val MODEL_DOWNLOAD_URL = "https://huggingface.co/openbmb/MiniCPM-Llama3-V-2_5/resolve/main/minicpm_llama3_v25_android.zip"
+// Optional: override with your CDN once it is verified
+securePreferencesManager.setLlmModelBaseUrlOverride("https://cdn.your-app.com/android/minicpm")
 private val MODEL_CHECKSUM = "sha256_from_deployment_manifest"
 ```
 


### PR DESCRIPTION
## Summary
- point the MiniCPM downloader back at the Hugging Face distribution and allow a secure-prefs override for future CDN rollouts
- add unit coverage that exercises `downloadModel` against the checked-in MiniCPM ZIP via a MockWebServer fixture
- document the restored default endpoint in deployment guides and add the MockWebServer dependency for tests

## Testing
- `./gradlew :app:testDebugUnitTest --console=plain` *(fails: Build Tools 35.0.0 cannot be downloaded in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e1e5cc508328846951662b8e6dcb