### PR TITLE
Normalize rupee glyphs in OCR descriptions

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
@@ -223,7 +223,7 @@ class EnhancedOCRHelper {
             // For Myntra, try to find their specific voucher description format
             findMatch(MYNTRA_DESCRIPTION_PATTERN, text)?.let {
                 val description = it.trim() + " up to ₹" + (result["amount"] ?: "").replace("₹", "")
-                result["description"] = description
+                setDescription(result, description)
                 descriptionFound = true
                 Log.d(TAG, "Found Myntra description: $description")
             }
@@ -234,18 +234,18 @@ class EnhancedOCRHelper {
                 myntraDescRegex.find(text)?.let {
                     val desc = it.groupValues[0].trim()
                     if (desc.isNotBlank()) {
-                        result["description"] = desc
+                        setDescription(result, desc)
                         descriptionFound = true
                         Log.d(TAG, "Found Myntra description with alt pattern: $desc")
                     }
                 }
             }
         }
-        
+
         // If no description found yet, try standard pattern
         if (!descriptionFound) {
             findMatch(DESCRIPTION_PATTERN, text)?.let {
-                result["description"] = it.trim()
+                setDescription(result, it.trim())
                 descriptionFound = true
                 Log.d(TAG, "Found standard description: ${it.trim()}")
             }
@@ -254,7 +254,7 @@ class EnhancedOCRHelper {
         // If we couldn't extract any information, provide some defaults
         if (result.isEmpty()) {
             result["storeName"] = if (isMyntraCoupon) "Myntra" else "Unknown Store"
-            result["description"] = "Scanned coupon"
+            setDescription(result, "Scanned coupon")
         }
         
         // Set default amount if not found
@@ -264,6 +264,13 @@ class EnhancedOCRHelper {
         
         Log.d(TAG, "Final extracted coupon info: $result")
         return result
+    }
+
+    private fun setDescription(result: MutableMap<String, String>, description: String) {
+        val cleaned = LocalLlmOcrService.cleanDescription(description)
+        if (cleaned.isNotBlank()) {
+            result["description"] = cleaned
+        }
     }
     
     /**

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -39,6 +39,10 @@ class LocalLlmOcrService(
         private const val SERVICE_VERSION = "1.0.0"
         private const val SUPPORTED_MODEL_VERSION = "v2.5-q4-android"
 
+        private val RUPEE_VARIANT_PATTERN = Regex(
+            pattern = """(?i)(^|\s+)(?:₹|rs\.?|t)[\s:=-]*([+-]?\d[\d,]*(?:\.\d+)?)"""
+        )
+
         fun cleanDescription(raw: String?): String {
             if (raw.isNullOrBlank()) {
                 return ""
@@ -79,9 +83,24 @@ class LocalLlmOcrService(
                 normalized
             }
 
-            return cleanedLines.joinToString(" ")
+            val joined = cleanedLines.joinToString(" ")
                 .replace(Regex("\\s+"), " ")
                 .trim()
+
+            return normalizeRupeeVariants(joined)
+        }
+
+        private fun normalizeRupeeVariants(text: String): String {
+            if (text.isEmpty()) {
+                return text
+            }
+
+            return RUPEE_VARIANT_PATTERN.replace(text) { matchResult ->
+                val leading = matchResult.groupValues[1]
+                val amount = matchResult.groupValues[2]
+                val cleanedAmount = amount.replaceFirst(Regex("^([+-]?)0+(?=\\d)"), "$1")
+                leading + "₹" + cleanedAmount
+            }
         }
     }
     

--- a/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
@@ -215,6 +215,15 @@ class LocalLlmOcrServiceTest {
     }
 
     @Test
+    fun `cleanDescription normalizes rupee-like glyphs`() {
+        val rawDescription = "LIFETIME CASHBACK T568"
+
+        val cleaned = LocalLlmOcrService.cleanDescription(rawDescription)
+
+        assertEquals("Lifetime cashback ₹568", cleaned)
+    }
+
+    @Test
     fun `should handle LLM timeout and use fallback`() = runTest {
         // Arrange: LLM times out
         every { mockLlmRuntime.runInference(any(), any()) } returns null


### PR DESCRIPTION
## Summary
- normalize rupee-like currency markers in `LocalLlmOcrService.cleanDescription` so rupee values are canonical
- reuse the shared sanitizer when `EnhancedOCRHelper` populates fallback descriptions to align OCR outputs
- add a regression test covering rupee glyph normalization in `LocalLlmOcrServiceTest`

## Testing
- ./gradlew test --tests "*LocalLlmOcrServiceTest*" *(fails: Android SDK not configured in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d89946e6dc832887f945135ec44754