### PR TITLE
Launch multi-coupon selection activity from scanner

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("kotlin-kapt")
+    id("kotlin-parcelize")
     id("androidx.navigation.safeargs.kotlin")
     id("com.google.dagger.hilt.android")
 }

--- a/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
@@ -3,6 +3,7 @@ package com.example.coupontracker.ml
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.RectF
+import android.os.Parcelable
 import android.util.DisplayMetrics
 import android.util.Log
 import androidx.annotation.VisibleForTesting
@@ -17,6 +18,7 @@ import java.nio.ByteOrder
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
+import kotlinx.parcelize.Parcelize
 
 /**
  * Two-Stage Multi-Coupon Detection System
@@ -621,12 +623,13 @@ data class CropResult(
 /**
  * Metadata describing how much padding was applied around a crop on each edge.
  */
+@Parcelize
 data class CropPadding(
     val left: Float,
     val top: Float,
     val right: Float,
     val bottom: Float
-) {
+) : Parcelable {
     companion object {
         val ZERO = CropPadding(0f, 0f, 0f, 0f)
     }
@@ -635,6 +638,7 @@ data class CropPadding(
 /**
  * Represents a complete coupon instance with all its detected fields
  */
+@Parcelize
 data class CouponInstance(
     val id: String,
     val boundingBox: RectF,
@@ -643,7 +647,7 @@ data class CouponInstance(
     val fields: List<FieldDetection>,
     val cropBitmap: Bitmap,
     val cropPadding: CropPadding = CropPadding.ZERO
-) {
+) : Parcelable {
     fun getFieldByType(fieldType: FieldType): FieldDetection? {
         return fields.find { it.fieldType == fieldType }
     }
@@ -659,12 +663,13 @@ data class CouponInstance(
 /**
  * Represents a detected field within a coupon
  */
+@Parcelize
 data class FieldDetection(
     val fieldType: FieldType,
     val boundingBox: RectF,
     val confidence: Float,
     val text: String? = null
-)
+) : Parcelable
 
 /**
  * Represents a detected coupon boundary (Stage 1 result)

--- a/app/src/main/kotlin/com/example/coupontracker/ui/activity/MultiCouponSelectionActivity.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/activity/MultiCouponSelectionActivity.kt
@@ -1,9 +1,14 @@
 package com.example.coupontracker.ui.activity
 
+import android.app.Activity
+import android.content.Intent
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -27,6 +32,7 @@ import com.example.coupontracker.ui.viewmodel.ScannerUiState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import java.io.IOException
 
 @AndroidEntryPoint
 class MultiCouponSelectionActivity : AppCompatActivity() {
@@ -44,21 +50,29 @@ class MultiCouponSelectionActivity : AppCompatActivity() {
         const val EXTRA_COUPON_INSTANCES = "coupon_instances"
         const val EXTRA_ORIGINAL_BITMAP = "original_bitmap"
         const val EXTRA_IMAGE_URI = "image_uri"
+        const val EXTRA_RESULT_TYPE = "result_type"
+        const val EXTRA_RESULT_PROCESSED_COUNT = "processed_count"
+        const val EXTRA_RESULT_MESSAGE = "result_message"
+
+        const val RESULT_TYPE_ALL_PROCESSED = "all_processed"
+        const val RESULT_TYPE_SINGLE_PROCESSED = "single_processed"
+        const val RESULT_TYPE_ALREADY_SAVED = "already_saved"
     }
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMultiCouponSelectionBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        
+
         setupUI()
-        extractIntentData()
         setupRecyclerView()
+        extractIntentData()
         observeViewModel()
     }
     
     private fun setupUI() {
         binding.toolbar.setNavigationOnClickListener {
+            setResult(Activity.RESULT_CANCELED)
             finish()
         }
         
@@ -76,11 +90,42 @@ class MultiCouponSelectionActivity : AppCompatActivity() {
     }
     
     private fun extractIntentData() {
-        // In a real implementation, you would pass data through Intent extras
-        // For now, we'll use a simple approach
-        
-        // This is a simplified approach - in practice, you might use Parcelable or pass data differently
         Log.d(TAG, "Extracting intent data for multi-coupon selection")
+
+        val instances: ArrayList<CouponInstance>? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableArrayListExtra(EXTRA_COUPON_INSTANCES, CouponInstance::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableArrayListExtra(EXTRA_COUPON_INSTANCES)
+        }
+
+        val bitmap: Bitmap? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(EXTRA_ORIGINAL_BITMAP, Bitmap::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(EXTRA_ORIGINAL_BITMAP)
+        }
+
+        val uriString = intent.getStringExtra(EXTRA_IMAGE_URI)
+
+        if (instances.isNullOrEmpty()) {
+            Log.w(TAG, "No coupon instances found in intent extras")
+            Toast.makeText(this, R.string.multi_coupon_missing_data, Toast.LENGTH_LONG).show()
+            finish()
+            return
+        }
+
+        couponInstances = instances
+        imageUri = uriString
+
+        originalBitmap = bitmap ?: uriString?.let { loadBitmapSafely(Uri.parse(it)) }
+
+        if (originalBitmap == null) {
+            Log.w(TAG, "Original bitmap missing; proceeding without overlay image")
+            Toast.makeText(this, R.string.multi_coupon_missing_image, Toast.LENGTH_SHORT).show()
+        }
+
+        displayCoupons(couponInstances, originalBitmap)
     }
     
     private fun setupRecyclerView() {
@@ -122,36 +167,59 @@ class MultiCouponSelectionActivity : AppCompatActivity() {
                         binding.progressBar.visibility = View.GONE
                         binding.buttonsContainer.visibility = View.VISIBLE
 
+                        val processedCount = state.processedCoupons.size
                         Toast.makeText(
                             this@MultiCouponSelectionActivity,
-                            "Successfully saved ${state.processedCoupons.size} coupons",
+                            "Successfully saved $processedCount coupons",
                             Toast.LENGTH_LONG
                         ).show()
-                        
+
+                        val resultIntent = Intent().apply {
+                            putExtra(EXTRA_RESULT_TYPE, RESULT_TYPE_ALL_PROCESSED)
+                            putExtra(EXTRA_RESULT_PROCESSED_COUNT, processedCount)
+                        }
+                        setResult(Activity.RESULT_OK, resultIntent)
                         finish()
                     }
                     is ScannerUiState.Saved -> {
                         binding.progressBar.visibility = View.GONE
                         binding.buttonsContainer.visibility = View.VISIBLE
-                        
+
+                        val message = "Coupon saved successfully!"
                         Toast.makeText(
                             this@MultiCouponSelectionActivity,
-                            "Coupon saved successfully!",
+                            message,
                             Toast.LENGTH_SHORT
                         ).show()
-                        
+
+                        val resultIntent = Intent().apply {
+                            putExtra(EXTRA_RESULT_TYPE, RESULT_TYPE_SINGLE_PROCESSED)
+                            putExtra(EXTRA_RESULT_PROCESSED_COUNT, 1)
+                            putExtra(EXTRA_RESULT_MESSAGE, message)
+                            putExtra(EXTRA_IMAGE_URI, imageUri)
+                        }
+                        setResult(Activity.RESULT_OK, resultIntent)
                         finish()
                     }
                     is ScannerUiState.AlreadySaved -> {
                         binding.progressBar.visibility = View.GONE
                         binding.buttonsContainer.visibility = View.VISIBLE
-                        
+
+                        val existing = state.existingCoupon
+                        val message = "Coupon already saved: ${existing.redeemCode ?: existing.storeName}"
                         Toast.makeText(
                             this@MultiCouponSelectionActivity,
-                            "Coupon already saved: ${state.existingCoupon.redeemCode ?: state.existingCoupon.storeName}",
+                            message,
                             Toast.LENGTH_LONG
                         ).show()
-                        
+
+                        val resultIntent = Intent().apply {
+                            putExtra(EXTRA_RESULT_TYPE, RESULT_TYPE_ALREADY_SAVED)
+                            putExtra(EXTRA_RESULT_PROCESSED_COUNT, 1)
+                            putExtra(EXTRA_RESULT_MESSAGE, message)
+                            putExtra(EXTRA_IMAGE_URI, imageUri)
+                        }
+                        setResult(Activity.RESULT_OK, resultIntent)
                         finish()
                     }
                     is ScannerUiState.Error -> {
@@ -177,16 +245,20 @@ class MultiCouponSelectionActivity : AppCompatActivity() {
         }
     }
     
-    private fun displayCoupons(instances: List<CouponInstance>, bitmap: Bitmap) {
+    private fun displayCoupons(instances: List<CouponInstance>, bitmap: Bitmap?) {
         Log.d(TAG, "Displaying ${instances.size} detected coupons")
-        
+
         // Update header info
         binding.detectedCountText.text = "Detected ${instances.size} coupons"
-        
-        // Show original image with overlays
-        val overlayBitmap = createOverlayBitmap(bitmap, instances)
-        binding.originalImageView.setImageBitmap(overlayBitmap)
-        
+
+        // Show original image with overlays when available
+        if (bitmap != null) {
+            val overlayBitmap = createOverlayBitmap(bitmap, instances)
+            binding.originalImageView.setImageBitmap(overlayBitmap)
+        } else {
+            binding.originalImageView.setImageDrawable(null)
+        }
+
         // Update adapter
         adapter.updateCoupons(instances)
         
@@ -195,7 +267,7 @@ class MultiCouponSelectionActivity : AppCompatActivity() {
         binding.processSelectedButton.visibility = View.VISIBLE
         binding.processAllButton.visibility = View.VISIBLE
     }
-    
+
     private fun createOverlayBitmap(originalBitmap: Bitmap, instances: List<CouponInstance>): Bitmap {
         val overlayBitmap = originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
         val canvas = Canvas(overlayBitmap)
@@ -261,19 +333,30 @@ class MultiCouponSelectionActivity : AppCompatActivity() {
     
     private fun processSelectedCoupons() {
         val selectedCoupons = adapter.getSelectedCoupons()
-        
+
         if (selectedCoupons.isEmpty()) {
             Toast.makeText(this, "Please select at least one coupon", Toast.LENGTH_SHORT).show()
             return
         }
-        
+
         Log.d(TAG, "Processing ${selectedCoupons.size} selected coupons")
         viewModel.processSelectedCoupons(selectedCoupons, imageUri)
     }
-    
+
     private fun processAllCoupons() {
         Log.d(TAG, "Processing all ${couponInstances.size} detected coupons")
         viewModel.processAllCoupons(couponInstances, imageUri)
+    }
+
+    private fun loadBitmapSafely(uri: Uri): Bitmap? {
+        return try {
+            contentResolver.openInputStream(uri)?.use { inputStream ->
+                BitmapFactory.decodeStream(inputStream)
+            }
+        } catch (ioException: IOException) {
+            Log.e(TAG, "Failed to load bitmap from $uri", ioException)
+            null
+        }
     }
     
     /**

--- a/app/src/main/kotlin/com/example/coupontracker/ui/fragment/ScannerFragment.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/fragment/ScannerFragment.kt
@@ -1,6 +1,8 @@
 package com.example.coupontracker.ui.fragment
 
 import android.Manifest
+import android.app.Activity
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
@@ -22,6 +24,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.example.coupontracker.R
 import com.example.coupontracker.databinding.FragmentScannerBinding
+import com.example.coupontracker.ui.activity.MultiCouponSelectionActivity
 import com.example.coupontracker.ui.viewmodel.ScannerViewModel
 import com.example.coupontracker.ui.viewmodel.ScannerUiState
 import com.example.coupontracker.util.CouponInfo
@@ -46,9 +49,9 @@ class ScannerFragment : Fragment() {
     private var imageCapture: ImageCapture? = null
     private lateinit var outputDirectory: File
     private lateinit var cameraExecutor: ExecutorService
-    
+
     private val TAG = "ScannerFragment"
-    
+
     private val requestPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { isGranted ->
@@ -62,6 +65,46 @@ class ScannerFragment : Fragment() {
             ).show()
             findNavController().navigateUp()
         }
+    }
+
+    private val multiCouponSelectionLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        val currentBinding = _binding
+
+        if (result.resultCode == Activity.RESULT_OK) {
+            val data = result.data
+            val processedCount = data?.getIntExtra(
+                MultiCouponSelectionActivity.EXTRA_RESULT_PROCESSED_COUNT,
+                0
+            ) ?: 0
+            val resultType = data?.getStringExtra(MultiCouponSelectionActivity.EXTRA_RESULT_TYPE)
+            val explicitMessage = data?.getStringExtra(MultiCouponSelectionActivity.EXTRA_RESULT_MESSAGE)
+
+            val fallbackMessage = when (resultType) {
+                MultiCouponSelectionActivity.RESULT_TYPE_ALL_PROCESSED ->
+                    getString(R.string.multi_coupon_all_saved_snackbar, processedCount)
+
+                MultiCouponSelectionActivity.RESULT_TYPE_SINGLE_PROCESSED ->
+                    getString(R.string.multi_coupon_single_saved_snackbar)
+
+                MultiCouponSelectionActivity.RESULT_TYPE_ALREADY_SAVED ->
+                    getString(R.string.multi_coupon_already_saved_snackbar)
+
+                else -> if (processedCount > 0) {
+                    getString(R.string.multi_coupon_all_saved_snackbar, processedCount)
+                } else {
+                    null
+                }
+            }
+
+            val messageToShow = explicitMessage ?: fallbackMessage
+            if (!messageToShow.isNullOrBlank() && currentBinding != null) {
+                Snackbar.make(currentBinding.root, messageToShow, Snackbar.LENGTH_LONG).show()
+            }
+        }
+
+        viewModel.resetState()
     }
     
     override fun onCreateView(
@@ -162,16 +205,25 @@ class ScannerFragment : Fragment() {
                     is ScannerUiState.MultiCouponDetected -> {
                         binding.progressBar.visibility = View.GONE
                         binding.captureButton.isEnabled = true
-                        
-                        // Handle multi-coupon detection
-                        Snackbar.make(
-                            binding.root,
-                            "Detected ${state.couponInstances.size} coupons! Opening selection interface...",
-                            Snackbar.LENGTH_LONG
-                        ).show()
-                        
-                        // Navigate to multi-coupon selection activity
-                        // For now, just show a message - you can implement navigation later
+
+                        val selectionIntent = Intent(
+                            requireContext(),
+                            MultiCouponSelectionActivity::class.java
+                        ).apply {
+                            putParcelableArrayListExtra(
+                                MultiCouponSelectionActivity.EXTRA_COUPON_INSTANCES,
+                                ArrayList(state.couponInstances)
+                            )
+                            putExtra(
+                                MultiCouponSelectionActivity.EXTRA_ORIGINAL_BITMAP,
+                                state.originalBitmap
+                            )
+                            state.imageUri?.let {
+                                putExtra(MultiCouponSelectionActivity.EXTRA_IMAGE_URI, it)
+                            }
+                        }
+
+                        multiCouponSelectionLauncher.launch(selectionIntent)
                     }
                     is ScannerUiState.AllCouponsSaved -> {
                         binding.progressBar.visibility = View.GONE

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,9 @@
     <string name="clear_data">Clear All Data</string>
     <string name="llm_verifying_model">Verifying model integrity…</string>
     <string name="llm_download_error_network">Check your internet connection or update the model URL in Advanced Settings</string>
+    <string name="multi_coupon_missing_data">Unable to open detected coupons. Please try scanning again.</string>
+    <string name="multi_coupon_missing_image">Original scan preview unavailable.</string>
+    <string name="multi_coupon_all_saved_snackbar">Successfully saved %1$d coupons.</string>
+    <string name="multi_coupon_single_saved_snackbar">Coupon processed successfully.</string>
+    <string name="multi_coupon_already_saved_snackbar">Coupon was already saved.</string>
 </resources>


### PR DESCRIPTION
## Summary
- annotate coupon instance models with Parcelable support and enable the kotlin-parcelize plugin for intent hand-off
- launch the multi-coupon selection activity from the scanner fragment with the detected instances and handle the activity result to reset scanning UI
- update the selection activity to read intent extras, provide result data back to the scanner, and surface helpful status strings

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e8745078832880c1630ddc522721