### PR TITLE
Add interactive overlay controls to multi-coupon selection

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/activity/MultiCouponSelectionActivity.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/activity/MultiCouponSelectionActivity.kt
@@ -1,8 +1,6 @@
 package com.example.coupontracker.ui.activity
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Paint
 import android.graphics.RectF
 import android.os.Bundle
 import android.util.Log
@@ -12,7 +10,6 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -22,77 +19,120 @@ import com.example.coupontracker.databinding.ItemCouponSelectionBinding
 import com.example.coupontracker.ml.CouponInstance
 import com.example.coupontracker.ml.CouponStatus
 import com.example.coupontracker.ml.FieldType
+import com.example.coupontracker.ml.FieldDetection
 import com.example.coupontracker.ui.viewmodel.ScannerViewModel
 import com.example.coupontracker.ui.viewmodel.ScannerUiState
+import com.example.coupontracker.ui.view.MultiCouponOverlayView
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import java.util.UUID
 
 @AndroidEntryPoint
 class MultiCouponSelectionActivity : AppCompatActivity() {
-    
+
     private lateinit var binding: ActivityMultiCouponSelectionBinding
     private val viewModel: ScannerViewModel by viewModels()
     private lateinit var adapter: CouponSelectionAdapter
-    
-    private var couponInstances: List<CouponInstance> = emptyList()
+
+    private var couponInstances: MutableList<CouponInstance> = mutableListOf()
     private var originalBitmap: Bitmap? = null
     private var imageUri: String? = null
-    
+
     companion object {
         private const val TAG = "MultiCouponSelection"
         const val EXTRA_COUPON_INSTANCES = "coupon_instances"
         const val EXTRA_ORIGINAL_BITMAP = "original_bitmap"
         const val EXTRA_IMAGE_URI = "image_uri"
     }
-    
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMultiCouponSelectionBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        
+
         setupUI()
         extractIntentData()
         setupRecyclerView()
         observeViewModel()
     }
