### PR TITLE
Normalize store names and reject short alphanumerics

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/CouponFieldExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/CouponFieldExtractor.kt
@@ -19,7 +19,7 @@ class CouponFieldExtractor {
             // Common explicit "from [merchant]" format
             Pattern.compile("(?i)(?:from|at|by|shop)\\s+([A-Z][A-Za-z0-9\\s&.'-]{2,25})\\b"),
             // Common merchant names - high confidence
-            Pattern.compile("(?i)\\b(myntra|amazon|flipkart|swiggy|zomato|uber|ola|makemytrip|paytm|phonepe|google|microsoft|apple|netflix|spotify)\\b"),
+            Pattern.compile("(?i)\\b(${MerchantCatalog.popularMerchantPattern})\\b"),
             // Payment apps that issue coupons
             Pattern.compile("(?i)\\b(gpay|googlepay|amazonpay|paytm|phonepe|mobikwik|freecharge)\\b")
         )

--- a/app/src/main/kotlin/com/example/coupontracker/util/GenericFieldHeuristics.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/GenericFieldHeuristics.kt
@@ -48,6 +48,15 @@ object GenericFieldHeuristics {
             return true
         }
         
+        // Treat two-character alphanumeric tokens (F2, 9X) as noise
+        if (cleanValue.length == 2 &&
+            cleanValue.any { it.isDigit() } &&
+            cleanValue.any { it.isLetter() }
+        ) {
+            Log.d(TAG, "Treating '$value' as alphanumeric noise - two-character token")
+            return true
+        }
+
         // Check for single digits or very short non-meaningful text
         if (cleanValue.matches(Regex("\\d{1,2}")) || cleanValue.length <= 2) {
             Log.d(TAG, "Treating '$value' as too short/meaningless - length: ${cleanValue.length}")

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.Date
+import java.util.Locale
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -30,13 +31,78 @@ class LocalLlmOcrService(
     
     companion object {
         private const val TAG = "LocalLlmOcrService"
-        
+
         // Inference timeout (30 seconds)
         private const val INFERENCE_TIMEOUT_MS = 30000L
-        
+
         // Model version tracking
         private const val SERVICE_VERSION = "1.0.0"
         private const val SUPPORTED_MODEL_VERSION = "v2.5-q4-android"
+
+        private val LEADING_TOKEN_ALLOWED_PUNCTUATION = setOf('\'', '&', '-', '.')
+
+        internal fun normalizeStoreName(rawStoreName: String?): String {
+            if (rawStoreName.isNullOrBlank()) {
+                return "Unknown Store"
+            }
+
+            val trimmed = rawStoreName.trim()
+            if (trimmed.equals("Unknown", ignoreCase = true)) {
+                return "Unknown Store"
+            }
+
+            val filteredTokens = trimmed.split(Regex("\\s+")).dropWhile { token ->
+                shouldDropLeadingToken(token)
+            }
+
+            val cleaned = filteredTokens.joinToString(" ").ifBlank { trimmed }
+            val normalized = cleaned.trim().replace(Regex("\\s+"), " ")
+            if (normalized.isBlank()) {
+                return "Unknown Store"
+            }
+
+            if (GenericFieldHeuristics.isGenericOrMissing(normalized)) {
+                return "Unknown Store"
+            }
+
+            MerchantCatalog.findBestMatch(normalized)?.let { return it }
+
+            val displayName = normalized.split(Regex("\\s+")).joinToString(" ") { token ->
+                if (token.all { it.isUpperCase() || !it.isLetter() }) {
+                    token.lowercase(Locale.ROOT).replaceFirstChar { ch ->
+                        if (ch.isLowerCase()) ch.titlecase(Locale.ROOT) else ch.toString()
+                    }
+                } else {
+                    token.replaceFirstChar { ch ->
+                        if (ch.isLowerCase()) ch.titlecase(Locale.ROOT) else ch.toString()
+                    }
+                }
+            }
+
+            return displayName
+        }
+
+        private fun shouldDropLeadingToken(token: String): Boolean {
+            if (token.isBlank()) return true
+
+            val trimmedToken = token.trim()
+            if (trimmedToken.isEmpty()) return true
+
+            val firstChar = trimmedToken.first()
+            if (!firstChar.isLetter()) {
+                return true
+            }
+
+            if (trimmedToken.any { it.isDigit() }) {
+                return true
+            }
+
+            if (trimmedToken.any { !it.isLetter() && it !in LEADING_TOKEN_ALLOWED_PUNCTUATION }) {
+                return true
+            }
+
+            return false
+        }
     }
     
     // Dependencies
@@ -241,13 +307,7 @@ class LocalLlmOcrService(
             val json = JSONObject(cleanResponse)
             
             // Extract fields with fallbacks and generic filtering
-            val storeName = json.optString("storeName", "Unknown Store").let {
-                when {
-                    it.isBlank() || it == "Unknown" -> "Unknown Store"
-                    GenericFieldHeuristics.isGenericOrMissing(it) -> "Unknown Store"
-                    else -> it
-                }
-            }
+            val storeName = normalizeStoreName(json.optString("storeName"))
             
             val description = json.optString("description", "Coupon offer").let {
                 when {

--- a/app/src/main/kotlin/com/example/coupontracker/util/MerchantCatalog.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/MerchantCatalog.kt
@@ -1,0 +1,47 @@
+package com.example.coupontracker.util
+
+import java.util.Locale
+import java.util.regex.Pattern
+
+/**
+ * Shared merchant catalog used by OCR components to normalize detected store names.
+ */
+object MerchantCatalog {
+    private val POPULAR_MERCHANTS = listOf(
+        "Myntra",
+        "Amazon",
+        "Flipkart",
+        "Swiggy",
+        "Zomato",
+        "Uber",
+        "Ola",
+        "MakeMyTrip",
+        "Paytm",
+        "PhonePe",
+        "Google",
+        "Microsoft",
+        "Apple",
+        "Netflix",
+        "Spotify"
+    )
+
+    private val MERCHANT_LOOKUP = POPULAR_MERCHANTS.associateBy { it.lowercase(Locale.ROOT) }
+
+    val popularMerchantPattern: String by lazy {
+        POPULAR_MERCHANTS.joinToString("|") { Pattern.quote(it) }
+    }
+
+    fun findBestMatch(candidate: String): String? {
+        val normalized = candidate.trim().lowercase(Locale.ROOT)
+        if (normalized.isEmpty()) return null
+
+        MERCHANT_LOOKUP[normalized]?.let { return it }
+
+        val tokens = normalized.split(Regex("\\s+"))
+        for (token in tokens) {
+            MERCHANT_LOOKUP[token]?.let { return it }
+        }
+
+        return null
+    }
+}

--- a/app/src/test/kotlin/com/example/coupontracker/util/GenericFieldHeuristicsTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/GenericFieldHeuristicsTest.kt
@@ -51,6 +51,8 @@ class GenericFieldHeuristicsTest {
         assertTrue(GenericFieldHeuristics.isGenericOrMissing("22"))
         assertTrue(GenericFieldHeuristics.isGenericOrMissing("a"))
         assertTrue(GenericFieldHeuristics.isGenericOrMissing("ab"))
+        assertTrue(GenericFieldHeuristics.isGenericOrMissing("F2"))
+        assertTrue(GenericFieldHeuristics.isGenericOrMissing("9X"))
     }
     
     @Test

--- a/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceNormalizationTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceNormalizationTest.kt
@@ -1,0 +1,13 @@
+package com.example.coupontracker.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalLlmOcrServiceNormalizationTest {
+
+    @Test
+    fun `normalizeStoreName should drop leading alphanumeric noise`() {
+        val normalized = LocalLlmOcrService.normalizeStoreName("F2 Souvenir")
+        assertEquals("Souvenir", normalized)
+    }
+}


### PR DESCRIPTION
## Summary
- share the popular merchant catalog with LocalLlmOcrService so store normalization can reuse CouponFieldExtractor data
- add a normalizeStoreName helper that strips noisy leading tokens, reuses heuristics, and falls back to Unknown Store
- tighten GenericFieldHeuristics and add unit coverage to ensure two-character alphanumerics are discarded and F2 Souvenir normalizes to Souvenir

## Testing
- ./gradlew test --tests "com.example.coupontracker.util.GenericFieldHeuristicsTest" --tests "com.example.coupontracker.util.LocalLlmOcrServiceNormalizationTest" *(fails: missing Android SDK in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d83c147f148328ad02c62063f597ae