### PR TITLE
Normalize store name prefixes during OCR parsing

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/GenericFieldHeuristics.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/GenericFieldHeuristics.kt
@@ -8,6 +8,42 @@ import android.util.Log
  */
 object GenericFieldHeuristics {
     private const val TAG = "GenericFieldHeuristics"
+
+    /**
+     * Detect leading store name tokens that should be discarded during normalization.
+     * Used to drop numeric/symbol noise like "F2" or "9X" prefixes before validation.
+     */
+    fun shouldDiscardStorePrefix(token: String): Boolean {
+        if (token.isBlank()) return true
+
+        val trimmed = token.trim()
+        val cleaned = trimmed.trim { !it.isLetterOrDigit() }
+        if (cleaned.isEmpty()) return true
+
+        val hasDigit = cleaned.any { it.isDigit() }
+        val hasLetter = cleaned.any { it.isLetter() }
+        val hasSymbol = trimmed.any { !it.isLetterOrDigit() }
+
+        // Pure numbering or punctuation prefixes ("01", "#", "-", etc.)
+        if (!hasLetter && (hasDigit || hasSymbol)) {
+            Log.d(TAG, "Discarding store prefix '$token' - contains no letters")
+            return true
+        }
+
+        // Short alphanumeric noise like "F2" or "9X" should be removed
+        if (hasDigit && hasLetter && cleaned.length <= 3) {
+            Log.d(TAG, "Discarding store prefix '$token' - short alphanumeric noise")
+            return true
+        }
+
+        // Tokens with symbols but only a couple of characters ("*A", "@B")
+        if (hasSymbol && cleaned.length <= 2) {
+            Log.d(TAG, "Discarding store prefix '$token' - short symbol noise")
+            return true
+        }
+
+        return false
+    }
     
     /**
      * Check if a field contains generic/boilerplate text that should be treated as missing

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -83,6 +83,21 @@ class LocalLlmOcrService(
                 .replace(Regex("\\s+"), " ")
                 .trim()
         }
+
+        fun normalizeStoreName(raw: String?): String {
+            if (raw.isNullOrBlank()) {
+                return ""
+            }
+
+            val tokens = raw.trim().split(Regex("\\s+"))
+            val filteredTokens = tokens.dropWhile { token ->
+                GenericFieldHeuristics.shouldDiscardStorePrefix(token)
+            }
+
+            return filteredTokens.joinToString(" ") { it.trim() }
+                .replace(Regex("\\s+"), " ")
+                .trim()
+        }
     }
     
     // Dependencies
@@ -287,11 +302,12 @@ class LocalLlmOcrService(
             val json = JSONObject(cleanResponse)
             
             // Extract fields with fallbacks and generic filtering
-            val storeName = json.optString("storeName", "Unknown Store").let {
+            val storeName = json.optString("storeName", "Unknown Store").let { raw ->
+                val normalized = normalizeStoreName(raw)
                 when {
-                    it.isBlank() || it == "Unknown" -> "Unknown Store"
-                    GenericFieldHeuristics.isGenericOrMissing(it) -> "Unknown Store"
-                    else -> it
+                    normalized.isBlank() || normalized.equals("Unknown", ignoreCase = true) -> "Unknown Store"
+                    GenericFieldHeuristics.isGenericOrMissing(normalized) -> "Unknown Store"
+                    else -> normalized
                 }
             }
             
@@ -522,7 +538,12 @@ class LocalLlmOcrService(
             }
             
             Log.d(TAG, "Traditional OCR fallback result: $extractedInfo")
-            return@withContext extractedInfo
+            val normalizedInfo = extractedInfo.copy(
+                storeName = normalizeStoreName(extractedInfo.storeName).ifBlank { "Unknown Store" },
+                description = cleanDescription(extractedInfo.description)
+            )
+
+            return@withContext normalizedInfo
             
         } catch (e: Exception) {
             Log.e(TAG, "ML Kit OCR fallback failed: ${e.message}", e)
@@ -531,7 +552,10 @@ class LocalLlmOcrService(
             try {
                 val modelBasedService = ModelBasedOCRService(context)
                 val result = modelBasedService.processCouponImage(bitmap)
-                val cleanedResult = result.copy(description = cleanDescription(result.description))
+                val cleanedResult = result.copy(
+                    storeName = normalizeStoreName(result.storeName).ifBlank { "Unknown Store" },
+                    description = cleanDescription(result.description)
+                )
                 Log.d(TAG, "Model-based OCR fallback result: $cleanedResult")
                 return@withContext cleanedResult
             } catch (e2: Exception) {

--- a/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
@@ -215,6 +215,13 @@ class LocalLlmOcrServiceTest {
     }
 
     @Test
+    fun `normalizeStoreName removes short alphanumeric prefixes`() {
+        val normalized = LocalLlmOcrService.normalizeStoreName("F2 Souvenir")
+
+        assertEquals("Souvenir", normalized)
+    }
+
+    @Test
     fun `should handle LLM timeout and use fallback`() = runTest {
         // Arrange: LLM times out
         every { mockLlmRuntime.runInference(any(), any()) } returns null


### PR DESCRIPTION
## Summary
- add a LocalLlmOcrService helper to normalize store names by dropping numeric or symbolic prefixes before validation
- extend GenericFieldHeuristics with logic to detect discardable store prefixes such as short alphanumeric noise
- cover the normalization behaviour with a unit test that ensures "F2 Souvenir" resolves to "Souvenir"

## Testing
- ./gradlew test --tests com.example.coupontracker.util.LocalLlmOcrServiceTest *(fails: Android SDK not configured in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8994937548328a4f22de9143feede