### PR TITLE
Select latest history entry for model metadata

### DIFF
--- a/update_app.py
+++ b/update_app.py
@@ -57,9 +57,9 @@ def update_app_model(models_dir="models", app_dir="../app/src/main/assets"):
         if os.path.exists(history_file):
             with open(history_file, 'r') as f:
                 history = json.load(f)
-            
+
             if history:
-                latest_model = history[0]
+                latest_model = history[-1]
                 model_version = latest_model.get("version", "unknown")
             else:
                 model_version = "unknown"


### PR DESCRIPTION
## Summary
- load the most recent history entry when determining the model version for metadata

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68d7e9c7af4483289eb1f3e88fb0bb0f