### PR TITLE
Add padding-aware coupon cropping

### DIFF
--- a/app/src/androidTest/java/com/example/coupontracker/ml/TwoStageDetectorPaddingTest.kt
+++ b/app/src/androidTest/java/com/example/coupontracker/ml/TwoStageDetectorPaddingTest.kt
@@ -1,0 +1,83 @@
+package com.example.coupontracker.ml
+
+import android.graphics.Bitmap
+import android.graphics.RectF
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.roundToInt
+
+@RunWith(AndroidJUnit4::class)
+class TwoStageDetectorPaddingTest {
+
+    private lateinit var detector: TwoStageDetector
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        detector = TwoStageDetector(context, initializeOnCreate = false)
+    }
+
+    @After
+    fun tearDown() {
+        detector.cleanup()
+    }
+
+    @Test
+    fun cropBitmap_appliesPaddingWithinImageBounds() {
+        val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+        val detectionBox = RectF(2f, 2f, 40f, 40f)
+
+        val cropResult = detector.cropBitmap(bitmap, detectionBox)
+
+        val cropOriginX = detectionBox.left - cropResult.padding.left
+        val cropOriginY = detectionBox.top - cropResult.padding.top
+        val cropRight = detectionBox.right + cropResult.padding.right
+        val cropBottom = detectionBox.bottom + cropResult.padding.bottom
+
+        assertTrue("Crop should start within bitmap bounds", cropOriginX >= 0f && cropOriginY >= 0f)
+        assertTrue(
+            "Crop should end within bitmap bounds",
+            cropRight <= bitmap.width.toFloat() && cropBottom <= bitmap.height.toFloat()
+        )
+
+        val expectedWidth = (cropRight - cropOriginX).roundToInt()
+        val expectedHeight = (cropBottom - cropOriginY).roundToInt()
+        assertEquals(expectedWidth, cropResult.bitmap.width)
+        assertEquals(expectedHeight, cropResult.bitmap.height)
+    }
+
+    @Test
+    fun adjustFieldCoordinates_removesPaddingOffsets() {
+        val couponBox = RectF(20f, 20f, 60f, 80f)
+        val padding = CropPadding(left = 12f, top = 8f, right = 6f, bottom = 4f)
+        val fields = listOf(
+            FieldDetection(
+                fieldType = FieldType.CODE_REGION,
+                boundingBox = RectF(10f, 15f, 30f, 35f),
+                confidence = 0.9f
+            )
+        )
+
+        val adjustedFields = detector.adjustFieldCoordinates(fields, couponBox, padding)
+        val adjustedBox = adjustedFields.first().boundingBox
+
+        val expectedLeft = couponBox.left - padding.left + fields.first().boundingBox.left
+        val expectedTop = couponBox.top - padding.top + fields.first().boundingBox.top
+        val expectedRight = couponBox.left - padding.left + fields.first().boundingBox.right
+        val expectedBottom = couponBox.top - padding.top + fields.first().boundingBox.bottom
+
+        assertEquals(expectedLeft, adjustedBox.left, 0.001f)
+        assertEquals(expectedTop, adjustedBox.top, 0.001f)
+        assertEquals(expectedRight, adjustedBox.right, 0.001f)
+        assertEquals(expectedBottom, adjustedBox.bottom, 0.001f)
+
+        assertTrue(adjustedBox.left >= couponBox.left - padding.left)
+        assertTrue(adjustedBox.top >= couponBox.top - padding.top)
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
@@ -3,7 +3,9 @@ package com.example.coupontracker.ml
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.RectF
+import android.util.DisplayMetrics
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import org.json.JSONObject
 import org.tensorflow.lite.Interpreter
 import org.tensorflow.lite.support.common.FileUtil
@@ -14,6 +16,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 /**
  * Two-Stage Multi-Coupon Detection System
@@ -26,7 +29,7 @@ import kotlin.math.min
  * - Partial coupon screenshots (top/bottom cut-off)
  * - Scrollable coupon lists
  */
-class TwoStageDetector(private val context: Context) {
+class TwoStageDetector(private val context: Context, initializeOnCreate: Boolean = true) {
     
     companion object {
         private const val TAG = "TwoStageDetector"
@@ -35,6 +38,7 @@ class TwoStageDetector(private val context: Context) {
         private const val CONFIDENCE_THRESHOLD = 0.5f
         private const val IOU_THRESHOLD = 0.4f
         private const val MAX_DETECTIONS = 50
+        private const val DEFAULT_CROP_PADDING_DP = 12f
         
         // Model paths
         private const val STAGE1_MODEL_PATH = "models/multi_coupon/stage1_coupon_detector.tflite"
@@ -59,7 +63,9 @@ class TwoStageDetector(private val context: Context) {
     private var isInitialized = false
     
     init {
-        initializeModels()
+        if (initializeOnCreate) {
+            initializeModels()
+        }
     }
     
     /**
@@ -180,7 +186,8 @@ class TwoStageDetector(private val context: Context) {
             couponDetections.forEachIndexed { index, couponDetection ->
                 try {
                     // Crop coupon from original image
-                    val couponCrop = cropBitmap(bitmap, couponDetection.boundingBox)
+                    val cropResult = cropBitmap(bitmap, couponDetection.boundingBox)
+                    val couponCrop = cropResult.bitmap
                     
                     if (couponCrop.width < 10 || couponCrop.height < 10) {
                         Log.w(TAG, "Coupon crop too small, skipping instance $index")
@@ -191,8 +198,12 @@ class TwoStageDetector(private val context: Context) {
                     val fieldDetections = detectFieldsInCoupon(couponCrop)
                     
                     // Adjust field coordinates back to original image space
-                    val adjustedFields = adjustFieldCoordinates(fieldDetections, couponDetection.boundingBox)
-                    
+                    val adjustedFields = adjustFieldCoordinates(
+                        fieldDetections,
+                        couponDetection.boundingBox,
+                        cropResult.padding
+                    )
+
                     couponInstances.add(
                         CouponInstance(
                             id = "coupon_${System.currentTimeMillis()}_$index",
@@ -200,7 +211,8 @@ class TwoStageDetector(private val context: Context) {
                             status = couponDetection.status,
                             confidence = couponDetection.confidence,
                             fields = adjustedFields,
-                            cropBitmap = couponCrop
+                            cropBitmap = couponCrop,
+                            cropPadding = cropResult.padding
                         )
                     )
                     
@@ -428,35 +440,79 @@ class TwoStageDetector(private val context: Context) {
     /**
      * Crop bitmap to specified rectangle with bounds checking
      */
-    private fun cropBitmap(bitmap: Bitmap, rect: RectF): Bitmap {
-        val left = max(0, rect.left.toInt())
-        val top = max(0, rect.top.toInt())
-        val right = min(bitmap.width, rect.right.toInt())
-        val bottom = min(bitmap.height, rect.bottom.toInt())
-        
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun cropBitmap(
+        bitmap: Bitmap,
+        rect: RectF,
+        paddingDp: Float = DEFAULT_CROP_PADDING_DP
+    ): CropResult {
+        val density = if (bitmap.density > 0) bitmap.density else DisplayMetrics.DENSITY_DEFAULT
+        val densityScale = density / DisplayMetrics.DENSITY_DEFAULT.toFloat()
+        val paddingPx = (paddingDp * densityScale).roundToInt()
+
+        val expandedLeft = rect.left - paddingPx
+        val expandedTop = rect.top - paddingPx
+        val expandedRight = rect.right + paddingPx
+        val expandedBottom = rect.bottom + paddingPx
+
+        val clampedLeft = max(0f, expandedLeft)
+        val clampedTop = max(0f, expandedTop)
+        val clampedRight = min(bitmap.width.toFloat(), expandedRight)
+        val clampedBottom = min(bitmap.height.toFloat(), expandedBottom)
+
+        val left = clampedLeft.toInt()
+        val top = clampedTop.toInt()
+        val right = clampedRight.toInt()
+        val bottom = clampedBottom.toInt()
+
         val width = right - left
         val height = bottom - top
-        
-        return if (width > 0 && height > 0) {
-            Bitmap.createBitmap(bitmap, left, top, width, height)
-        } else {
-            // Return a small placeholder if crop is invalid
-            Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+
+        if (width <= 0 || height <= 0) {
+            return CropResult(
+                bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888),
+                padding = CropPadding.ZERO
+            )
         }
+
+        val crop = Bitmap.createBitmap(bitmap, left, top, width, height)
+
+        val paddingLeft = (rect.left - left).coerceAtLeast(0f)
+        val paddingTop = (rect.top - top).coerceAtLeast(0f)
+        val paddingRight = (right - rect.right).coerceAtLeast(0f)
+        val paddingBottom = (bottom - rect.bottom).coerceAtLeast(0f)
+
+        return CropResult(
+            bitmap = crop,
+            padding = CropPadding(
+                left = paddingLeft,
+                top = paddingTop,
+                right = paddingRight,
+                bottom = paddingBottom
+            )
+        )
     }
-    
+
     /**
      * Adjust field coordinates from crop space back to original image space
      */
-    private fun adjustFieldCoordinates(fields: List<FieldDetection>, couponBox: RectF): List<FieldDetection> {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun adjustFieldCoordinates(
+        fields: List<FieldDetection>,
+        couponBox: RectF,
+        padding: CropPadding
+    ): List<FieldDetection> {
+        val offsetLeft = couponBox.left - padding.left
+        val offsetTop = couponBox.top - padding.top
+
         return fields.map { field ->
             val adjustedBox = RectF(
-                couponBox.left + field.boundingBox.left,
-                couponBox.top + field.boundingBox.top,
-                couponBox.left + field.boundingBox.right,
-                couponBox.top + field.boundingBox.bottom
+                offsetLeft + field.boundingBox.left,
+                offsetTop + field.boundingBox.top,
+                offsetLeft + field.boundingBox.right,
+                offsetTop + field.boundingBox.bottom
             )
-            
+
             field.copy(boundingBox = adjustedBox)
         }
     }
@@ -555,6 +611,28 @@ class TwoStageDetector(private val context: Context) {
  */
 
 /**
+ * Represents the bitmap crop result and the padding that was applied.
+ */
+data class CropResult(
+    val bitmap: Bitmap,
+    val padding: CropPadding
+)
+
+/**
+ * Metadata describing how much padding was applied around a crop on each edge.
+ */
+data class CropPadding(
+    val left: Float,
+    val top: Float,
+    val right: Float,
+    val bottom: Float
+) {
+    companion object {
+        val ZERO = CropPadding(0f, 0f, 0f, 0f)
+    }
+}
+
+/**
  * Represents a complete coupon instance with all its detected fields
  */
 data class CouponInstance(
@@ -563,7 +641,8 @@ data class CouponInstance(
     val status: CouponStatus,
     val confidence: Float,
     val fields: List<FieldDetection>,
-    val cropBitmap: Bitmap
+    val cropBitmap: Bitmap,
+    val cropPadding: CropPadding = CropPadding.ZERO
 ) {
     fun getFieldByType(fieldType: FieldType): FieldDetection? {
         return fields.find { it.fieldType == fieldType }


### PR DESCRIPTION
## Summary
- expand `TwoStageDetector` cropping with DPI-aware padding and adjust field remapping to subtract the offset
- expose crop padding metadata through `CouponInstance` so downstream consumers know the crop includes margins
- add instrumentation coverage to confirm padded crops stay within bounds and field boxes map back correctly

## Testing
- ./gradlew test *(fails: Android SDK not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a628b2a8832897e378455ba671ad