### PR TITLE
Limit coupon processing concurrency and surface extraction progress

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/activity/MultiCouponSelectionActivity.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/activity/MultiCouponSelectionActivity.kt
@@ -22,6 +22,8 @@ import com.example.coupontracker.databinding.ItemCouponSelectionBinding
 import com.example.coupontracker.ml.CouponInstance
 import com.example.coupontracker.ml.CouponStatus
 import com.example.coupontracker.ml.FieldType
+import com.example.coupontracker.ui.viewmodel.CouponExtractionStatus
+import com.example.coupontracker.ui.viewmodel.CouponProcessingStage
 import com.example.coupontracker.ui.viewmodel.ScannerViewModel
 import com.example.coupontracker.ui.viewmodel.ScannerUiState
 import dagger.hilt.android.AndroidEntryPoint
@@ -118,13 +120,28 @@ class MultiCouponSelectionActivity : AppCompatActivity() {
                         // Save the coupon
                         viewModel.saveCoupon(state.coupon)
                     }
+                    is ScannerUiState.ProcessingCoupons -> {
+                        binding.progressBar.visibility = View.VISIBLE
+                        binding.buttonsContainer.visibility = View.GONE
+                        adapter.updateProcessingStatuses(state.statuses)
+                    }
                     is ScannerUiState.AllCouponsSaved -> {
                         binding.progressBar.visibility = View.GONE
                         binding.buttonsContainer.visibility = View.VISIBLE
-                        
+
+                        adapter.updateProcessingStatuses(state.statuses)
+
+                        val failedCount = state.statuses.count { it.stage == CouponProcessingStage.FALLBACK }
+                        val savedCount = state.coupons.size
+                        val message = if (failedCount > 0) {
+                            "Saved $savedCount coupons, $failedCount failed"
+                        } else {
+                            "Successfully saved $savedCount coupons"
+                        }
+
                         Toast.makeText(
                             this@MultiCouponSelectionActivity,
-                            "Successfully saved ${state.coupons.size} coupons",
+                            message,
                             Toast.LENGTH_LONG
                         ).show()
                         
@@ -281,12 +298,19 @@ class MultiCouponSelectionActivity : AppCompatActivity() {
 class CouponSelectionAdapter(
     private val onCouponClick: (CouponInstance, Int) -> Unit
 ) : RecyclerView.Adapter<CouponSelectionAdapter.CouponViewHolder>() {
-    
+
     private var coupons: List<CouponInstance> = emptyList()
     private val selectedPositions = mutableSetOf<Int>()
-    
+    private var processingStatuses: Map<Int, CouponExtractionStatus> = emptyMap()
+
     fun updateCoupons(newCoupons: List<CouponInstance>) {
         coupons = newCoupons
+        processingStatuses = emptyMap()
+        notifyDataSetChanged()
+    }
+
+    fun updateProcessingStatuses(statuses: List<CouponExtractionStatus>) {
+        processingStatuses = statuses.associateBy { it.index }
         notifyDataSetChanged()
     }
     
@@ -321,17 +345,36 @@ class CouponSelectionAdapter(
         
         fun bind(coupon: CouponInstance, position: Int, isSelected: Boolean) {
             binding.couponImageView.setImageBitmap(coupon.cropBitmap)
-            
+
             binding.couponNumberText.text = "Coupon ${position + 1}"
-            
-            binding.statusText.text = when (coupon.status) {
-                CouponStatus.COMPLETE -> "Complete"
-                CouponStatus.PARTIAL_TOP -> "Partial (Top)"
-                CouponStatus.PARTIAL_BOTTOM -> "Partial (Bottom)"
+
+            val extractionStatus = processingStatuses[position]
+            if (extractionStatus != null) {
+                val message = extractionStatus.message?.takeIf { it.isNotBlank() }
+                binding.statusText.text = buildString {
+                    append(extractionStatus.stage.label)
+                    if (message != null) {
+                        append(": ")
+                        append(message)
+                    }
+                }
+                val enabled = extractionStatus.stage == CouponProcessingStage.QUEUED
+                binding.processButton.isEnabled = enabled
+                binding.selectionCheckbox.isEnabled = enabled
+                binding.root.isEnabled = enabled
+            } else {
+                binding.statusText.text = when (coupon.status) {
+                    CouponStatus.COMPLETE -> "Complete"
+                    CouponStatus.PARTIAL_TOP -> "Partial (Top)"
+                    CouponStatus.PARTIAL_BOTTOM -> "Partial (Bottom)"
+                }
+                binding.processButton.isEnabled = true
+                binding.selectionCheckbox.isEnabled = true
+                binding.root.isEnabled = true
             }
-            
+
             binding.fieldsCountText.text = "${coupon.fields.size} fields detected"
-            
+
             binding.confidenceText.text = "Confidence: ${String.format("%.1f%%", coupon.confidence * 100)}"
             
             // Show detected fields

--- a/app/src/main/kotlin/com/example/coupontracker/ui/fragment/ScannerFragment.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/fragment/ScannerFragment.kt
@@ -150,7 +150,7 @@ class ScannerFragment : Fragment() {
                     is ScannerUiState.MultiCouponDetected -> {
                         binding.progressBar.visibility = View.GONE
                         binding.captureButton.isEnabled = true
-                        
+
                         // Handle multi-coupon detection
                         Snackbar.make(
                             binding.root,
@@ -161,10 +161,14 @@ class ScannerFragment : Fragment() {
                         // Navigate to multi-coupon selection activity
                         // For now, just show a message - you can implement navigation later
                     }
+                    is ScannerUiState.ProcessingCoupons -> {
+                        binding.progressBar.visibility = View.VISIBLE
+                        binding.captureButton.isEnabled = false
+                    }
                     is ScannerUiState.AllCouponsSaved -> {
                         binding.progressBar.visibility = View.GONE
                         binding.captureButton.isEnabled = true
-                        
+
                         Snackbar.make(
                             binding.root,
                             "Successfully saved ${state.coupons.size} coupons!",

--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/ScannerScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/ScannerScreen.kt
@@ -216,7 +216,7 @@ fun ScannerScreen(
                     }
                 }
 
-                uiState is ScannerUiState.Scanning -> {
+                uiState is ScannerUiState.Scanning || uiState is ScannerUiState.ProcessingCoupons -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -16,12 +16,20 @@ import com.example.coupontracker.ml.FieldType
 import com.example.coupontracker.util.MultiEngineOCR
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
 import java.io.InputStream
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -185,35 +193,117 @@ class ScannerViewModel @Inject constructor(
      */
     fun processAllCoupons(couponInstances: List<CouponInstance>, originalImageUri: String?) {
         viewModelScope.launch {
-            try {
-                _uiState.value = ScannerUiState.Scanning
-                Log.d(TAG, "Processing all ${couponInstances.size} detected coupons")
+            if (couponInstances.isEmpty()) {
+                _uiState.value = ScannerUiState.Error("No coupons to process")
+                return@launch
+            }
 
+            try {
+                Log.d(TAG, "Processing all ${couponInstances.size} detected coupons with concurrency")
+
+                val semaphore = Semaphore(4)
+                val statusMutex = Mutex()
+                val savedCouponsMutex = Mutex()
                 val savedCoupons = mutableListOf<Coupon>()
 
-                for ((index, instance) in couponInstances.withIndex()) {
-                    try {
-                        val extractedInfo = extractTextFromFields(instance)
-                        val coupon = createCouponFromInstance(instance, extractedInfo, originalImageUri)
-                        
-                        // Save coupon to repository
-                        couponRepository.insertCoupon(coupon)
-                        savedCoupons.add(coupon)
-                        
-                        Log.d(TAG, "Saved coupon ${index + 1}/${couponInstances.size}: ${coupon.redeemCode}")
-                        
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Error processing coupon $index", e)
-                        // Continue with other coupons
+                val statuses = couponInstances.mapIndexed { index, instance ->
+                    CouponExtractionStatus(
+                        index = index,
+                        instanceId = instance.id,
+                        stage = CouponProcessingStage.QUEUED
+                    )
+                }.toMutableList()
+
+                suspend fun publishStatuses() {
+                    statusMutex.withLock {
+                        _uiState.value = ScannerUiState.ProcessingCoupons(statuses.map { it.copy() })
                     }
                 }
 
-                if (savedCoupons.isNotEmpty()) {
-                    _uiState.value = ScannerUiState.AllCouponsSaved(savedCoupons)
+                suspend fun updateStatus(
+                    index: Int,
+                    stage: CouponProcessingStage,
+                    coupon: Coupon? = null,
+                    message: String? = null
+                ) {
+                    statusMutex.withLock {
+                        val current = statuses[index]
+                        statuses[index] = current.copy(stage = stage, coupon = coupon, message = message)
+                        _uiState.value = ScannerUiState.ProcessingCoupons(statuses.map { it.copy() })
+                    }
+                }
+
+                suspend fun markFallback(index: Int, reason: String?) {
+                    updateStatus(index, CouponProcessingStage.FALLBACK, message = reason)
+                }
+
+                publishStatuses()
+
+                val jobs = couponInstances.mapIndexed { index, instance ->
+                    viewModelScope.async {
+                        semaphore.withPermit {
+                            updateStatus(index, CouponProcessingStage.RUNNING_MINI_CPM)
+                            try {
+                                val extractedInfo = extractTextFromFields(instance)
+
+                                updateStatus(index, CouponProcessingStage.VALIDATING)
+
+                                if (!instance.hasRequiredFields()) {
+                                    markFallback(index, "Missing required fields")
+                                    return@withPermit
+                                }
+
+                                if (extractedInfo.isEmpty()) {
+                                    markFallback(index, "No text extracted")
+                                    return@withPermit
+                                }
+
+                                val coupon = createCouponFromInstance(instance, extractedInfo, originalImageUri)
+
+                                withContext(Dispatchers.IO) {
+                                    couponRepository.insertCoupon(coupon)
+                                }
+
+                                savedCouponsMutex.withLock {
+                                    savedCoupons.add(coupon)
+                                }
+
+                                updateStatus(index, CouponProcessingStage.SAVED, coupon = coupon, message = coupon.redeemCode)
+                            } catch (e: CancellationException) {
+                                withContext(NonCancellable) {
+                                    markFallback(index, "Cancelled")
+                                }
+                                throw e
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Error processing coupon ${instance.id}", e)
+                                markFallback(index, e.message)
+                            }
+                        }
+                    }
+                }
+
+                try {
+                    jobs.awaitAll()
+                } catch (e: CancellationException) {
+                    Log.w(TAG, "Coupon processing cancelled", e)
+                    throw e
+                }
+
+                val finalStatuses = statusMutex.withLock {
+                    statuses.map { it.copy() }
+                }
+
+                val processedCoupons = savedCouponsMutex.withLock {
+                    savedCoupons.toList()
+                }
+
+                if (processedCoupons.isNotEmpty()) {
+                    _uiState.value = ScannerUiState.AllCouponsSaved(processedCoupons, finalStatuses)
                 } else {
                     _uiState.value = ScannerUiState.Error("Failed to save any coupons")
                 }
-
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Error processing all coupons", e)
                 _uiState.value = ScannerUiState.Error("Error processing coupons: ${e.message}")
@@ -459,7 +549,9 @@ class ScannerViewModel @Inject constructor(
     fun saveCoupon(coupon: Coupon) {
         viewModelScope.launch {
             try {
-                couponRepository.insertCoupon(coupon)
+                withContext(Dispatchers.IO) {
+                    couponRepository.insertCoupon(coupon)
+                }
                 _uiState.value = ScannerUiState.Saved(coupon)
             } catch (e: Exception) {
                 Log.e(TAG, "Error saving coupon", e)
@@ -497,13 +589,36 @@ sealed class ScannerUiState {
     data class Success(val coupon: Coupon) : ScannerUiState()
     data class Saved(val coupon: Coupon) : ScannerUiState()
     data class Error(val message: String) : ScannerUiState()
-    
+
     // New states for multi-coupon support
     data class MultiCouponDetected(
-        val couponInstances: List<CouponInstance>, 
-        val originalBitmap: Bitmap, 
+        val couponInstances: List<CouponInstance>,
+        val originalBitmap: Bitmap,
         val imageUri: String?
     ) : ScannerUiState()
-    
-    data class AllCouponsSaved(val coupons: List<Coupon>) : ScannerUiState()
+
+    data class ProcessingCoupons(
+        val statuses: List<CouponExtractionStatus>
+    ) : ScannerUiState()
+
+    data class AllCouponsSaved(
+        val coupons: List<Coupon>,
+        val statuses: List<CouponExtractionStatus>
+    ) : ScannerUiState()
+}
+
+data class CouponExtractionStatus(
+    val index: Int,
+    val instanceId: String,
+    val stage: CouponProcessingStage,
+    val coupon: Coupon? = null,
+    val message: String? = null
+)
+
+enum class CouponProcessingStage(val label: String) {
+    QUEUED("Queued"),
+    RUNNING_MINI_CPM("Running MiniCPM"),
+    VALIDATING("Validating"),
+    SAVED("Saved"),
+    FALLBACK("Fallback")
 }


### PR DESCRIPTION
## Summary
- process multi-coupon batches with a semaphore-limited coroutine fan-out and richer lifecycle tracking in `ScannerViewModel`
- extend `ScannerUiState` with processing metadata so the selection UI can render per-coupon progress and gracefully handle fallbacks
- refresh selection, fragment, and compose screens to react to staged updates and keep repository writes on the IO dispatcher

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not configured in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a626f74083289f9311c3ea32c425