### PR TITLE
Allow RegionBasedExtractor to accept alphabetic coupon codes

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/RegionBasedExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/RegionBasedExtractor.kt
@@ -186,16 +186,21 @@ class RegionBasedExtractor(
                     while (matcher.find()) {
                         val potentialCode = matcher.group(1)
 
-                        // Validate code format - must have both letters and numbers
-                        // and not be a common word or too short
-                        if (potentialCode != null &&
-                            potentialCode.length >= 5 &&
-                            potentialCode.matches(".*[A-Za-z].*".toRegex()) &&
-                            potentialCode.matches(".*[0-9].*".toRegex()) &&
-                            !isCommonWord(potentialCode)) {
+                        // Validate code format - require letters, allow optional digits,
+                        // ensure sufficient length, and skip common instruction words
+                        if (potentialCode != null) {
+                            val hasLetter = potentialCode.any { it.isLetter() }
+                            val hasDigit = potentialCode.any { it.isDigit() }
+                            val isAlphabetic = potentialCode.all { it.isLetter() }
 
-                            Log.d(TAG, "Found standalone coupon code: $potentialCode")
-                            return potentialCode.uppercase()
+                            if (potentialCode.length >= 5 &&
+                                hasLetter &&
+                                (hasDigit || isAlphabetic) &&
+                                !isCommonWord(potentialCode)) {
+
+                                Log.d(TAG, "Found standalone coupon code: $potentialCode")
+                                return potentialCode.uppercase()
+                            }
                         }
                     }
                 }
@@ -502,7 +507,8 @@ class RegionBasedExtractor(
         val commonWords = setOf(
             "the", "and", "for", "with", "off", "use", "get", "code", "coupon",
             "offer", "valid", "till", "from", "upto", "free", "save", "discount",
-            "cashback", "expires", "days", "hours", "flat", "extra", "today"
+            "cashback", "expires", "days", "hours", "flat", "extra", "today",
+            "redeem", "apply", "terms", "conditions"
         )
         return commonWords.contains(word.lowercase())
     }

--- a/app/src/test/java/com/example/coupontracker/util/RegionBasedExtractorTest.kt
+++ b/app/src/test/java/com/example/coupontracker/util/RegionBasedExtractorTest.kt
@@ -1,0 +1,31 @@
+package com.example.coupontracker.util
+
+import android.graphics.Bitmap
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RegionBasedExtractorTest {
+
+    private val extractor = RegionBasedExtractor(TextExtractor())
+
+    @Test
+    fun `extractRedeemCode accepts alphabetic coupon codes`() = runBlocking {
+        val bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888)
+        val rawText = """
+            Special Deals
+            Don't miss out on exclusive savings
+            MISSEDYOU
+            Redeem today
+        """.trimIndent()
+
+        val couponInfo = extractor.extractCouponInfo(bitmap, rawText)
+
+        assertNotNull("Expected redeem code to be extracted", couponInfo.redeemCode)
+        assertEquals("MISSEDYOU", couponInfo.redeemCode)
+    }
+}


### PR DESCRIPTION
## Summary
- relax RegionBasedExtractor coupon code validation to accept alphabetic codes while filtering more instruction keywords
- add a Robolectric regression test that verifies the MISSEDYOU code is surfaced

## Testing
- ./gradlew test --tests com.example.coupontracker.util.RegionBasedExtractorTest *(fails: Android SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d90074f8c08328bd98e04bce313e6f