### PR TITLE
Add normalized coupon metadata migration

### DIFF
--- a/app/src/androidTest/java/com/example/coupontracker/data/local/CouponDaoTest.kt
+++ b/app/src/androidTest/java/com/example/coupontracker/data/local/CouponDaoTest.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.coupontracker.data.model.Coupon
+import com.example.coupontracker.data.util.CouponDedupUtils
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -13,7 +14,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.Date
-import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class CouponDaoTest {
@@ -130,10 +130,14 @@ class CouponDaoTest {
 
     @Test
     fun findByStoreAndDescriptionMatchesCouponsWithCodes() = runBlocking {
+        val description = "Limited Time Offer!!!"
+        val normalized = CouponDedupUtils.normalizeDescription(description)
+
         val coupon = Coupon(
             id = 0,
             storeName = "Store",
-            description = "Limited Time Offer",
+            description = description,
+            normalizedDescription = normalized,
             expiryDate = Date(),
             cashbackAmount = 15.0,
             redeemCode = "CODE123",
@@ -143,12 +147,11 @@ class CouponDaoTest {
 
         couponDao.insertCoupon(coupon)
 
-        val normalized = coupon.description.lowercase(Locale.getDefault()).trim()
         val duplicate = couponDao.findByStoreAndDescription(
             storeName = coupon.storeName,
             normalizedDescription = normalized,
-            descriptionHash = null,
-            descriptionSignature = null
+            imagePhash = null,
+            imageSignature = null
         )
 
         assert(duplicate != null)

--- a/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDao.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDao.kt
@@ -55,9 +55,9 @@ interface CouponDao {
         """
         SELECT * FROM coupons
         WHERE storeName = :storeName
-          AND LOWER(TRIM(description)) = :normalizedDescription
-          AND (:descriptionHash IS NULL OR :descriptionHash IS NOT NULL)
-          AND (:descriptionSignature IS NULL OR :descriptionSignature IS NOT NULL)
+          AND normalizedDescription = :normalizedDescription
+          AND (:imagePhash IS NULL OR imagePhash = :imagePhash)
+          AND (:imageSignature IS NULL OR imageSignature = :imageSignature)
         ORDER BY updatedAt DESC
         LIMIT 1
         """
@@ -65,7 +65,7 @@ interface CouponDao {
     suspend fun findByStoreAndDescription(
         storeName: String,
         normalizedDescription: String,
-        descriptionHash: String?,
-        descriptionSignature: String?
+        imagePhash: String?,
+        imageSignature: String?
     ): Coupon?
 }

--- a/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDatabase.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDatabase.kt
@@ -6,8 +6,9 @@ import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.example.coupontracker.data.model.Coupon
+import com.example.coupontracker.data.util.CouponDedupUtils
 
-@Database(entities = [Coupon::class], version = 3)
+@Database(entities = [Coupon::class], version = 4)
 @TypeConverters(Converters::class)
 abstract class CouponDatabase : RoomDatabase() {
     abstract fun couponDao(): CouponDao
@@ -27,6 +28,37 @@ abstract class CouponDatabase : RoomDatabase() {
                 database.execSQL("ALTER TABLE coupons ADD COLUMN usageCount INTEGER NOT NULL DEFAULT 0")
                 database.execSQL("ALTER TABLE coupons ADD COLUMN reminderDate INTEGER")
                 database.execSQL("ALTER TABLE coupons ADD COLUMN platformType TEXT")
+            }
+        }
+
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE coupons ADD COLUMN normalizedDescription TEXT")
+                database.execSQL("ALTER TABLE coupons ADD COLUMN imagePhash TEXT")
+                database.execSQL("ALTER TABLE coupons ADD COLUMN imageSignature TEXT")
+
+                database.query("SELECT id, description FROM coupons").use { cursor ->
+                    val updateStatement = database.compileStatement(
+                        "UPDATE coupons SET normalizedDescription = ? WHERE id = ?"
+                    )
+                    try {
+                        while (cursor.moveToNext()) {
+                            val id = cursor.getLong(0)
+                            val description = cursor.getString(1)
+                            val normalized = CouponDedupUtils.normalizeDescription(description)
+                            updateStatement.bindString(1, normalized)
+                            updateStatement.bindLong(2, id)
+                            updateStatement.executeUpdateDelete()
+                            updateStatement.clearBindings()
+                        }
+                    } finally {
+                        updateStatement.close()
+                    }
+                }
+
+                // The legacy database only stored URIs to coupon images, so we cannot
+                // backfill perceptual hashes or signatures for existing rows. The new
+                // columns remain null until fresh image data is processed.
             }
         }
     }

--- a/app/src/main/kotlin/com/example/coupontracker/data/model/Coupon.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/model/Coupon.kt
@@ -10,10 +10,13 @@ data class Coupon(
     val id: Long = 0,
     val storeName: String,
     val description: String,
+    val normalizedDescription: String? = null,
     val expiryDate: Date,
     val cashbackAmount: Double,
     val redeemCode: String?,
     val imageUri: String?,
+    val imagePhash: String? = null,
+    val imageSignature: String? = null,
     val category: String? = null,
     val status: String? = null,
 

--- a/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepository.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepository.kt
@@ -29,7 +29,7 @@ interface CouponRepository {
     suspend fun saveOrMergeCoupon(
         coupon: Coupon,
         normalizedDescription: String,
-        descriptionHash: String?,
-        descriptionSignature: String?
+        imagePhash: String?,
+        imageSignature: String?
     ): Long
 }

--- a/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepositoryImpl.kt
@@ -83,30 +83,39 @@ class CouponRepositoryImpl @Inject constructor(
     override suspend fun saveOrMergeCoupon(
         coupon: Coupon,
         normalizedDescription: String,
-        descriptionHash: String?,
-        descriptionSignature: String?
+        imagePhash: String?,
+        imageSignature: String?
     ): Long {
-        val existing = couponDao.findByStoreAndDescription(
-            storeName = coupon.storeName,
+        val normalizedCoupon = coupon.copy(
             normalizedDescription = normalizedDescription,
-            descriptionHash = descriptionHash,
-            descriptionSignature = descriptionSignature
+            imagePhash = imagePhash,
+            imageSignature = imageSignature
+        )
+
+        val existing = couponDao.findByStoreAndDescription(
+            storeName = normalizedCoupon.storeName,
+            normalizedDescription = normalizedDescription,
+            imagePhash = imagePhash,
+            imageSignature = imageSignature
         )
 
         return if (existing != null) {
-            val merged = mergeCoupons(existing, coupon)
+            val merged = mergeCoupons(existing, normalizedCoupon)
             couponDao.updateCoupon(merged)
             existing.id
         } else {
-            couponDao.insertCoupon(coupon)
+            couponDao.insertCoupon(normalizedCoupon)
         }
     }
 
     private fun mergeCoupons(existing: Coupon, incoming: Coupon): Coupon {
         return incoming.copy(
             id = existing.id,
+            normalizedDescription = incoming.normalizedDescription ?: existing.normalizedDescription,
             redeemCode = incoming.redeemCode ?: existing.redeemCode,
             imageUri = incoming.imageUri ?: existing.imageUri,
+            imagePhash = incoming.imagePhash ?: existing.imagePhash,
+            imageSignature = incoming.imageSignature ?: existing.imageSignature,
             category = incoming.category ?: existing.category,
             status = incoming.status ?: existing.status,
             minimumPurchase = incoming.minimumPurchase ?: existing.minimumPurchase,

--- a/app/src/main/kotlin/com/example/coupontracker/data/util/CouponDedupUtils.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/util/CouponDedupUtils.kt
@@ -1,0 +1,23 @@
+package com.example.coupontracker.data.util
+
+import java.util.Locale
+
+/**
+ * Utility helpers for deduplicating coupons based on their textual descriptions.
+ */
+object CouponDedupUtils {
+    private val NON_ALPHANUMERIC_REGEX = Regex("[^a-z0-9]+")
+    private val WHITESPACE_REGEX = Regex("\\s+")
+
+    /**
+     * Normalizes a coupon description by lowercasing, stripping non-alphanumeric
+     * characters, and collapsing repeated whitespace. This mirrors the logic
+     * used by the deduplication query so it can be reused across migrations and
+     * repository operations.
+     */
+    fun normalizeDescription(description: String): String {
+        val lowercased = description.lowercase(Locale.US)
+        val cleaned = NON_ALPHANUMERIC_REGEX.replace(lowercased, " ")
+        return WHITESPACE_REGEX.replace(cleaned.trim(), " ")
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/di/DatabaseModule.kt
@@ -27,7 +27,10 @@ object DatabaseModule {
             CouponDatabase::class.java,
             CouponDatabase.DATABASE_NAME
         )
-            .addMigrations(CouponDatabase.MIGRATION_2_3)
+            .addMigrations(
+                CouponDatabase.MIGRATION_2_3,
+                CouponDatabase.MIGRATION_3_4
+            )
             .fallbackToDestructiveMigration()
             .build()
     }

--- a/app/src/test/java/com/example/coupontracker/data/local/CouponDatabaseMigrationTest.kt
+++ b/app/src/test/java/com/example/coupontracker/data/local/CouponDatabaseMigrationTest.kt
@@ -1,0 +1,132 @@
+package com.example.coupontracker.data.local
+
+import android.content.ContentValues
+import android.content.Context
+import androidx.room.Room
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import com.example.coupontracker.data.util.CouponDedupUtils
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CouponDatabaseMigrationTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val databaseName = "migration-test-db"
+
+    @After
+    fun tearDown() {
+        context.deleteDatabase(databaseName)
+    }
+
+    @Test
+    fun migrate3To4_populatesNormalizedDescription_andSupportsDedupLookup() = runBlocking {
+        val storeName = "Legacy Store"
+        val description = "SAVE $10!!! Limited time"
+        createLegacyDatabase(storeName, description)
+        val normalized = CouponDedupUtils.normalizeDescription(description)
+
+        val database = Room.databaseBuilder(context, CouponDatabase::class.java, databaseName)
+            .addMigrations(CouponDatabase.MIGRATION_3_4)
+            .allowMainThreadQueries()
+            .build()
+
+        val migratedCoupon = database.couponDao().findByStoreAndDescription(
+            storeName = storeName,
+            normalizedDescription = normalized,
+            imagePhash = null,
+            imageSignature = null
+        )
+
+        assertNotNull("Coupon should be found after migration", migratedCoupon)
+        assertEquals(normalized, migratedCoupon?.normalizedDescription)
+        assertNull(migratedCoupon?.imagePhash)
+        assertNull(migratedCoupon?.imageSignature)
+
+        database.close()
+    }
+
+    private fun createLegacyDatabase(storeName: String, description: String) {
+        context.deleteDatabase(databaseName)
+        val configuration = SupportSQLiteOpenHelper.Configuration.builder(context)
+            .name(databaseName)
+            .callback(object : SupportSQLiteOpenHelper.Callback(3) {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS `coupons` (
+                            `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                            `storeName` TEXT NOT NULL,
+                            `description` TEXT NOT NULL,
+                            `expiryDate` INTEGER NOT NULL,
+                            `cashbackAmount` REAL NOT NULL,
+                            `redeemCode` TEXT,
+                            `imageUri` TEXT,
+                            `category` TEXT,
+                            `status` TEXT,
+                            `minimumPurchase` REAL,
+                            `maximumDiscount` REAL,
+                            `isPriority` INTEGER NOT NULL,
+                            `paymentMethod` TEXT,
+                            `usageLimit` INTEGER,
+                            `usageCount` INTEGER NOT NULL,
+                            `reminderDate` INTEGER,
+                            `platformType` TEXT,
+                            `rating` TEXT,
+                            `createdAt` INTEGER NOT NULL,
+                            `updatedAt` INTEGER NOT NULL
+                        )
+                        """
+                    )
+                }
+
+                override fun onUpgrade(
+                    db: SupportSQLiteDatabase,
+                    oldVersion: Int,
+                    newVersion: Int
+                ) {
+                    // No-op for the test schema
+                }
+            })
+            .build()
+
+        val openHelper = FrameworkSQLiteOpenHelperFactory().create(configuration)
+        val db = openHelper.writableDatabase
+        val now = System.currentTimeMillis()
+
+        val values = ContentValues().apply {
+            put("storeName", storeName)
+            put("description", description)
+            put("expiryDate", now)
+            put("cashbackAmount", 5.0)
+            put("redeemCode", "LEGACY")
+            put("imageUri", null as String?)
+            put("category", "Legacy")
+            put("status", null as String?)
+            put("minimumPurchase", null as Double?)
+            put("maximumDiscount", null as Double?)
+            put("isPriority", 0)
+            put("paymentMethod", null as String?)
+            put("usageLimit", null as Int?)
+            put("usageCount", 1)
+            put("reminderDate", null as Long?)
+            put("platformType", null as String?)
+            put("rating", null as String?)
+            put("createdAt", now)
+            put("updatedAt", now)
+        }
+
+        db.insert("coupons", SupportSQLiteDatabase.CONFLICT_ABORT, values)
+        db.close()
+        openHelper.close()
+    }
+}

--- a/app/src/test/java/com/example/coupontracker/data/repository/CouponRepositoryTest.kt
+++ b/app/src/test/java/com/example/coupontracker/data/repository/CouponRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.example.coupontracker.data.repository
 
 import com.example.coupontracker.data.local.CouponDao
 import com.example.coupontracker.data.model.Coupon
+import com.example.coupontracker.data.util.CouponDedupUtils
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -94,10 +95,14 @@ class CouponRepositoryTest {
 
     @Test
     fun `saveOrMergeCoupon reuses coupon with existing code`() = runBlocking {
+        val description = "Limited Time Offer!!!"
+        val normalized = CouponDedupUtils.normalizeDescription(description)
+
         val existing = Coupon(
             id = 42,
             storeName = "Store",
-            description = "Limited Time Offer",
+            description = description,
+            normalizedDescription = normalized,
             expiryDate = Date(),
             cashbackAmount = 10.0,
             redeemCode = "CODE123",
@@ -107,10 +112,10 @@ class CouponRepositoryTest {
             createdAt = Date(0),
             updatedAt = Date(0)
         )
-        val normalized = existing.description.lowercase().trim()
 
         val incoming = existing.copy(
             id = 0,
+            normalizedDescription = null,
             redeemCode = null,
             cashbackAmount = 20.0,
             usageCount = 5,
@@ -122,8 +127,8 @@ class CouponRepositoryTest {
             couponDao.findByStoreAndDescription(
                 storeName = existing.storeName,
                 normalizedDescription = normalized,
-                descriptionHash = null,
-                descriptionSignature = null
+                imagePhash = null,
+                imageSignature = null
             )
         } returns existing
         coEvery { couponDao.updateCoupon(any()) } returns Unit
@@ -136,6 +141,7 @@ class CouponRepositoryTest {
             couponDao.updateCoupon(
                 match {
                     it.id == existing.id &&
+                        it.normalizedDescription == normalized &&
                         it.redeemCode == existing.redeemCode &&
                         it.cashbackAmount == incoming.cashbackAmount &&
                         it.usageCount == kotlin.math.max(existing.usageCount, incoming.usageCount) &&


### PR DESCRIPTION
## Summary
- add a Room migration that backfills normalizedDescription while adding image metadata columns
- update the coupon model, DAO, and repository logic to rely on the normalized description for dedupe queries
- add a shared normalization utility plus unit and instrumentation tests to cover the migration and dedupe flow

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bfbdec90832889528d2d91e0de6c