### PR TITLE
Add stub multi-coupon detector assets and document delivery workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ data/
 models/
 !app/src/test/resources/models/
 !app/src/test/resources/models/**
+!app/src/main/assets/models/
+!app/src/main/assets/models/**
 
 # Local backup files
 *.bak

--- a/app/src/main/assets/models/multi_coupon/manifest.json
+++ b/app/src/main/assets/models/multi_coupon/manifest.json
@@ -1,0 +1,24 @@
+{
+  "model_version": "0.1.0-stub",
+  "model_type": "two_stage_yolo",
+  "stage1_model": "stage1_coupon_detector.tflite",
+  "stage2_model": "stage2_field_detector.tflite",
+  "stage1_input_size": [640, 640],
+  "stage2_input_size": [320, 320],
+  "stage1_classes": [
+    "coupon_complete",
+    "coupon_partial_top",
+    "coupon_partial_bottom"
+  ],
+  "stage2_classes": [
+    "code_region",
+    "benefit_region",
+    "expiry_region",
+    "app_region",
+    "terms_region"
+  ],
+  "confidence_threshold": 0.5,
+  "iou_threshold": 0.4,
+  "stub_mode": true,
+  "stub_notes": "Trained YOLO models are distributed separately. Use complete_multi_coupon_pipeline.sh or the internal artifact delivery process to populate app/src/main/assets/models/multi_coupon with production binaries before shipping."
+}

--- a/app/src/main/assets/models/multi_coupon/stage1_coupon_detector.tflite
+++ b/app/src/main/assets/models/multi_coupon/stage1_coupon_detector.tflite
@@ -1,0 +1,2 @@
+Placeholder binary for the Stage 1 coupon detector.
+Replace this file with the trained stage1_coupon_detector.tflite artifact before running production builds.

--- a/app/src/main/assets/models/multi_coupon/stage2_field_detector.tflite
+++ b/app/src/main/assets/models/multi_coupon/stage2_field_detector.tflite
@@ -1,0 +1,2 @@
+Placeholder binary for the Stage 2 field detector.
+Replace this file with the trained stage2_field_detector.tflite artifact before running production builds.

--- a/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
@@ -58,6 +58,7 @@ class TwoStageDetector(private val context: Context, initializeOnCreate: Boolean
     
     // Model configuration
     private var modelManifest: JSONObject? = null
+    private var stubMode: Boolean = false
     private val stage1Classes = arrayOf("coupon_complete", "coupon_partial_top", "coupon_partial_bottom")
     private val stage2Classes = arrayOf("code_region", "benefit_region", "expiry_region", "app_region", "terms_region")
     
@@ -80,15 +81,28 @@ class TwoStageDetector(private val context: Context, initializeOnCreate: Boolean
             // Load model manifest
             loadModelManifest()
             
+            if (stubMode) {
+                Log.w(
+                    TAG,
+                    "Multi-coupon manifest is marked as stub_mode. Skipping TensorFlow Lite interpreter initialization. " +
+                        "Replace the placeholder assets with trained binaries for production use."
+                )
+                stage1Interpreter = null
+                stage2Interpreter = null
+                initializeImageProcessors()
+                isInitialized = true
+                return
+            }
+
             // Load Stage 1 Model (Coupon Detection)
             loadStage1Model()
-            
-            // Load Stage 2 Model (Field Detection)  
+
+            // Load Stage 2 Model (Field Detection)
             loadStage2Model()
-            
+
             // Initialize image processors
             initializeImageProcessors()
-            
+
             isInitialized = true
             Log.i(TAG, "Two-stage models initialized successfully")
             
@@ -106,7 +120,9 @@ class TwoStageDetector(private val context: Context, initializeOnCreate: Boolean
             val version = modelManifest?.optString("model_version", "unknown")
             val modelType = modelManifest?.optString("model_type", "unknown")
             
-            Log.d(TAG, "Model manifest loaded - Version: $version, Type: $modelType")
+            stubMode = modelManifest?.optBoolean("stub_mode", false) ?: false
+
+            Log.d(TAG, "Model manifest loaded - Version: $version, Type: $modelType, Stub: $stubMode")
             
         } catch (e: Exception) {
             Log.w(TAG, "Could not load model manifest, using defaults", e)
@@ -160,6 +176,11 @@ class TwoStageDetector(private val context: Context, initializeOnCreate: Boolean
             return emptyList()
         }
         
+        if (stubMode) {
+            Log.w(TAG, "TwoStageDetector is running in stub mode; multi-coupon detections are disabled.")
+            return emptyList()
+        }
+
         val stage1Interpreter = this.stage1Interpreter
         val stage2Interpreter = this.stage2Interpreter
         

--- a/docs/multi_coupon_model_delivery.md
+++ b/docs/multi_coupon_model_delivery.md
@@ -1,0 +1,48 @@
+# Multi-Coupon Model Delivery
+
+The trained multi-coupon detector artifacts are significantly larger than the
+rest of the Android project and are distributed outside of the public Git
+repository. The Android app now ships with placeholder assets under
+`app/src/main/assets/models/multi_coupon/` so the build can proceed without
+TensorFlow Lite errors. Replace the placeholders with the production binaries
+before shipping.
+
+## Artifact Overview
+
+| Stage | File name | Description |
+|-------|-----------|-------------|
+| Stage 1 | `stage1_coupon_detector.tflite` | YOLOv8-based coupon instance detector. |
+| Stage 2 | `stage2_field_detector.tflite` | YOLOv8-based coupon field detector. |
+| Manifest | `manifest.json` | Configuration consumed by `TwoStageDetector`. |
+
+## How to Obtain the Trained Models
+
+1. **Internal artifact store** – Download the latest `multi_coupon_models_v*.zip`
+   bundle from the release portal and extract it into
+   `app/src/main/assets/models/multi_coupon/`.
+2. **Re-train locally** – Run the end-to-end helper script, which will generate
+   demo data, train both stages, and copy the resulting TFLite models into the
+   Android assets directory:
+
+   ```bash
+   ./complete_multi_coupon_pipeline.sh
+   ```
+
+   Ensure the host has the Python dependencies listed in
+   `requirements.txt` installed (notably `ultralytics`, `opencv-python`, and
+   `onnxruntime`).
+
+After either option the placeholder `.tflite` files can be deleted or
+overwritten. The manifest shipped in the repository already lists the filenames
+expected by `TwoStageDetector`.
+
+## Verification
+
+After the trained artifacts are in place run:
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+and watch `adb logcat` while launching the scanner. The `TwoStageDetector`
+initialization log should confirm the models were loaded without warnings.


### PR DESCRIPTION
## Summary
- add a multi_coupon assets directory with manifest and placeholder model binaries
- update TwoStageDetector to recognise stub manifests and skip TFLite initialisation when placeholders are present
- document how to obtain and install the trained multi-coupon detector package outside of version control and allow assets/models to be tracked

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ee8446cc8328b575848cf39ef0dd