### PR TITLE
Refine rupee glyph normalization for OCR cleanup

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -42,7 +42,8 @@ class LocalLlmOcrService(
         private const val SUPPORTED_MODEL_VERSION = "v2.5-q4-android"
 
         private val RUPEE_VARIANT_PATTERN = Regex(
-            pattern = """(?i)(^|\s+|[^\w₹])(?:₹|rs\.?|t)[\s:=-]*([+-]?\d[\d,]*(?:\.\d+)?)"""
+            pattern = """(^|\s+|[^\w₹])((?:₹|₨|૱|रु|रू|rs\.?))[\s:=-]*([+-]?\d[\d,]*(?:\.\d+)?)""",
+            options = setOf(RegexOption.IGNORE_CASE)
         )
 
         private val STORE_PREFIX_EXTRACTION_PATTERN = Regex(
@@ -105,7 +106,22 @@ class LocalLlmOcrService(
 
             return RUPEE_VARIANT_PATTERN.replace(text) { matchResult ->
                 val leading = matchResult.groupValues[1]
-                val amount = matchResult.groupValues[2]
+                val marker = matchResult.groupValues[2]
+                val amount = matchResult.groupValues[3]
+
+                val markerStart = matchResult.range.first + leading.length
+                val markerEnd = markerStart + marker.length
+                val precedingChar = text.getOrNull(markerStart - 1)
+                val followingChar = text.getOrNull(markerEnd)
+
+                if (marker.any { it.isLetter() }) {
+                    val precedingIsLetter = precedingChar?.isLetter() == true
+                    val followingIsLetter = followingChar?.isLetter() == true
+                    if (precedingIsLetter || followingIsLetter) {
+                        return@replace matchResult.value
+                    }
+                }
+
                 val cleanedAmount = amount.replaceFirst(Regex("^([+-]?)0+(?=\\d)"), "$1")
                 leading + "₹" + cleanedAmount
             }

--- a/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/LocalLlmOcrServiceTest.kt
@@ -254,12 +254,30 @@ class LocalLlmOcrServiceTest {
     }
 
     @Test
-    fun `cleanDescription normalizes rupee-like glyphs`() {
-        val rawDescription = "LIFETIME CASHBACK T568"
+    fun `cleanDescription leaves plain amounts unchanged`() {
+        val rawDescription = "Flat 100 off"
 
         val cleaned = LocalLlmOcrService.cleanDescription(rawDescription)
 
-        assertEquals("Lifetime cashback ₹568", cleaned)
+        assertEquals("Flat 100 off", cleaned)
+    }
+
+    @Test
+    fun `cleanDescription normalizes textual rupee markers`() {
+        val rawDescription = "Get Rs 100 cashback"
+
+        val cleaned = LocalLlmOcrService.cleanDescription(rawDescription)
+
+        assertEquals("Get ₹100 cashback", cleaned)
+    }
+
+    @Test
+    fun `cleanDescription normalizes rupee glyph variants`() {
+        val rawDescription = "Save ₨ 250 today"
+
+        val cleaned = LocalLlmOcrService.cleanDescription(rawDescription)
+
+        assertEquals("Save ₹250 today", cleaned)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- tighten rupee detection to known glyph variants and guard against alphabetic word false positives
- ensure cleanDescription only normalizes genuine rupee markers and leaves regular words untouched
- add targeted unit tests covering plain text, Rs, and rupee glyph variants

## Testing
- ./gradlew test --tests "com.example.coupontracker.util.LocalLlmOcrServiceTest" *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d922f1951c83289f157a5562963589