### PR TITLE
Normalize OCR rupee glyphs and trim store prefixes

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -42,7 +42,11 @@ class LocalLlmOcrService(
         private const val SUPPORTED_MODEL_VERSION = "v2.5-q4-android"
 
         private val RUPEE_VARIANT_PATTERN = Regex(
-            pattern = """(?i)(^|\s+)(?:₹|rs\.?|t)[\s:=-]*([+-]?\d[\d,]*(?:\.\d+)?)"""
+            pattern = """(?i)(^|\s+|[^\w₹])(?:₹|rs\.?|t)[\s:=-]*([+-]?\d[\d,]*(?:\.\d+)?)"""
+        )
+
+        private val STORE_PREFIX_EXTRACTION_PATTERN = Regex(
+            pattern = """(?i)^([A-Za-z][\w'&@.]*?(?:\s+[A-Za-z][\w'&@.]*){0,3})\s*[:\-\|–—]+\s*(.+)$"""
         )
 
         fun cleanDescription(raw: String?): String {
@@ -89,7 +93,9 @@ class LocalLlmOcrService(
                 .replace(Regex("\\s+"), " ")
                 .trim()
 
-            return normalizeRupeeVariants(joined)
+            val withoutStorePrefix = stripLikelyStorePrefix(joined)
+            val normalizedRupees = normalizeRupeeVariants(withoutStorePrefix)
+            return ensureLeadingCapital(normalizedRupees)
         }
 
         private fun normalizeRupeeVariants(text: String): String {
@@ -102,6 +108,57 @@ class LocalLlmOcrService(
                 val amount = matchResult.groupValues[2]
                 val cleanedAmount = amount.replaceFirst(Regex("^([+-]?)0+(?=\\d)"), "$1")
                 leading + "₹" + cleanedAmount
+            }
+        }
+
+        private fun stripLikelyStorePrefix(text: String): String {
+            if (text.isBlank()) {
+                return text
+            }
+
+            val match = STORE_PREFIX_EXTRACTION_PATTERN.find(text) ?: return text
+            val remainder = match.groupValues[2].trim()
+            if (remainder.isEmpty()) {
+                return text
+            }
+
+            val lowerRemainder = remainder.lowercase(Locale.getDefault())
+            val indicatorKeywords = listOf(
+                "coupon", "coupons", "cashback", "discount", "discounts", "offer", "offers",
+                "deal", "deals", "sale", "save", "savings", "reward", "rewards", "code", "promo",
+                "%", "₹"
+            )
+
+            val hasKeyword = indicatorKeywords.any { keyword ->
+                when (keyword) {
+                    "%" -> remainder.contains('%')
+                    "₹" -> remainder.contains('₹')
+                    else -> lowerRemainder.contains(keyword)
+                }
+            }
+
+            val hasDigits = remainder.any { it.isDigit() }
+
+            return if (hasKeyword || hasDigits) remainder else text
+        }
+
+        private fun ensureLeadingCapital(text: String): String {
+            if (text.isBlank()) {
+                return text
+            }
+
+            val firstLetterIndex = text.indexOfFirst { it.isLetter() }
+            if (firstLetterIndex == -1) {
+                return text
+            }
+
+            val firstLetter = text[firstLetterIndex]
+            return if (firstLetter.isLowerCase()) {
+                val builder = StringBuilder(text)
+                builder.replace(firstLetterIndex, firstLetterIndex + 1, firstLetter.titlecase(Locale.getDefault()))
+                builder.toString()
+            } else {
+                text
             }
         }
     }

--- a/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
@@ -245,6 +245,15 @@ class LocalLlmOcrServiceTest {
     }
 
     @Test
+    fun `cleanDescription trims store name prefixes`() {
+        val rawDescription = "AMAZON - EXTRA SAVINGS ON ELECTRONICS"
+
+        val cleaned = LocalLlmOcrService.cleanDescription(rawDescription)
+
+        assertEquals("Extra savings on electronics", cleaned)
+    }
+
+    @Test
     fun `cleanDescription normalizes rupee-like glyphs`() {
         val rawDescription = "LIFETIME CASHBACK T568"
 


### PR DESCRIPTION
## Summary
- extend LocalLlmOcrService.cleanDescription to strip store-like prefixes and standardize rupee glyph variants
- add unit coverage for store prefix trimming and rupee glyph normalization

## Testing
- ./gradlew test --tests "com.example.coupontracker.util.LocalLlmOcrServiceTest" *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d89d727e2883289efaed542c78b2d4