### PR TITLE
Sanitize redeem codes in OCR pipelines

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
@@ -131,26 +131,32 @@ class EnhancedOCRHelper {
             while (myntraMatcher.find()) {
                 val potentialCode = myntraMatcher.group(1)
                 // Ensure it has both letters and numbers for higher confidence
-                if (potentialCode.contains(Regex("[A-Z]")) && 
+                if (potentialCode.contains(Regex("[A-Z]")) &&
                     potentialCode.contains(Regex("[0-9]")) &&
                     potentialCode.length >= 10) {
-                    result["code"] = potentialCode.uppercase()
-                    codeFound = true
-                    Log.d(TAG, "Found Myntra coupon code: $potentialCode")
-                    break
+                    val sanitized = RedeemCodeSanitizer.sanitize(potentialCode)
+                    if (sanitized != null) {
+                        result["code"] = sanitized
+                        codeFound = true
+                        Log.d(TAG, "Found Myntra coupon code: $potentialCode")
+                        break
+                    }
                 }
             }
         }
-        
+
         // If no code found yet, try standard pattern
         if (!codeFound) {
             findMatch(CODE_PATTERN, text)?.let {
-                result["code"] = it.trim().uppercase()
-                codeFound = true
-                Log.d(TAG, "Found standard coupon code: ${it.trim()}")
+                val sanitized = RedeemCodeSanitizer.sanitize(it)
+                if (sanitized != null) {
+                    result["code"] = sanitized
+                    codeFound = true
+                    Log.d(TAG, "Found standard coupon code: ${it.trim()}")
+                }
             }
         }
-        
+
         // If still no code found, try looking for isolated alphanumeric strings
         if (!codeFound) {
             // Look for isolated alphanumeric strings that might be codes
@@ -158,12 +164,15 @@ class EnhancedOCRHelper {
             codeRegex.findAll(text).forEach { match ->
                 val potentialCode = match.groupValues[1]
                 // Ensure it has both letters and numbers and isn't just a random sequence
-                if (potentialCode.contains(Regex("[A-Z]")) && 
+                if (potentialCode.contains(Regex("[A-Z]")) &&
                     potentialCode.contains(Regex("[0-9]"))) {
-                    result["code"] = potentialCode.uppercase()
-                    codeFound = true
-                    Log.d(TAG, "Found potential code from isolated string: $potentialCode")
-                    return@forEach
+                    val sanitized = RedeemCodeSanitizer.sanitize(potentialCode)
+                    if (sanitized != null) {
+                        result["code"] = sanitized
+                        codeFound = true
+                        Log.d(TAG, "Found potential code from isolated string: $potentialCode")
+                        return@forEach
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -313,7 +313,7 @@ class LocalLlmOcrService(
             // Try both 'redeemCode' (from prompt) and 'code' (fallback) to handle both field names
             val code = (json.optString("redeemCode").takeIf { it.isNotBlank() && it != "Unknown" }
                 ?: json.optString("code").takeIf { it.isNotBlank() && it != "Unknown" })
-                ?.trim()?.uppercase()
+                ?.let { RedeemCodeSanitizer.sanitize(it) }
                 ?.takeIf { !GenericFieldHeuristics.isGenericOrMissing(it) }
             
             val expiryDate = json.optString("expiryDate").let {

--- a/app/src/main/kotlin/com/example/coupontracker/util/RedeemCodeSanitizer.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/RedeemCodeSanitizer.kt
@@ -1,0 +1,40 @@
+package com.example.coupontracker.util
+
+object RedeemCodeSanitizer {
+    private val whitespaceRegex = "\\s+".toRegex()
+
+    fun sanitize(raw: String?): String? {
+        if (raw.isNullOrBlank()) {
+            return null
+        }
+
+        val trimmed = raw.trim()
+        if (trimmed.isEmpty()) {
+            return null
+        }
+
+        val tokens = whitespaceRegex.split(trimmed).filter { it.isNotBlank() }
+        if (tokens.isEmpty()) {
+            return null
+        }
+
+        val cleanedTokens = tokens.map { token ->
+            token.trim { !it.isLetterOrDigit() }
+        }
+
+        val prunedTokens = cleanedTokens.dropLastWhile { token ->
+            token.isBlank() || token.any { !it.isLetterOrDigit() } || token.length < 2
+        }
+
+        val baseTokens = if (prunedTokens.isNotEmpty()) prunedTokens else cleanedTokens
+
+        val collapsed = baseTokens.joinToString(separator = "") { token ->
+            token.filter { it.isLetterOrDigit() }
+        }
+
+        val sanitized = collapsed.trimEnd { !it.isLetterOrDigit() }
+        val uppercase = sanitized.uppercase()
+
+        return uppercase.takeIf { it.isNotBlank() }
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
@@ -594,7 +594,9 @@ class TextExtractor {
         if (codeMatcher.find()) {
             val code = codeMatcher.group(1)
             Log.d(TAG, "Found code from 'code:' pattern: $code")
-            return code
+            RedeemCodeSanitizer.sanitize(code)?.let { sanitized ->
+                return sanitized
+            }
         }
 
         // Look for "code" pattern without colon (common in Myntra coupons)
@@ -603,7 +605,9 @@ class TextExtractor {
         if (codeWithoutColonMatcher.find()) {
             val code = codeWithoutColonMatcher.group(1)
             Log.d(TAG, "Found code from 'code' pattern without colon: $code")
-            return code
+            RedeemCodeSanitizer.sanitize(code)?.let { sanitized ->
+                return sanitized
+            }
         }
 
         // Check specifically for Myntra coupon code format
@@ -616,7 +620,9 @@ class TextExtractor {
                 // Skip if it's too long to be a code
                 if (potentialCode?.length ?: 0 <= 20) {
                     Log.d(TAG, "Found Myntra code from specific pattern: $potentialCode")
-                    return potentialCode
+                    RedeemCodeSanitizer.sanitize(potentialCode)?.let { sanitized ->
+                        return sanitized
+                    }
                 }
             }
         }
@@ -630,7 +636,9 @@ class TextExtractor {
             // Skip if it's likely not a code (too long or too short)
             if ((potentialCode?.length ?: 0) in 6..20 && !COMMON_WORDS.contains(potentialCode?.lowercase() ?: "")) {
                 Log.d(TAG, "Found code from all caps+digits pattern: $potentialCode")
-                return potentialCode
+                RedeemCodeSanitizer.sanitize(potentialCode)?.let { sanitized ->
+                    return sanitized
+                }
             }
         }
 
@@ -646,7 +654,9 @@ class TextExtractor {
 
                 if (potentialCode.length >= 5 && potentialCode.matches("[A-Z0-9]+".toRegex())) {
                     Log.d(TAG, "Found code after indicator '$indicator': $potentialCode")
-                    return potentialCode
+                    RedeemCodeSanitizer.sanitize(potentialCode)?.let { sanitized ->
+                        return sanitized
+                    }
                 }
             }
         }

--- a/app/src/test/java/com/example/coupontracker/util/TextExtractorTest.kt
+++ b/app/src/test/java/com/example/coupontracker/util/TextExtractorTest.kt
@@ -158,10 +158,19 @@ class TextExtractorTest {
             Code: SWGGS01BO719GFHS
             Claim Now
         """.trimIndent()
-        
+
         val redeemCode = extractor.extractRedeemCode(text)
         assertNotNull("Redeem code should not be null", redeemCode)
         assertEquals("SWGGS01BO719GFHS", redeemCode)
+    }
+
+    @Test
+    fun `extractRedeemCode collapses whitespace and trims trailing noise`() {
+        val text = "Use code Q2SQ74 JS7CK O today"
+
+        val redeemCode = extractor.extractRedeemCode(text)
+
+        assertEquals("Q2SQ74JS7CK", redeemCode)
     }
     
     @Test


### PR DESCRIPTION
## Summary
- add a RedeemCodeSanitizer helper to normalize coupon codes before use
- apply the sanitizer throughout the LLM and OCR pipelines to collapse whitespace and drop trailing noise
- add a regression test ensuring "Q2SQ74 JS7CK O" resolves to "Q2SQ74JS7CK"

## Testing
- :app:testDebugUnitTest *(fails: Android SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8994849d883288f3f42309adcbd7d