### PR TITLE
Normalize coupon descriptions across OCR fallbacks

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.Date
+import java.util.Locale
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -30,13 +31,58 @@ class LocalLlmOcrService(
     
     companion object {
         private const val TAG = "LocalLlmOcrService"
-        
+
         // Inference timeout (30 seconds)
         private const val INFERENCE_TIMEOUT_MS = 30000L
-        
+
         // Model version tracking
         private const val SERVICE_VERSION = "1.0.0"
         private const val SUPPORTED_MODEL_VERSION = "v2.5-q4-android"
+
+        fun cleanDescription(raw: String?): String {
+            if (raw.isNullOrBlank()) {
+                return ""
+            }
+
+            val timestampPattern = Regex("^\\d{1,2}:\\d{2}")
+            val singleLetterPattern = Regex("""^[A-Za-z]$""")
+
+            val cleanedLines = raw.lines().mapNotNull { line ->
+                val trimmed = line.trim()
+                if (trimmed.isBlank()) {
+                    return@mapNotNull null
+                }
+
+                if (timestampPattern.containsMatchIn(trimmed)) {
+                    return@mapNotNull null
+                }
+
+                if (singleLetterPattern.matches(trimmed)) {
+                    return@mapNotNull null
+                }
+
+                if (trimmed.equals("x", ignoreCase = true)) {
+                    return@mapNotNull null
+                }
+
+                val uppercaseLetters = trimmed.count { it.isLetter() && it.isUpperCase() }
+                val lowercaseLetters = trimmed.count { it.isLetter() && it.isLowerCase() }
+
+                val normalized = if (uppercaseLetters > 0 && uppercaseLetters >= lowercaseLetters && trimmed.contains(' ')) {
+                    trimmed.lowercase(Locale.getDefault()).replaceFirstChar { char ->
+                        if (char.isLowerCase()) char.titlecase(Locale.getDefault()) else char.toString()
+                    }
+                } else {
+                    trimmed
+                }
+
+                normalized
+            }
+
+            return cleanedLines.joinToString(" ")
+                .replace(Regex("\\s+"), " ")
+                .trim()
+        }
     }
     
     // Dependencies
@@ -249,11 +295,13 @@ class LocalLlmOcrService(
                 }
             }
             
-            val description = json.optString("description", "Coupon offer").let {
+            val description = json.optString("description", "").let {
+                val cleaned = cleanDescription(it)
                 when {
-                    it.isBlank() || it == "Unknown" -> "Coupon offer"
-                    GenericFieldHeuristics.isGenericOrMissing(it) -> "Coupon offer"
-                    else -> it.take(100) // Limit length
+                    cleaned.isBlank() -> "Coupon offer"
+                    cleaned.equals("Unknown", ignoreCase = true) -> "Coupon offer"
+                    GenericFieldHeuristics.isGenericOrMissing(cleaned) -> "Coupon offer"
+                    else -> cleaned.take(100)
                 }
             }
             
@@ -301,7 +349,7 @@ class LocalLlmOcrService(
                 }
             }
             
