### PR TITLE
Remove root build artifacts from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
 .DS_Store
+# Keep the root Gradle build outputs out of version control
 /build
 /captures
 .externalNativeBuild


### PR DESCRIPTION
## Summary
- remove the generated `build/` directory from version control so future Gradle outputs stay untracked
- add a clarifying comment in `.gitignore` to highlight the existing rule that ignores the root `build/` folder

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a10604d88328a49fdab9eae36127