### PR TITLE
Handle connectivity errors in ModelDownloadManager

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.util.Log
 import androidx.annotation.VisibleForTesting
+import com.example.coupontracker.R
 import com.example.coupontracker.util.SecurePreferencesManager
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -12,11 +13,17 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import java.net.ConnectException
 import java.net.HttpURLConnection
+import java.net.NoRouteToHostException
+import java.net.SocketException
+import java.net.SocketTimeoutException
 import java.net.URL
+import java.net.UnknownHostException
 import java.security.MessageDigest
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
+import javax.net.ssl.SSLException
 
 /**
  * Manages downloading and verification of MiniCPM-Llama3-V2.5 model files
@@ -140,8 +147,7 @@ class ModelDownloadManager(
 
             downloadResult.getOrElse { error ->
                 tempFile.delete()
-                val reason = error.message?.takeIf { it.isNotBlank() } ?: error::class.java.simpleName
-                return@withContext DownloadResult.Error("Download failed: $reason")
+                return@withContext DownloadResult.Error(resolveErrorMessage(error))
             }
             
             // Verify downloaded file
@@ -186,10 +192,37 @@ class ModelDownloadManager(
             
         } catch (e: Exception) {
             Log.e(TAG, "Model download failed", e)
-            val reason = e.message?.takeIf { it.isNotBlank() } ?: e::class.java.simpleName
-            DownloadResult.Error("Download failed: $reason")
+            DownloadResult.Error(resolveErrorMessage(e))
         }
     }
+
+    private fun resolveErrorMessage(throwable: Throwable): String {
+        return if (isConnectivityIssue(throwable)) {
+            context.getString(R.string.llm_download_error_network)
+        } else {
+            val reason = throwable.message?.takeIf { it.isNotBlank() } ?: throwable::class.java.simpleName
+            "Download failed: $reason"
+        }
+    }
+
+    private fun isConnectivityIssue(throwable: Throwable): Boolean {
+        var current: Throwable? = throwable
+        while (current != null) {
+            when (current) {
+                is ConnectivityException,
+                is UnknownHostException,
+                is SocketTimeoutException,
+                is ConnectException,
+                is NoRouteToHostException,
+                is SocketException,
+                is SSLException -> return true
+            }
+            current = current.cause
+        }
+        return false
+    }
+
+    private class ConnectivityException(cause: Throwable) : IOException(cause)
 
     /**
      * Download a file with progress tracking
@@ -261,7 +294,12 @@ class ModelDownloadManager(
             }
         } catch (e: Exception) {
             Log.e(TAG, "File download failed", e)
-            Result.failure(e)
+            val exception = if (isConnectivityIssue(e)) {
+                ConnectivityException(e)
+            } else {
+                e
+            }
+            Result.failure(exception)
         }
     }
     

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,4 +28,5 @@
     <string name="import_data">Import Data</string>
     <string name="clear_data">Clear All Data</string>
     <string name="llm_verifying_model">Verifying model integrity…</string>
+    <string name="llm_download_error_network">Check your internet connection or update the model URL in Advanced Settings</string>
 </resources>

--- a/app/src/test/kotlin/com/example/coupontracker/llm/ModelDownloadManagerTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/llm/ModelDownloadManagerTest.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import androidx.test.core.app.ApplicationProvider
+import com.example.coupontracker.R
 import com.example.coupontracker.util.SecurePreferencesManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -29,6 +30,7 @@ import java.io.File
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
+import java.net.UnknownHostException
 import java.security.MessageDigest
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -141,6 +143,34 @@ class ModelDownloadManagerTest {
             kotlin.test.assertTrue(message.contains("Service Unavailable"), "Expected error message to include response message, but was: $message")
         } finally {
             tempFile.delete()
+            unmockkConstructor(URL::class)
+        }
+    }
+
+    @Test
+    fun downloadModel_whenConnectivityFails_returnsFriendlyError() = runTest {
+        simulateWifiConnection()
+        securePreferencesManager.setLlmDownloadWifiOnly(false)
+
+        mockkConstructor(URL::class)
+        val exception = UnknownHostException("Unable to resolve host example.com")
+        every { anyConstructed<URL>().openConnection() } throws exception
+
+        securePreferencesManager.setLlmModelBaseUrlOverride("https://example.com")
+
+        try {
+            val result = modelDownloadManager.downloadModel { }
+
+            kotlin.test.assertTrue(result is DownloadResult.Error, "Expected download to fail for connectivity issues")
+            val expectedMessage = context.getString(R.string.llm_download_error_network)
+            val actualMessage = (result as DownloadResult.Error).message
+            kotlin.test.assertEquals(
+                expectedMessage,
+                actualMessage,
+                "Expected connectivity exceptions to map to a user-friendly message"
+            )
+        } finally {
+            securePreferencesManager.setLlmModelBaseUrlOverride(null)
             unmockkConstructor(URL::class)
         }
     }


### PR DESCRIPTION
## Summary
- map connectivity-related download failures to a localized, user-facing message
- add a reusable connectivity detection helper and string resource
- cover the new error handling path with a targeted unit test

## Testing
- ./gradlew :app:testDebugUnitTest --tests "*ModelDownloadManagerTest*" *(fails: Android SDK not configured in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d7edf9139c83288d379b1eabf05e8b