### PR TITLE
Sanitize coupon codes across LLM and OCR flows

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/CouponCodeSanitizer.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/CouponCodeSanitizer.kt
@@ -1,0 +1,43 @@
+package com.example.coupontracker.util
+
+/**
+ * Utility helpers for normalising coupon codes extracted from LLM or OCR sources.
+ *
+ * Codes frequently contain errant whitespace or trailing characters when parsed from
+ * screenshots or raw text. The helpers below aggressively trim that noise so downstream
+ * validation operates on a predictable, uppercase alphanumeric token.
+ */
+object CouponCodeSanitizer {
+
+    private val whitespaceRegex = Regex("\\s+")
+
+    /**
+     * Normalise a raw coupon code string.
+     *
+     * Steps:
+     * 1. Trim the value and split by whitespace so we can discard stray trailing
+     *    one-character alphabetic fragments (e.g. "Q2SQ74 JS7CK O" -> "Q2SQ74 JS7CK").
+     * 2. Collapse all whitespace, remove trailing non-alphanumeric characters and
+     *    uppercase the value for consistent comparisons.
+     */
+    fun sanitize(raw: String?): String? {
+        if (raw.isNullOrBlank()) return null
+
+        val trimmed = raw.trim()
+        if (trimmed.isEmpty()) return null
+
+        val segments = trimmed.split(whitespaceRegex)
+            .filter { it.isNotBlank() }
+            .toMutableList()
+
+        while (segments.size > 1 && segments.last().length == 1 && segments.last().all { it.isLetter() }) {
+            segments.removeAt(segments.lastIndex)
+        }
+
+        val collapsed = segments.joinToString(separator = "")
+        val whitespaceRemoved = collapsed.replace(whitespaceRegex, "")
+        val cleaned = whitespaceRemoved.trimEnd { !it.isLetterOrDigit() }.uppercase()
+
+        return cleaned.takeIf { it.isNotBlank() }
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
@@ -131,26 +131,31 @@ class EnhancedOCRHelper {
             while (myntraMatcher.find()) {
                 val potentialCode = myntraMatcher.group(1)
                 // Ensure it has both letters and numbers for higher confidence
-                if (potentialCode.contains(Regex("[A-Z]")) && 
+                if (potentialCode.contains(Regex("[A-Z]")) &&
                     potentialCode.contains(Regex("[0-9]")) &&
                     potentialCode.length >= 10) {
-                    result["code"] = potentialCode.uppercase()
-                    codeFound = true
-                    Log.d(TAG, "Found Myntra coupon code: $potentialCode")
-                    break
+                    val sanitized = CouponCodeSanitizer.sanitize(potentialCode)
+                    if (sanitized != null) {
+                        result["code"] = sanitized
+                        codeFound = true
+                        Log.d(TAG, "Found Myntra coupon code: $sanitized")
+                        break
+                    }
                 }
             }
         }
-        
+
         // If no code found yet, try standard pattern
         if (!codeFound) {
             findMatch(CODE_PATTERN, text)?.let {
-                result["code"] = it.trim().uppercase()
-                codeFound = true
-                Log.d(TAG, "Found standard coupon code: ${it.trim()}")
+                CouponCodeSanitizer.sanitize(it)?.let { sanitized ->
+                    result["code"] = sanitized
+                    codeFound = true
+                    Log.d(TAG, "Found standard coupon code: $sanitized")
+                }
             }
         }
-        
+
         // If still no code found, try looking for isolated alphanumeric strings
         if (!codeFound) {
             // Look for isolated alphanumeric strings that might be codes
@@ -158,12 +163,14 @@ class EnhancedOCRHelper {
             codeRegex.findAll(text).forEach { match ->
                 val potentialCode = match.groupValues[1]
                 // Ensure it has both letters and numbers and isn't just a random sequence
-                if (potentialCode.contains(Regex("[A-Z]")) && 
+                if (potentialCode.contains(Regex("[A-Z]")) &&
                     potentialCode.contains(Regex("[0-9]"))) {
-                    result["code"] = potentialCode.uppercase()
-                    codeFound = true
-                    Log.d(TAG, "Found potential code from isolated string: $potentialCode")
-                    return@forEach
+                    CouponCodeSanitizer.sanitize(potentialCode)?.let { sanitized ->
+                        result["code"] = sanitized
+                        codeFound = true
+                        Log.d(TAG, "Found potential code from isolated string: $sanitized")
+                        return@forEach
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -263,9 +263,10 @@ class LocalLlmOcrService(
             // }
             
             // Try both 'redeemCode' (from prompt) and 'code' (fallback) to handle both field names
-            val code = (json.optString("redeemCode").takeIf { it.isNotBlank() && it != "Unknown" }
-                ?: json.optString("code").takeIf { it.isNotBlank() && it != "Unknown" })
-                ?.trim()?.uppercase()
+            val rawCode = json.optString("redeemCode").takeIf { it.isNotBlank() && it != "Unknown" }
+                ?: json.optString("code").takeIf { it.isNotBlank() && it != "Unknown" }
+
+            val code = CouponCodeSanitizer.sanitize(rawCode)
                 ?.takeIf { !GenericFieldHeuristics.isGenericOrMissing(it) }
             
             val expiryDate = json.optString("expiryDate").let {

--- a/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
@@ -200,11 +200,32 @@ class LocalLlmOcrServiceTest {
         assertEquals("Coupon offer", result.description) // Generic "description" replaced
         assertEquals("FLIP50", result.redeemCode)
         assertEquals(50.0, result.cashbackAmount, 0.01)
-        
+
         // Should pass validation since we have meaningful store name and code
         verify { mockTelemetryService.recordInference(any(), true, any(), any(), null) }
     }
-    
+
+    @Test
+    fun `should sanitize redeem code with whitespace and trailing fragments`() = runTest {
+        val noisyCodeResponse = """
+        {
+            "storeName": "Amazon",
+            "description": "Enjoy a limited time electronics discount",
+            "redeemCode": "Q2SQ74 JS7CK O",
+            "cashbackAmount": "15%",
+            "expiryDate": "2024-12-31",
+            "minOrderAmount": "₹1500"
+        }
+        """.trimIndent()
+
+        every { mockLlmRuntime.runInference(any(), any()) } returns noisyCodeResponse
+
+        val result = localLlmOcrService.processCouponImage(mockBitmap)
+
+        assertEquals("Amazon", result.storeName)
+        assertEquals("Q2SQ74JS7CK", result.redeemCode)
+    }
+
     @Test
     fun `should handle LLM timeout and use fallback`() = runTest {
         // Arrange: LLM times out


### PR DESCRIPTION
## Summary
- introduce a shared `CouponCodeSanitizer` utility to normalise coupon codes
- apply the sanitizer in both the LLM JSON parser and Enhanced OCR fallback paths
- add a regression unit test that checks `Q2SQ74 JS7CK O` is stored as `Q2SQ74JS7CK`

## Testing
- ./gradlew test --tests com.example.coupontracker.util.LocalLlmOcrServiceTest *(fails: SDK location not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d83c136dd48328a7da0005635e494f