### PR TITLE
Handle dash separators before coupon codes

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/OCRHelper.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/OCRHelper.kt
@@ -27,7 +27,7 @@ class OCRHelper {
         
         // Improved regex patterns for extracting coupon information
         private val STORE_PATTERN = Pattern.compile("(?i)(store|shop|merchant|retailer|brand|company|from)\\s*:?\\s*([A-Za-z0-9\\s&.'-]+)")
-        private val CODE_PATTERN = Pattern.compile("(?i)(code|coupon|promo|voucher|redeem|use)\\s*:?\\s*([A-Za-z0-9\\-_]+)")
+        private val CODE_PATTERN = Pattern.compile("(?i)(code|coupon|promo|voucher|redeem|use)\\s*[-–—:]?\\s*([A-Za-z0-9\\-_]+)")
         private val AMOUNT_PATTERN = Pattern.compile("(?i)(\\$?\\d+(\\.\\d{1,2})?|\\d+(\\.\\d{1,2})?)\\s*%?\\s*(off|cashback|discount|reward|save)")
         private val EXPIRY_PATTERN = Pattern.compile("(?i)(exp|expires|expiry|valid until|valid through|use by)\\s*:?\\s*(\\d{1,2}[/-]\\d{1,2}[/-]\\d{2,4})")
         private val DESCRIPTION_PATTERN = Pattern.compile("(?i)(description|details|offer|deal|get|save)\\s*:?\\s*([^\\n\\r.]+)")

--- a/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
@@ -589,7 +589,7 @@ class TextExtractor {
      */
     fun extractRedeemCode(text: String): String? {
         // First check for code: pattern (most common)
-        val codePattern = Pattern.compile("(?i)code:?\\s*([A-Z0-9]{5,})")
+        val codePattern = Pattern.compile("(?i)code\\s*[-–—:]?\\s*([A-Z0-9]{5,})")
         val codeMatcher = codePattern.matcher(text)
         if (codeMatcher.find()) {
             val code = codeMatcher.group(1)
@@ -600,7 +600,7 @@ class TextExtractor {
         }
 
         // Look for "code" pattern without colon (common in Myntra coupons)
-        val codeWithoutColonPattern = Pattern.compile("(?i)\\bcode\\b\\s*([A-Z0-9]{5,})")
+        val codeWithoutColonPattern = Pattern.compile("(?i)\\bcode\\b\\s*[-–—:]?\\s*([A-Z0-9]{5,})")
         val codeWithoutColonMatcher = codeWithoutColonPattern.matcher(text)
         if (codeWithoutColonMatcher.find()) {
             val code = codeWithoutColonMatcher.group(1)

--- a/app/src/test/java/com/example/coupontracker/util/TextExtractorTest.kt
+++ b/app/src/test/java/com/example/coupontracker/util/TextExtractorTest.kt
@@ -172,6 +172,20 @@ class TextExtractorTest {
 
         assertEquals("Q2SQ74JS7CK", redeemCode)
     }
+
+    @Test
+    fun `extractRedeemCode handles dash separators`() {
+        val variants = listOf(
+            "Use code- MISSEDYOU",
+            "Use code– MISSEDYOU",
+            "Use code—MISSEDYOU"
+        )
+
+        variants.forEach { sample ->
+            val redeemCode = extractor.extractRedeemCode(sample)
+            assertEquals("MISSEDYOU", redeemCode)
+        }
+    }
     
     @Test
     fun `test extractCashbackAmount from IXIGO coupon`() {


### PR DESCRIPTION
## Summary
- allow OCR code extraction to accept hyphen and dash separators before codes
- update TextExtractor regexes to support dash characters between "code" and the value
- add regression coverage for dash-separated code prompts

## Testing
- ./gradlew test --tests com.example.coupontracker.util.TextExtractorTest *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ff0ac708832885df370267a9697d