-    
+
     private fun setupUI() {
         binding.toolbar.setNavigationOnClickListener {
             finish()
         }
-        
-        binding.selectAllButton.setOnClickListener {
-            adapter.selectAll()
+
+        binding.toolbar.setOnMenuItemClickListener { item ->
+            when (item.itemId) {
+                R.id.action_select_all -> {
+                    binding.multiCouponOverlay.selectAll()
+                    true
+                }
+                R.id.action_add_tile -> {
+                    val addMode = binding.multiCouponOverlay.toggleAddTileMode()
+                    item.title = if (addMode) {
+                        getString(R.string.action_cancel_add_tile)
+                    } else {
+                        getString(R.string.action_add_tile)
+                    }
+                    if (addMode) {
+                        Toast.makeText(this, R.string.overlay_draw_instruction, Toast.LENGTH_SHORT).show()
+                    }
+                    true
+                }
+                R.id.action_delete -> {
+                    binding.multiCouponOverlay.deleteSelected()
+                    true
+                }
+                else -> false
+            }
         }
-        
+
+        binding.multiCouponOverlay.setOverlayListener(object : MultiCouponOverlayView.OverlayListener {
+            override fun onSelectionChanged(selectedIds: Set<String>) {
+                adapter.setSelectedIds(selectedIds)
+            }
+
+            override fun onCouponBoundingBoxChanged(couponId: String, newBoundingBox: RectF) {
+                handleCouponBoundingBoxChanged(couponId, newBoundingBox)
+            }
+
+            override fun onAddCouponRequested(boundingBox: RectF) {
+                handleAddTile(boundingBox)
+            }
+
+            override fun onDeleteRequested(selectedIds: Set<String>) {
+                handleDeleteCoupons(selectedIds)
+            }
+        })
+
         binding.processSelectedButton.setOnClickListener {
             processSelectedCoupons()
         }
-        
+
         binding.processAllButton.setOnClickListener {
             processAllCoupons()
         }
     }
-    
+
     private fun extractIntentData() {
-        // In a real implementation, you would pass data through Intent extras
-        // For now, we'll use a simple approach
-        
-        // This is a simplified approach - in practice, you might use Parcelable or pass data differently
         Log.d(TAG, "Extracting intent data for multi-coupon selection")
     }
-    
+
     private fun setupRecyclerView() {
-        adapter = CouponSelectionAdapter { instance, _ ->
-            // Handle single coupon selection
-            viewModel.selectCoupon(instance, imageUri)
-        }
-        
+        adapter = CouponSelectionAdapter(
+            onCouponClick = { instance, _ ->
+                viewModel.selectCoupon(instance, imageUri)
+            },
+            onSelectionChanged = { selectedIds ->
+                binding.multiCouponOverlay.setSelectedCouponIds(selectedIds)
+            }
+        )
+
         binding.couponsRecyclerView.layoutManager = LinearLayoutManager(this)
         binding.couponsRecyclerView.adapter = adapter
     }
-    
+
     private fun observeViewModel() {
         lifecycleScope.launch {
             viewModel.uiState.collect { state ->
@@ -108,44 +148,43 @@ class MultiCouponSelectionActivity : AppCompatActivity() {
                     is ScannerUiState.Success -> {
                         binding.progressBar.visibility = View.GONE
                         binding.buttonsContainer.visibility = View.VISIBLE
-                        
+
                         Toast.makeText(
                             this@MultiCouponSelectionActivity,
                             "Coupon processed successfully: ${state.coupon.redeemCode}",
                             Toast.LENGTH_LONG
                         ).show()
-                        
-                        // Save the coupon
+
                         viewModel.saveCoupon(state.coupon)
                     }
                     is ScannerUiState.AllCouponsSaved -> {
                         binding.progressBar.visibility = View.GONE
                         binding.buttonsContainer.visibility = View.VISIBLE
-                        
+
                         Toast.makeText(
                             this@MultiCouponSelectionActivity,
                             "Successfully saved ${state.coupons.size} coupons",
                             Toast.LENGTH_LONG
                         ).show()
-                        
+
                         finish()
                     }
                     is ScannerUiState.Saved -> {
                         binding.progressBar.visibility = View.GONE
                         binding.buttonsContainer.visibility = View.VISIBLE
-                        
+
                         Toast.makeText(
                             this@MultiCouponSelectionActivity,
                             "Coupon saved successfully!",
                             Toast.LENGTH_SHORT
                         ).show()
-                        
+
                         finish()
                     }
                     is ScannerUiState.Error -> {
                         binding.progressBar.visibility = View.GONE
                         binding.buttonsContainer.visibility = View.VISIBLE
-                        
+
                         Toast.makeText(
                             this@MultiCouponSelectionActivity,
                             "Error: ${state.message}",
@@ -153,153 +192,180 @@ class MultiCouponSelectionActivity : AppCompatActivity() {
                         ).show()
                     }
                     is ScannerUiState.MultiCouponDetected -> {
-                        // This state should be handled in the calling activity
-                        couponInstances = state.couponInstances
                         originalBitmap = state.originalBitmap
                         imageUri = state.imageUri
-                        
                         displayCoupons(state.couponInstances, state.originalBitmap)
                     }
                 }
             }
         }
     }
-    
+
     private fun displayCoupons(instances: List<CouponInstance>, bitmap: Bitmap) {
         Log.d(TAG, "Displaying ${instances.size} detected coupons")
-        
-        // Update header info
-        binding.detectedCountText.text = "Detected ${instances.size} coupons"
-        
-        // Show original image with overlays
-        val overlayBitmap = createOverlayBitmap(bitmap, instances)
-        binding.originalImageView.setImageBitmap(overlayBitmap)
-        
-        // Update adapter
-        adapter.updateCoupons(instances)
-        
-        // Update button states
-        binding.selectAllButton.visibility = View.VISIBLE
+
+        viewModel.resetManualOverrides()
+        binding.multiCouponOverlay.setImageBitmap(bitmap)
+        couponInstances = instances.map { cloneInstance(it) }.toMutableList()
+        binding.multiCouponOverlay.setCouponInstances(couponInstances)
+        binding.multiCouponOverlay.clearSelection()
+
+        adapter.updateCoupons(couponInstances)
+
         binding.processSelectedButton.visibility = View.VISIBLE
         binding.processAllButton.visibility = View.VISIBLE
+        updateDetectedCount()
     }
-    
-    private fun createOverlayBitmap(originalBitmap: Bitmap, instances: List<CouponInstance>): Bitmap {
-        val overlayBitmap = originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
-        val canvas = Canvas(overlayBitmap)
-        
-        val paint = Paint().apply {
-            style = Paint.Style.STROKE
-            strokeWidth = 8f
-            isAntiAlias = true
-        }
-        
-        val textPaint = Paint().apply {
-            textSize = 48f
-            isAntiAlias = true
-            color = ContextCompat.getColor(this@MultiCouponSelectionActivity, android.R.color.white)
-        }
-        
-        instances.forEachIndexed { index, instance ->
-            // Set color based on coupon status
-            paint.color = when (instance.status) {
-                CouponStatus.COMPLETE -> ContextCompat.getColor(this, android.R.color.holo_green_light)
-                CouponStatus.PARTIAL_TOP -> ContextCompat.getColor(this, android.R.color.holo_orange_light)
-                CouponStatus.PARTIAL_BOTTOM -> ContextCompat.getColor(this, android.R.color.holo_red_light)
-            }
-            
-            // Draw bounding box
-            canvas.drawRect(instance.boundingBox, paint)
-            
-            // Draw coupon number
-            val label = "${index + 1}"
-            canvas.drawText(
-                label,
-                instance.boundingBox.left + 10f,
-                instance.boundingBox.top + 60f,
-                textPaint
-            )
-            
-            // Draw field overlays
-            drawFieldOverlays(canvas, instance)
-        }
-        
-        return overlayBitmap
-    }
-    
-    private fun drawFieldOverlays(canvas: Canvas, instance: CouponInstance) {
-        val fieldPaint = Paint().apply {
-            style = Paint.Style.STROKE
-            strokeWidth = 4f
-            isAntiAlias = true
-        }
-        
-        instance.fields.forEach { field ->
-            fieldPaint.color = when (field.fieldType) {
-                FieldType.CODE_REGION -> ContextCompat.getColor(this, R.color.field_code)
-                FieldType.BENEFIT_REGION -> ContextCompat.getColor(this, R.color.field_benefit)
-                FieldType.EXPIRY_REGION -> ContextCompat.getColor(this, R.color.field_expiry)
-                FieldType.APP_REGION -> ContextCompat.getColor(this, R.color.field_app)
-                FieldType.TERMS_REGION -> ContextCompat.getColor(this, R.color.field_terms)
-            }
-            
-            canvas.drawRect(field.boundingBox, fieldPaint)
-        }
-    }
-    
+
     private fun processSelectedCoupons() {
         val selectedCoupons = adapter.getSelectedCoupons()
-        
+
         if (selectedCoupons.isEmpty()) {
             Toast.makeText(this, "Please select at least one coupon", Toast.LENGTH_SHORT).show()
             return
         }
-        
+
         Log.d(TAG, "Processing ${selectedCoupons.size} selected coupons")
         viewModel.processAllCoupons(selectedCoupons, imageUri)
     }
-    
+
     private fun processAllCoupons() {
         Log.d(TAG, "Processing all ${couponInstances.size} detected coupons")
         viewModel.processAllCoupons(couponInstances, imageUri)
     }
-    
-    /**
-     * Set the coupon instances to display (called from parent activity)
-     */
+
     fun setCouponInstances(instances: List<CouponInstance>, bitmap: Bitmap, uri: String?) {
-        couponInstances = instances
         originalBitmap = bitmap
         imageUri = uri
         displayCoupons(instances, bitmap)
     }
+
+    private fun handleCouponBoundingBoxChanged(couponId: String, newBoundingBox: RectF) {
+        val bitmap = originalBitmap ?: return
+        val index = couponInstances.indexOfFirst { it.id == couponId }
+        if (index == -1) return
+
+        val updatedInstance = cloneInstance(couponInstances[index]).copy(
+            boundingBox = RectF(newBoundingBox),
+            cropBitmap = createCropBitmap(bitmap, newBoundingBox)
+        )
+        couponInstances[index] = updatedInstance
+        adapter.updateCoupon(updatedInstance)
+        binding.multiCouponOverlay.updateCouponInstance(updatedInstance)
+        viewModel.updateManualCouponInstance(updatedInstance)
+    }
+
+    private fun handleAddTile(boundingBox: RectF) {
+        val bitmap = originalBitmap ?: run {
+            Toast.makeText(this, R.string.overlay_missing_bitmap, Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val sanitizedRect = RectF(
+            boundingBox.left.coerceAtLeast(0f),
+            boundingBox.top.coerceAtLeast(0f),
+            boundingBox.right.coerceAtMost(bitmap.width.toFloat()),
+            boundingBox.bottom.coerceAtMost(bitmap.height.toFloat())
+        )
+
+        val cropBitmap = createCropBitmap(bitmap, sanitizedRect)
+        val newInstance = CouponInstance(
+            id = UUID.randomUUID().toString(),
+            boundingBox = sanitizedRect,
+            status = CouponStatus.COMPLETE,
+            confidence = 1f,
+            fields = emptyList(),
+            cropBitmap = cropBitmap
+        )
+
+        couponInstances.add(newInstance)
+        adapter.updateCoupons(couponInstances)
+        binding.multiCouponOverlay.addCouponInstance(newInstance)
+        updateDetectedCount()
+        viewModel.updateManualCouponInstance(newInstance)
+
+        binding.multiCouponOverlay.exitAddTileMode()
+        binding.toolbar.menu.findItem(R.id.action_add_tile)?.title = getString(R.string.action_add_tile)
+    }
+
+    private fun handleDeleteCoupons(selectedIds: Set<String>) {
+        if (selectedIds.isEmpty()) return
+        couponInstances = couponInstances.filter { it.id !in selectedIds }.map { cloneInstance(it) }.toMutableList()
+        adapter.updateCoupons(couponInstances)
+        binding.multiCouponOverlay.setCouponInstances(couponInstances)
+        binding.multiCouponOverlay.clearSelection()
+        updateDetectedCount()
+        viewModel.removeManualCoupons(selectedIds)
+    }
+
+    private fun cloneInstance(instance: CouponInstance): CouponInstance {
+        val clonedFields = instance.fields.map { field -> cloneField(field) }
+        return instance.copy(
+            boundingBox = RectF(instance.boundingBox),
+            fields = clonedFields
+        )
+    }
+
+    private fun cloneField(field: FieldDetection): FieldDetection {
+        return field.copy(boundingBox = RectF(field.boundingBox))
+    }
+
+    private fun createCropBitmap(source: Bitmap, rect: RectF): Bitmap {
+        val left = rect.left.coerceIn(0f, (source.width - 1).toFloat()).toInt()
+        val top = rect.top.coerceIn(0f, (source.height - 1).toFloat()).toInt()
+        val right = rect.right.coerceIn((left + 1).toFloat(), source.width.toFloat()).toInt()
+        val bottom = rect.bottom.coerceIn((top + 1).toFloat(), source.height.toFloat()).toInt()
+        val width = (right - left).coerceAtLeast(1)
+        val height = (bottom - top).coerceAtLeast(1)
+        return Bitmap.createBitmap(source, left, top, width, height)
+    }
+
+    private fun updateDetectedCount() {
+        binding.detectedCountText.text = getString(R.string.detected_coupon_count, couponInstances.size)
+    }
 }
 
-/**
- * Adapter for coupon selection RecyclerView
- */
 class CouponSelectionAdapter(
-    private val onCouponClick: (CouponInstance, Int) -> Unit
+    private val onCouponClick: (CouponInstance, Int) -> Unit,
+    private val onSelectionChanged: (Set<String>) -> Unit
 ) : RecyclerView.Adapter<CouponSelectionAdapter.CouponViewHolder>() {
-    
-    private var coupons: List<CouponInstance> = emptyList()
-    private val selectedPositions = mutableSetOf<Int>()
-    
+
+    private var coupons: MutableList<CouponInstance> = mutableListOf()
+    private val selectedIds = linkedSetOf<String>()
+
     fun updateCoupons(newCoupons: List<CouponInstance>) {
-        coupons = newCoupons
+        coupons = newCoupons.toMutableList()
+        val validIds = coupons.map { it.id }.toSet()
+        selectedIds.retainAll(validIds)
         notifyDataSetChanged()
     }
-    
+
     fun selectAll() {
-        selectedPositions.clear()
-        selectedPositions.addAll(0 until coupons.size)
+        selectedIds.clear()
+        selectedIds.addAll(coupons.map { it.id })
+        notifyDataSetChanged()
+        onSelectionChanged(selectedIds)
+    }
+
+    fun getSelectedCoupons(): List<CouponInstance> {
+        return coupons.filter { selectedIds.contains(it.id) }
+    }
+
+    fun setSelectedIds(ids: Set<String>) {
+        if (selectedIds == ids) return
+        selectedIds.clear()
+        selectedIds.addAll(ids.intersect(coupons.map { it.id }.toSet()))
         notifyDataSetChanged()
     }
-    
-    fun getSelectedCoupons(): List<CouponInstance> {
-        return selectedPositions.map { coupons[it] }
+
+    fun updateCoupon(updated: CouponInstance) {
+        val index = coupons.indexOfFirst { it.id == updated.id }
+        if (index != -1) {
+            coupons[index] = updated
+            notifyItemChanged(index)
+        }
     }
-    
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CouponViewHolder {
         val binding = ItemCouponSelectionBinding.inflate(
             LayoutInflater.from(parent.context),
@@ -308,33 +374,32 @@ class CouponSelectionAdapter(
         )
         return CouponViewHolder(binding)
     }
-    
+
     override fun onBindViewHolder(holder: CouponViewHolder, position: Int) {
-        holder.bind(coupons[position], position, selectedPositions.contains(position))
+        holder.bind(coupons[position], position, selectedIds.contains(coupons[position].id))
     }
-    
+
     override fun getItemCount(): Int = coupons.size
-    
+
     inner class CouponViewHolder(
         private val binding: ItemCouponSelectionBinding
     ) : RecyclerView.ViewHolder(binding.root) {
-        
+
         fun bind(coupon: CouponInstance, position: Int, isSelected: Boolean) {
             binding.couponImageView.setImageBitmap(coupon.cropBitmap)
-            
+
             binding.couponNumberText.text = "Coupon ${position + 1}"
-            
+
             binding.statusText.text = when (coupon.status) {
                 CouponStatus.COMPLETE -> "Complete"
                 CouponStatus.PARTIAL_TOP -> "Partial (Top)"
                 CouponStatus.PARTIAL_BOTTOM -> "Partial (Bottom)"
             }
-            
+
             binding.fieldsCountText.text = "${coupon.fields.size} fields detected"
-            
+
             binding.confidenceText.text = "Confidence: ${String.format("%.1f%%", coupon.confidence * 100)}"
-            
-            // Show detected fields
+
             val fieldsList = coupon.fields.joinToString(", ") { field ->
                 when (field.fieldType) {
                     FieldType.CODE_REGION -> "Code"
@@ -345,33 +410,36 @@ class CouponSelectionAdapter(
                 }
             }
             binding.detectedFieldsText.text = if (fieldsList.isNotEmpty()) fieldsList else "No fields detected"
-            
-            // Set selection state
+
+            binding.selectionCheckbox.setOnCheckedChangeListener(null)
             binding.selectionCheckbox.isChecked = isSelected
             binding.root.isSelected = isSelected
-            
-            // Set click listeners
+
             binding.root.setOnClickListener {
-                if (selectedPositions.contains(position)) {
-                    selectedPositions.remove(position)
-                } else {
-                    selectedPositions.add(position)
-                }
+                toggleSelection(coupon)
                 notifyItemChanged(position)
             }
-            
+
             binding.processButton.setOnClickListener {
                 onCouponClick(coupon, position)
             }
-            
+
             binding.selectionCheckbox.setOnCheckedChangeListener { _, isChecked ->
                 if (isChecked) {
-                    selectedPositions.add(position)
+                    selectedIds.add(coupon.id)
                 } else {
-                    selectedPositions.remove(position)
+                    selectedIds.remove(coupon.id)
                 }
                 binding.root.isSelected = isChecked
+                onSelectionChanged(selectedIds)
             }
+        }
+
+        private fun toggleSelection(coupon: CouponInstance) {
+            if (!selectedIds.add(coupon.id)) {
+                selectedIds.remove(coupon.id)
+            }
+            onSelectionChanged(selectedIds)
         }
     }
 }

--- a/app/src/main/kotlin/com/example/coupontracker/ui/view/MultiCouponOverlayView.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/view/MultiCouponOverlayView.kt
@@ -1,0 +1,469 @@
+package com.example.coupontracker.ui.view
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.DashPathEffect
+import android.graphics.PointF
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.View
+import androidx.core.content.ContextCompat
+import com.example.coupontracker.R
+import com.example.coupontracker.ml.CouponInstance
+import com.example.coupontracker.ml.CouponStatus
+import com.example.coupontracker.ml.FieldType
+import java.util.EnumSet
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Overlay view that renders detected coupons and supports interactive editing.
+ */
+class MultiCouponOverlayView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    interface OverlayListener {
+        fun onSelectionChanged(selectedIds: Set<String>)
+        fun onCouponBoundingBoxChanged(couponId: String, newBoundingBox: RectF)
+        fun onAddCouponRequested(boundingBox: RectF)
+        fun onDeleteRequested(selectedIds: Set<String>)
+    }
+
+    private data class OverlayEntry(
+        var instance: CouponInstance,
+        val rect: RectF
+    )
+
+    private enum class Edge {
+        LEFT, TOP, RIGHT, BOTTOM
+    }
+
+    private enum class EditMode {
+        NONE,
+        MOVE,
+        RESIZE
+    }
+
+    private var overlayListener: OverlayListener? = null
+
+    private val overlayEntries = mutableListOf<OverlayEntry>()
+    private val selectedIds = linkedSetOf<String>()
+
+    private var bitmap: Bitmap? = null
+    private val drawMatrix = Matrix()
+    private val inverseMatrix = Matrix()
+    private val viewRect = RectF()
+    private val imageRect = RectF()
+
+    private val boundingPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = 4f
+    }
+    private val selectedPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = 6f
+        color = ContextCompat.getColor(context, R.color.primary)
+    }
+    private val selectionFillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+        color = Color.argb(60, 33, 150, 243)
+    }
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        textSize = 36f
+    }
+    private val fieldPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = 2f
+    }
+    private val addTilePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = 3f
+        color = ContextCompat.getColor(context, R.color.secondary)
+        pathEffect = DashPathEffect(floatArrayOf(16f, 12f), 0f)
+    }
+
+    private val gestureDetector = GestureDetector(context, OverlayGestureListener())
+
+    private var editMode: EditMode = EditMode.NONE
+    private var editingEntry: OverlayEntry? = null
+    private var activeEdges: EnumSet<Edge>? = null
+    private var lastBitmapPoint: PointF? = null
+
+    private var addTileMode = false
+    private var tempTileRect: RectF? = null
+
+    fun setOverlayListener(listener: OverlayListener) {
+        overlayListener = listener
+    }
+
+    fun setImageBitmap(bitmap: Bitmap?) {
+        this.bitmap = bitmap
+        updateMatrix()
+        invalidate()
+    }
+
+    fun setCouponInstances(instances: List<CouponInstance>) {
+        overlayEntries.clear()
+        instances.forEach { instance ->
+            overlayEntries.add(OverlayEntry(instance, RectF(instance.boundingBox)))
+        }
+        selectedIds.retainAll(instances.map { it.id }.toSet())
+        invalidate()
+    }
+
+    fun addCouponInstance(instance: CouponInstance) {
+        overlayEntries.add(OverlayEntry(instance, RectF(instance.boundingBox)))
+        selectedIds.add(instance.id)
+        overlayListener?.onSelectionChanged(selectedIds)
+        invalidate()
+    }
+
+    fun updateCouponInstance(instance: CouponInstance) {
+        val entry = overlayEntries.firstOrNull { it.instance.id == instance.id }
+        if (entry != null) {
+            entry.instance = instance
+            entry.rect.set(instance.boundingBox)
+            invalidate()
+        }
+    }
+
+    fun removeCoupons(ids: Set<String>) {
+        overlayEntries.removeAll { ids.contains(it.instance.id) }
+        selectedIds.removeAll(ids)
+        overlayListener?.onSelectionChanged(selectedIds)
+        invalidate()
+    }
+
+    fun setSelectedCouponIds(ids: Set<String>) {
+        selectedIds.clear()
+        selectedIds.addAll(ids)
+        invalidate()
+    }
+
+    fun selectAll() {
+        selectedIds.clear()
+        selectedIds.addAll(overlayEntries.map { it.instance.id })
+        overlayListener?.onSelectionChanged(selectedIds)
+        invalidate()
+    }
+
+    fun clearSelection() {
+        selectedIds.clear()
+        overlayListener?.onSelectionChanged(selectedIds)
+        invalidate()
+    }
+
+    fun toggleAddTileMode(): Boolean {
+        addTileMode = !addTileMode
+        tempTileRect = null
+        invalidate()
+        return addTileMode
+    }
+
+    fun exitAddTileMode() {
+        addTileMode = false
+        tempTileRect = null
+        invalidate()
+    }
+
+    fun deleteSelected() {
+        if (selectedIds.isEmpty()) return
+        overlayListener?.onDeleteRequested(selectedIds.toSet())
+    }
+
+    fun isInAddTileMode(): Boolean = addTileMode
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        bitmap?.let { bmp ->
+            canvas.drawBitmap(bmp, drawMatrix, null)
+        }
+
+        overlayEntries.forEachIndexed { index, entry ->
+            val viewRect = RectF(entry.rect)
+            drawMatrix.mapRect(viewRect)
+
+            boundingPaint.color = when (entry.instance.status) {
+                CouponStatus.COMPLETE -> ContextCompat.getColor(context, android.R.color.holo_green_light)
+                CouponStatus.PARTIAL_TOP -> ContextCompat.getColor(context, android.R.color.holo_orange_light)
+                CouponStatus.PARTIAL_BOTTOM -> ContextCompat.getColor(context, android.R.color.holo_red_light)
+            }
+
+            canvas.drawRect(viewRect, boundingPaint)
+
+            if (selectedIds.contains(entry.instance.id)) {
+                canvas.drawRect(viewRect, selectionFillPaint)
+                canvas.drawRect(viewRect, selectedPaint)
+            }
+
+            canvas.drawText((index + 1).toString(), viewRect.left + 12f, viewRect.top + 42f, textPaint)
+
+            entry.instance.fields.forEach { field ->
+                fieldPaint.color = when (field.fieldType) {
+                    FieldType.CODE_REGION -> ContextCompat.getColor(context, R.color.field_code)
+                    FieldType.BENEFIT_REGION -> ContextCompat.getColor(context, R.color.field_benefit)
+                    FieldType.EXPIRY_REGION -> ContextCompat.getColor(context, R.color.field_expiry)
+                    FieldType.APP_REGION -> ContextCompat.getColor(context, R.color.field_app)
+                    FieldType.TERMS_REGION -> ContextCompat.getColor(context, R.color.field_terms)
+                }
+                val fieldRect = RectF(field.boundingBox)
+                drawMatrix.mapRect(fieldRect)
+                canvas.drawRect(fieldRect, fieldPaint)
+            }
+        }
+
+        tempTileRect?.let { rect ->
+            val mapped = RectF(rect)
+            drawMatrix.mapRect(mapped)
+            canvas.drawRect(mapped, addTilePaint)
+        }
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        viewRect.set(paddingLeft.toFloat(), paddingTop.toFloat(), (w - paddingRight).toFloat(), (h - paddingBottom).toFloat())
+        updateMatrix()
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (bitmap == null) return false
+
+        val handledByGesture = gestureDetector.onTouchEvent(event)
+        val withinImage = imageRect.contains(event.x, event.y)
+
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                if (addTileMode && withinImage) {
+                    val start = toBitmapPoint(event.x, event.y)
+                    tempTileRect = RectF(start.x, start.y, start.x, start.y)
+                    parent.requestDisallowInterceptTouchEvent(true)
+                    invalidate()
+                    return true
+                }
+            }
+            MotionEvent.ACTION_MOVE -> {
+                if (addTileMode) {
+                    tempTileRect?.let { rect ->
+                        val point = toBitmapPoint(event.x, event.y)
+                        rect.right = point.x
+                        rect.bottom = point.y
+                        normalizeRect(rect)
+                        invalidate()
+                    }
+                    return true
+                }
+
+                if (editMode != EditMode.NONE && editingEntry != null) {
+                    val point = toBitmapPoint(event.x, event.y)
+                    handleDrag(point)
+                    invalidate()
+                    return true
+                }
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                if (addTileMode) {
+                    val rect = tempTileRect
+                    tempTileRect = null
+                    invalidate()
+                    if (event.actionMasked == MotionEvent.ACTION_UP && rect != null && rect.width() > MIN_TILE_SIZE && rect.height() > MIN_TILE_SIZE) {
+                        overlayListener?.onAddCouponRequested(RectF(rect))
+                    }
+                    return true
+                }
+
+                if (editMode != EditMode.NONE && editingEntry != null) {
+                    val rect = RectF(editingEntry!!.rect)
+                    overlayListener?.onCouponBoundingBoxChanged(editingEntry!!.instance.id, rect)
+                }
+                resetEditState()
+            }
+        }
+
+        return handledByGesture || addTileMode || editMode != EditMode.NONE
+    }
+
+    private fun handleDrag(point: PointF) {
+        val entry = editingEntry ?: return
+        val rect = entry.rect
+        val bitmap = bitmap ?: return
+        val lastPoint = lastBitmapPoint ?: point
+
+        when (editMode) {
+            EditMode.MOVE -> {
+                val dx = point.x - lastPoint.x
+                val dy = point.y - lastPoint.y
+                rect.offset(dx, dy)
+                clampRect(rect, bitmap)
+            }
+            EditMode.RESIZE -> {
+                val edges = activeEdges ?: EnumSet.noneOf(Edge::class.java)
+                if (edges.contains(Edge.LEFT)) {
+                    rect.left = point.x
+                }
+                if (edges.contains(Edge.RIGHT)) {
+                    rect.right = point.x
+                }
+                if (edges.contains(Edge.TOP)) {
+                    rect.top = point.y
+                }
+                if (edges.contains(Edge.BOTTOM)) {
+                    rect.bottom = point.y
+                }
+                normalizeRect(rect)
+                clampRect(rect, bitmap)
+                ensureMinimumSize(rect)
+            }
+            else -> Unit
+        }
+
+        lastBitmapPoint = point
+    }
+
+    private fun updateMatrix() {
+        val bmp = bitmap ?: return
+        val contentWidth = viewRect.width()
+        val contentHeight = viewRect.height()
+        if (contentWidth <= 0f || contentHeight <= 0f) return
+
+        val scale = min(contentWidth / bmp.width, contentHeight / bmp.height)
+        val scaledWidth = bmp.width * scale
+        val scaledHeight = bmp.height * scale
+        val dx = viewRect.left + (contentWidth - scaledWidth) / 2f
+        val dy = viewRect.top + (contentHeight - scaledHeight) / 2f
+
+        drawMatrix.reset()
+        drawMatrix.postScale(scale, scale)
+        drawMatrix.postTranslate(dx, dy)
+
+        imageRect.set(dx, dy, dx + scaledWidth, dy + scaledHeight)
+        drawMatrix.invert(inverseMatrix)
+    }
+
+    private fun toBitmapPoint(x: Float, y: Float): PointF {
+        val pts = floatArrayOf(x, y)
+        inverseMatrix.mapPoints(pts)
+        return PointF(pts[0], pts[1])
+    }
+
+    private fun resetEditState() {
+        editMode = EditMode.NONE
+        editingEntry = null
+        activeEdges = null
+        lastBitmapPoint = null
+    }
+
+    private fun findEntryAt(point: PointF): OverlayEntry? {
+        return overlayEntries.firstOrNull { it.rect.contains(point.x, point.y) }
+    }
+
+    private fun selectEntry(entry: OverlayEntry, toggle: Boolean = true) {
+        if (toggle) {
+            if (!selectedIds.add(entry.instance.id)) {
+                selectedIds.remove(entry.instance.id)
+            }
+        } else {
+            selectedIds.clear()
+            selectedIds.add(entry.instance.id)
+        }
+        overlayListener?.onSelectionChanged(selectedIds)
+        invalidate()
+    }
+
+    private fun clampRect(rect: RectF, bitmap: Bitmap) {
+        rect.left = rect.left.coerceIn(0f, bitmap.width.toFloat())
+        rect.top = rect.top.coerceIn(0f, bitmap.height.toFloat())
+        rect.right = rect.right.coerceIn(0f, bitmap.width.toFloat())
+        rect.bottom = rect.bottom.coerceIn(0f, bitmap.height.toFloat())
+        ensureMinimumSize(rect)
+    }
+
+    private fun ensureMinimumSize(rect: RectF) {
+        if (rect.width() < MIN_TILE_SIZE) {
+            rect.right = rect.left + MIN_TILE_SIZE
+        }
+        if (rect.height() < MIN_TILE_SIZE) {
+            rect.bottom = rect.top + MIN_TILE_SIZE
+        }
+    }
+
+    private fun normalizeRect(rect: RectF) {
+        val left = min(rect.left, rect.right)
+        val top = min(rect.top, rect.bottom)
+        val right = max(rect.left, rect.right)
+        val bottom = max(rect.top, rect.bottom)
+        rect.set(left, top, right, bottom)
+    }
+
+    private fun determineEditMode(entry: OverlayEntry, point: PointF): EditMode {
+        val rect = entry.rect
+        val threshold = EDGE_SLOP
+        val edges = EnumSet.noneOf(Edge::class.java)
+
+        if (abs(point.x - rect.left) <= threshold) {
+            edges.add(Edge.LEFT)
+        }
+        if (abs(point.x - rect.right) <= threshold) {
+            edges.add(Edge.RIGHT)
+        }
+        if (abs(point.y - rect.top) <= threshold) {
+            edges.add(Edge.TOP)
+        }
+        if (abs(point.y - rect.bottom) <= threshold) {
+            edges.add(Edge.BOTTOM)
+        }
+
+        return if (edges.isEmpty()) {
+            editMode = EditMode.MOVE
+            activeEdges = null
+            EditMode.MOVE
+        } else {
+            activeEdges = edges
+            editMode = EditMode.RESIZE
+            EditMode.RESIZE
+        }
+    }
+
+    private inner class OverlayGestureListener : GestureDetector.SimpleOnGestureListener() {
+        override fun onDown(e: MotionEvent): Boolean {
+            return true
+        }
+
+        override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+            if (addTileMode) return true
+            val point = toBitmapPoint(e.x, e.y)
+            val entry = findEntryAt(point)
+            if (entry != null) {
+                selectEntry(entry)
+                return true
+            }
+            return false
+        }
+
+        override fun onLongPress(e: MotionEvent) {
+            if (addTileMode) return
+            val point = toBitmapPoint(e.x, e.y)
+            val entry = findEntryAt(point) ?: return
+            selectEntry(entry, toggle = false)
+            editingEntry = entry
+            lastBitmapPoint = point
+            determineEditMode(entry, point)
+            parent.requestDisallowInterceptTouchEvent(true)
+        }
+    }
+
+    companion object {
+        private const val EDGE_SLOP = 24f
+        private const val MIN_TILE_SIZE = 24f
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -40,6 +40,7 @@ class ScannerViewModel @Inject constructor(
 
     private val multiEngineOCR: MultiEngineOCR = MultiEngineOCR(context)
     private val twoStageDetector: TwoStageDetector = TwoStageDetector(context)
+    private val manualCouponOverrides = mutableMapOf<String, CouponInstance>()
 
     companion object {
         private const val TAG = "ScannerViewModel"
@@ -171,7 +172,8 @@ class ScannerViewModel @Inject constructor(
                 Log.d(TAG, "Processing selected coupon: ${selectedInstance.id}")
 
                 // Process the selected coupon
-                processSingleCoupon(selectedInstance, originalImageUri)
+                val instance = manualCouponOverrides[selectedInstance.id] ?: selectedInstance
+                processSingleCoupon(instance, originalImageUri)
 
             } catch (e: Exception) {
                 Log.e(TAG, "Error processing selected coupon", e)
@@ -187,11 +189,12 @@ class ScannerViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 _uiState.value = ScannerUiState.Scanning
-                Log.d(TAG, "Processing all ${couponInstances.size} detected coupons")
+                val adjustedInstances = getManualAdjustedInstances(couponInstances)
+                Log.d(TAG, "Processing all ${adjustedInstances.size} detected coupons")
 
                 val savedCoupons = mutableListOf<Coupon>()
 
-                for ((index, instance) in couponInstances.withIndex()) {
+                for ((index, instance) in adjustedInstances.withIndex()) {
                     try {
                         val extractedInfo = extractTextFromFields(instance)
                         val coupon = createCouponFromInstance(instance, extractedInfo, originalImageUri)
@@ -485,6 +488,26 @@ class ScannerViewModel @Inject constructor(
         } catch (e: Exception) {
             Log.e(TAG, "Error cleaning up TwoStageDetector", e)
         }
+    }
+
+    fun resetManualOverrides() {
+        manualCouponOverrides.clear()
+    }
+
+    fun updateManualCouponInstance(instance: CouponInstance) {
+        manualCouponOverrides[instance.id] = instance
+    }
+
+    fun removeManualCoupons(ids: Set<String>) {
+        ids.forEach { manualCouponOverrides.remove(it) }
+    }
+
+    fun getManualAdjustedInstances(instances: List<CouponInstance>): List<CouponInstance> {
+        val updated = instances.map { manualCouponOverrides[it.id] ?: it }
+        val extras = manualCouponOverrides.values.filter { manual ->
+            instances.none { it.id == manual.id }
+        }
+        return updated + extras
     }
 }
 

--- a/app/src/main/res/drawable/ic_select_all.xml
+++ b/app/src/main/res/drawable/ic_select_all.xml
@@ -6,5 +6,5 @@
     android:viewportHeight="24">
     <path
         android:fillColor="@color/on_primary"
-        android:pathData="M6,7v14c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6zm3,12c0,0.55 -0.45,1 -1,1s-1,-0.45 -1,-1V10c0,-0.55 0.45,-1 1,-1s1,0.45 1,1v9zm6,0c0,0.55 -0.45,1 -1,1s-1,-0.45 -1,-1V10c0,-0.55 0.45,-1 1,-1s1,0.45 1,1v9zM15.5,3l-1,-1h-5l-1,1H5v2h14V3h-3.5z" />
+        android:pathData="M3,5h2V3H3v2zm4,0h10V3H7v2zm12,0h2V3h-2v2zM3,9h2V7H3v2zm16,-2v2h2V7h-2zM3,13h2v-2H3v2zm16,-2v2h2v-2h-2zM3,17h2v-2H3v2zm16,-2v2h2v-2h-2zM3,21h2v-2H3v2zm4,0h10v-2H7v2zm12,0h2v-2h-2v2z" />
 </vector>

--- a/app/src/main/res/layout/activity_multi_coupon_selection.xml
+++ b/app/src/main/res/layout/activity_multi_coupon_selection.xml
@@ -17,7 +17,8 @@
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:title="Multi-Coupon Detection"
         app:titleTextColor="@android:color/white"
-        app:navigationIcon="@drawable/ic_arrow_back" />
+        app:navigationIcon="@drawable/ic_arrow_back"
+        app:menu="@menu/menu_multi_coupon_selection" />
 
     <!-- Header Info -->
     <LinearLayout
@@ -54,13 +55,11 @@
         app:cardCornerRadius="8dp"
         app:cardElevation="4dp">
 
-        <ImageView
-            android:id="@+id/original_image_view"
+        <com.example.coupontracker.ui.view.MultiCouponOverlayView
+            android:id="@+id/multi_coupon_overlay"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scaleType="centerCrop"
-            android:contentDescription="Original image with detected coupons"
-            tools:src="@drawable/ic_image_placeholder" />
+            android:contentDescription="Coupon overlay" />
 
     </androidx.cardview.widget.CardView>
 
@@ -94,22 +93,11 @@
         android:elevation="8dp">
 
         <Button
-            android:id="@+id/select_all_button"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_marginEnd="8dp"
-            android:text="Select All"
-            android:textColor="@color/primary"
-            style="@style/Widget.Material3.Button.OutlinedButton"
-            android:visibility="gone" />
-
-        <Button
             android:id="@+id/process_selected_button"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:layout_marginHorizontal="4dp"
+            android:layout_marginEnd="8dp"
             android:text="Process Selected"
             android:backgroundTint="@color/secondary"
             android:textColor="@color/on_secondary"

--- a/app/src/main/res/menu/menu_multi_coupon_selection.xml
+++ b/app/src/main/res/menu/menu_multi_coupon_selection.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_select_all"
+        android:title="@string/action_select_all"
+        android:icon="@drawable/ic_select_all"
+        app:showAsAction="ifRoom|withText" />
+    <item
+        android:id="@+id/action_add_tile"
+        android:title="@string/action_add_tile"
+        android:icon="@drawable/ic_add"
+        app:showAsAction="ifRoom|withText" />
+    <item
+        android:id="@+id/action_delete"
+        android:title="@string/delete_coupon"
+        android:icon="@drawable/ic_delete"
+        app:showAsAction="ifRoom|withText" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,10 @@
     <string name="clear_data">Clear All Data</string>
     <string name="llm_verifying_model">Verifying model integrity…</string>
     <string name="llm_download_error_network">Check your internet connection or update the model URL in Advanced Settings</string>
+    <string name="action_select_all">Select All</string>
+    <string name="action_add_tile">Add Tile</string>
+    <string name="action_cancel_add_tile">Cancel Add Tile</string>
+    <string name="detected_coupon_count">Detected %1$d coupons</string>
+    <string name="overlay_draw_instruction">Drag on the image to add a tile, then tap Cancel Add Tile.</string>
+    <string name="overlay_missing_bitmap">Original image not available for editing.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a dedicated `MultiCouponOverlayView` that renders coupon bounds, supports selection, drag-resize, and drawing new tiles
- integrate the overlay into `MultiCouponSelectionActivity` with toolbar actions for select all, add tile, and delete while syncing selections with the list and ScannerViewModel overrides
- persist manual edits in `ScannerViewModel` and update resources/layouts for the new toolbar actions and icons

## Testing
- ./gradlew lintDebug *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a627e8908328af8e897b59185829