### PR TITLE
Allow description dedupe to match coupons with redeem codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,12 @@ logs/
 
 # Data directories
 data/
+!app/src/main/kotlin/com/example/coupontracker/data/
+!app/src/main/kotlin/com/example/coupontracker/data/**
+!app/src/test/java/com/example/coupontracker/data/
+!app/src/test/java/com/example/coupontracker/data/**
+!app/src/androidTest/java/com/example/coupontracker/data/
+!app/src/androidTest/java/com/example/coupontracker/data/**
 models/
 !app/src/test/resources/models/
 !app/src/test/resources/models/**

--- a/app/src/androidTest/java/com/example/coupontracker/data/local/CouponDaoTest.kt
+++ b/app/src/androidTest/java/com/example/coupontracker/data/local/CouponDaoTest.kt
@@ -13,6 +13,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.Date
+import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class CouponDaoTest {
@@ -126,4 +127,31 @@ class CouponDaoTest {
         // Then
         assert(coupons.isEmpty())
     }
-} 
+
+    @Test
+    fun findByStoreAndDescriptionMatchesCouponsWithCodes() = runBlocking {
+        val coupon = Coupon(
+            id = 0,
+            storeName = "Store",
+            description = "Limited Time Offer",
+            expiryDate = Date(),
+            cashbackAmount = 15.0,
+            redeemCode = "CODE123",
+            imageUri = null,
+            category = "Test"
+        )
+
+        couponDao.insertCoupon(coupon)
+
+        val normalized = coupon.description.lowercase(Locale.getDefault()).trim()
+        val duplicate = couponDao.findByStoreAndDescription(
+            storeName = coupon.storeName,
+            normalizedDescription = normalized,
+            descriptionHash = null,
+            descriptionSignature = null
+        )
+
+        assert(duplicate != null)
+        assert(duplicate?.redeemCode == coupon.redeemCode)
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDao.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDao.kt
@@ -50,4 +50,22 @@ interface CouponDao {
 
     @Query("SELECT * FROM coupons WHERE expiryDate BETWEEN :startDate AND :endDate ORDER BY expiryDate ASC")
     fun getCouponsExpiringBetween(startDate: Date, endDate: Date): Flow<List<Coupon>>
+
+    @Query(
+        """
+        SELECT * FROM coupons
+        WHERE storeName = :storeName
+          AND LOWER(TRIM(description)) = :normalizedDescription
+          AND (:descriptionHash IS NULL OR :descriptionHash IS NOT NULL)
+          AND (:descriptionSignature IS NULL OR :descriptionSignature IS NOT NULL)
+        ORDER BY updatedAt DESC
+        LIMIT 1
+        """
+    )
+    suspend fun findByStoreAndDescription(
+        storeName: String,
+        normalizedDescription: String,
+        descriptionHash: String?,
+        descriptionSignature: String?
+    ): Coupon?
 }

--- a/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepository.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepository.kt
@@ -26,4 +26,10 @@ interface CouponRepository {
     suspend fun updateCouponPriority(couponId: Long, isPriority: Boolean)
     suspend fun updateCouponReminder(couponId: Long, reminderDate: Date?)
     suspend fun updateCouponStatus(couponId: Long, status: String)
+    suspend fun saveOrMergeCoupon(
+        coupon: Coupon,
+        normalizedDescription: String,
+        descriptionHash: String?,
+        descriptionSignature: String?
+    ): Long
 }

--- a/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.example.coupontracker.data.local.CouponDao
 import com.example.coupontracker.data.model.Coupon
 import kotlinx.coroutines.flow.Flow
 import java.util.Date
+import kotlin.math.max
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -77,5 +78,48 @@ class CouponRepositoryImpl @Inject constructor(
             updatedAt = Date()
         )
         couponDao.updateCoupon(updatedCoupon)
+    }
+
+    override suspend fun saveOrMergeCoupon(
+        coupon: Coupon,
+        normalizedDescription: String,
+        descriptionHash: String?,
+        descriptionSignature: String?
+    ): Long {
+        val existing = couponDao.findByStoreAndDescription(
+            storeName = coupon.storeName,
+            normalizedDescription = normalizedDescription,
+            descriptionHash = descriptionHash,
+            descriptionSignature = descriptionSignature
+        )
+
+        return if (existing != null) {
+            val merged = mergeCoupons(existing, coupon)
+            couponDao.updateCoupon(merged)
+            existing.id
+        } else {
+            couponDao.insertCoupon(coupon)
+        }
+    }
+
+    private fun mergeCoupons(existing: Coupon, incoming: Coupon): Coupon {
+        return incoming.copy(
+            id = existing.id,
+            redeemCode = incoming.redeemCode ?: existing.redeemCode,
+            imageUri = incoming.imageUri ?: existing.imageUri,
+            category = incoming.category ?: existing.category,
+            status = incoming.status ?: existing.status,
+            minimumPurchase = incoming.minimumPurchase ?: existing.minimumPurchase,
+            maximumDiscount = incoming.maximumDiscount ?: existing.maximumDiscount,
+            isPriority = incoming.isPriority || existing.isPriority,
+            paymentMethod = incoming.paymentMethod ?: existing.paymentMethod,
+            usageLimit = incoming.usageLimit ?: existing.usageLimit,
+            usageCount = max(incoming.usageCount, existing.usageCount),
+            reminderDate = incoming.reminderDate ?: existing.reminderDate,
+            platformType = incoming.platformType ?: existing.platformType,
+            rating = incoming.rating ?: existing.rating,
+            createdAt = existing.createdAt,
+            updatedAt = Date()
+        )
     }
 }

--- a/app/src/test/java/com/example/coupontracker/data/repository/CouponRepositoryTest.kt
+++ b/app/src/test/java/com/example/coupontracker/data/repository/CouponRepositoryTest.kt
@@ -15,11 +15,13 @@ class CouponRepositoryTest {
 
     private lateinit var couponDao: CouponDao
     private lateinit var repository: CouponRepository
+    private lateinit var repositoryImpl: CouponRepositoryImpl
 
     @Before
     fun setup() {
         couponDao = mockk(relaxed = true)
-        repository = CouponRepositoryImpl(couponDao)
+        repositoryImpl = CouponRepositoryImpl(couponDao)
+        repository = repositoryImpl
     }
 
     @Test
@@ -89,4 +91,57 @@ class CouponRepositoryTest {
         // Then
         coVerify { couponDao.deleteCoupon(coupon) }
     }
-} 
+
+    @Test
+    fun `saveOrMergeCoupon reuses coupon with existing code`() = runBlocking {
+        val existing = Coupon(
+            id = 42,
+            storeName = "Store",
+            description = "Limited Time Offer",
+            expiryDate = Date(),
+            cashbackAmount = 10.0,
+            redeemCode = "CODE123",
+            imageUri = null,
+            category = "Test",
+            usageCount = 1,
+            createdAt = Date(0),
+            updatedAt = Date(0)
+        )
+        val normalized = existing.description.lowercase().trim()
+
+        val incoming = existing.copy(
+            id = 0,
+            redeemCode = null,
+            cashbackAmount = 20.0,
+            usageCount = 5,
+            createdAt = Date(),
+            updatedAt = Date()
+        )
+
+        coEvery {
+            couponDao.findByStoreAndDescription(
+                storeName = existing.storeName,
+                normalizedDescription = normalized,
+                descriptionHash = null,
+                descriptionSignature = null
+            )
+        } returns existing
+        coEvery { couponDao.updateCoupon(any()) } returns Unit
+
+        val result = repositoryImpl.saveOrMergeCoupon(incoming, normalized, null, null)
+
+        assert(result == existing.id)
+        coVerify(exactly = 0) { couponDao.insertCoupon(any()) }
+        coVerify {
+            couponDao.updateCoupon(
+                match {
+                    it.id == existing.id &&
+                        it.redeemCode == existing.redeemCode &&
+                        it.cashbackAmount == incoming.cashbackAmount &&
+                        it.usageCount == kotlin.math.max(existing.usageCount, incoming.usageCount) &&
+                        it.createdAt == existing.createdAt
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- whitelist the data source directories so DAO and repository files remain tracked
- update the Room query to look up coupons by store and normalized description without excluding rows that contain redeem codes, and expose a repository helper that merges duplicates
- add DAO and repository tests to confirm a code-less coupon still deduplicates with an existing coupon that already has a redeem code

## Testing
- ./gradlew test *(fails: Android SDK not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bc8f8fd48328970844ae520bf927