-            CouponInfo(
+            return CouponInfo(
                 storeName = finalStoreName,
                 description = description,
                 expiryDate = parsedExpiryDate,
@@ -462,6 +510,9 @@ class LocalLlmOcrService(
             // Use existing TextExtractor to parse the OCR text
             val textExtractor = TextExtractor()
             val extractedInfo = textExtractor.extractCouponInfoSync(mlKitText, captureTimestamp)
+                .let { info ->
+                    info.copy(description = cleanDescription(info.description))
+                }
             
             // Validate that we got meaningful extraction results
             if (extractedInfo.storeName == "Unknown Store" && 
@@ -480,15 +531,16 @@ class LocalLlmOcrService(
             try {
                 val modelBasedService = ModelBasedOCRService(context)
                 val result = modelBasedService.processCouponImage(bitmap)
-                Log.d(TAG, "Model-based OCR fallback result: $result")
-                return@withContext result
+                val cleanedResult = result.copy(description = cleanDescription(result.description))
+                Log.d(TAG, "Model-based OCR fallback result: $cleanedResult")
+                return@withContext cleanedResult
             } catch (e2: Exception) {
                 Log.e(TAG, "All OCR methods failed", e2)
-                
+
                 // Return minimal CouponInfo as last resort
                 CouponInfo(
                     storeName = "Unknown Store",
-                    description = "All OCR methods failed - please try again"
+                    description = cleanDescription("All OCR methods failed - please try again")
                 )
             }
         }

--- a/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
@@ -101,7 +101,7 @@ class TextExtractor {
 
         val result = CouponInfo(
             storeName = storeName ?: "",
-            description = description ?: "",
+            description = sanitizeDescription(description) ?: "",
             expiryDate = expiryDate,
             cashbackAmount = cashbackAmount,
             redeemCode = redeemCode,
@@ -204,7 +204,7 @@ class TextExtractor {
 
             val cleanDescription = "$storeName Coupon - $discountPhrase"
             Log.d(TAG, "Created clean description: $cleanDescription")
-            return cleanDescription
+            sanitizeDescription(cleanDescription)?.let { return it }
         }
 
         // If we couldn't create a clean description, fall back to pattern matching
@@ -215,7 +215,7 @@ class TextExtractor {
         if (offerMatcher.find()) {
             val offer = offerMatcher.group(1)?.trim()
             Log.d(TAG, "Found description from 'Offer:' pattern: $offer")
-            return offer
+            sanitizeDescription(offer)?.let { return it }
         }
 
         // Look for "You won X products at ₹Y + ₹Z cashback" pattern
@@ -224,7 +224,7 @@ class TextExtractor {
         if (wonProductsMatcher.find()) {
             val desc = wonProductsMatcher.group(1)?.trim()
             Log.d(TAG, "Found description from 'You won products' pattern: $desc")
-            return desc
+            sanitizeDescription(desc)?.let { return it }
         }
 
         // Special case for coupons with "Get upto ₹X" pattern
@@ -233,7 +233,7 @@ class TextExtractor {
         if (getUptoMatcher.find()) {
             val desc = getUptoMatcher.group(1)
             Log.d(TAG, "Found description from 'Get upto' pattern: $desc")
-            return desc
+            sanitizeDescription(desc)?.let { return it }
         }
 
         // Look for "Up to X% off" pattern
@@ -242,7 +242,7 @@ class TextExtractor {
         if (upToMatcher.find()) {
             val desc = upToMatcher.group(1)?.trim()
             Log.d(TAG, "Found description from 'Up to X%' pattern: $desc")
-            return desc
+            sanitizeDescription(desc)?.let { return it }
         }
 
         // Look for "Flat ₹X OFF" pattern
@@ -251,7 +251,7 @@ class TextExtractor {
         if (flatOffMatcher.find()) {
             val desc = flatOffMatcher.group(1)?.trim()
             Log.d(TAG, "Found description from 'Flat ₹X OFF' pattern: $desc")
-            return desc
+            sanitizeDescription(desc)?.let { return it }
         }
 
         // Look for discount descriptions
@@ -268,7 +268,7 @@ class TextExtractor {
             if (matcher.find()) {
                 val desc = matcher.group(1)
                 Log.d(TAG, "Found description from discount pattern: $desc")
-                return desc
+                sanitizeDescription(desc)?.let { return it }
             }
         }
 
@@ -277,10 +277,15 @@ class TextExtractor {
         if (sentences.isNotEmpty() && sentences[0].length > 10) {
             val desc = sentences[0].trim()
             Log.d(TAG, "Using first sentence as description: $desc")
-            return desc
+            return sanitizeDescription(desc)
         }
 
         return null
+    }
+
+    private fun sanitizeDescription(value: String?): String? {
+        val cleaned = LocalLlmOcrService.cleanDescription(value)
+        return cleaned.ifBlank { null }
     }
 
     /**

--- a/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
@@ -200,11 +200,20 @@ class LocalLlmOcrServiceTest {
         assertEquals("Coupon offer", result.description) // Generic "description" replaced
         assertEquals("FLIP50", result.redeemCode)
         assertEquals(50.0, result.cashbackAmount, 0.01)
-        
+
         // Should pass validation since we have meaningful store name and code
         verify { mockTelemetryService.recordInference(any(), true, any(), any(), null) }
     }
-    
+
+    @Test
+    fun `cleanDescription removes noise and normalizes casing`() {
+        val rawDescription = "12:40 9 X\nfree body mist OF YOUR CHOICE"
+
+        val cleaned = LocalLlmOcrService.cleanDescription(rawDescription)
+
+        assertEquals("Free body mist of your choice", cleaned)
+    }
+
     @Test
     fun `should handle LLM timeout and use fallback`() = runTest {
         // Arrange: LLM times out


### PR DESCRIPTION
## Summary
- add a reusable LocalLlmOcrService.cleanDescription helper that strips noise and normalizes casing
- apply the new sanitizer to LLM parsing, OCR fallbacks, and TextExtractor outputs for consistent descriptions
- cover the sanitizer with a unit test to lock in the expected formatting

## Testing
- ./gradlew test *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d83c1785088328ae7cb82a5c7b845f