### PR TITLE
Normalize coupon expiry fallback handling

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/components/BrandComponents.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/components/BrandComponents.kt
@@ -534,9 +534,11 @@ object DateFormatter {
     private val shortDateFormat = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
     private val monthDayFormat = SimpleDateFormat("MMM dd", Locale.getDefault())
 
-    fun formatFull(date: Date?): String = date?.let(fullDateFormat::format) ?: "No expiry provided"
-    fun formatShort(date: Date?): String = date?.let(shortDateFormat::format) ?: "No expiry provided"
-    fun formatMonthDay(date: Date?): String = date?.let(monthDayFormat::format) ?: "No expiry provided"
+    private const val UNKNOWN_EXPIRY_TEXT = "Unknown"
+
+    fun formatFull(date: Date?): String = date?.let(fullDateFormat::format) ?: UNKNOWN_EXPIRY_TEXT
+    fun formatShort(date: Date?): String = date?.let(shortDateFormat::format) ?: UNKNOWN_EXPIRY_TEXT
+    fun formatMonthDay(date: Date?): String = date?.let(monthDayFormat::format) ?: UNKNOWN_EXPIRY_TEXT
 
     fun getExpiryStatus(expiryDate: Date?): StatusType {
         val date = expiryDate ?: return StatusType.INFO
@@ -551,7 +553,7 @@ object DateFormatter {
     }
 
     fun getExpiryText(expiryDate: Date?): String {
-        val date = expiryDate ?: return "No expiry provided"
+        val date = expiryDate ?: return UNKNOWN_EXPIRY_TEXT
         val now = Calendar.getInstance().time
         val daysUntilExpiry = ((date.time - now.time) / (1000 * 60 * 60 * 24)).toInt()
 

--- a/app/src/main/kotlin/com/example/coupontracker/util/CouponInputManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/CouponInputManager.kt
@@ -34,8 +34,36 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.Executors
+import kotlin.math.abs
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+
+internal const val EXPIRY_FALLBACK_TOLERANCE_MS = 5_000L
+
+internal fun normalizeExpiryDate(extractedExpiry: Date?, captureTimestamp: Date?): Date? {
+    if (extractedExpiry == null) {
+        return null
+    }
+
+    captureTimestamp?.let { timestamp ->
+        if (areWithinTolerance(extractedExpiry, timestamp)) {
+            return null
+        }
+    }
+
+    if (captureTimestamp == null) {
+        val now = Date()
+        if (areWithinTolerance(extractedExpiry, now)) {
+            return null
+        }
+    }
+
+    return extractedExpiry
+}
+
+private fun areWithinTolerance(first: Date, second: Date): Boolean {
+    return abs(first.time - second.time) <= EXPIRY_FALLBACK_TOLERANCE_MS
+}
 
 /**
  * Manager class for handling various coupon input methods
@@ -150,13 +178,17 @@ class CouponInputManager(private val context: Context) {
 
                 // Process with OCR using capture timestamp
                 val couponInfo = imageProcessor.processImage(bitmap, captureTimestamp)
+                val normalizedExpiry = normalizeExpiryDate(couponInfo.expiryDate, captureTimestamp)
+                if (couponInfo.expiryDate != null && normalizedExpiry == null) {
+                    Log.d(TAG, "Discarding fallback expiry date; treating as unknown")
+                }
 
                 // Convert CouponInfo to Coupon
                 return@withContext Coupon(
                     id = 0,
                     storeName = couponInfo.storeName.ifBlank { "Unknown Store" },
                     description = couponInfo.description.ifBlank { "No description" },
-                    expiryDate = couponInfo.expiryDate,
+                    expiryDate = normalizedExpiry,
                     cashbackAmount = couponInfo.cashbackAmount ?: 0.0,
                     redeemCode = couponInfo.redeemCode,
                     imageUri = null, // We'll set this later in the ViewModel

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="description">Description</string>
     <string name="cashback_amount">Cashback Amount</string>
     <string name="expiry_date">Expiry Date</string>
-    <string name="no_expiry_provided">No expiry provided</string>
+    <string name="no_expiry_provided">Unknown</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="category">Category</string>
     <string name="save">Save</string>

--- a/app/src/test/kotlin/com/example/coupontracker/util/CouponInputManagerTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/CouponInputManagerTest.kt
@@ -1,0 +1,19 @@
+package com.example.coupontracker.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.Date
+
+class CouponInputManagerTest {
+
+    @Test
+    fun captureTimestampFallback_isTreatedAsUnknown() {
+        val captureTimestamp = Date()
+
+        val normalized = normalizeExpiryDate(Date(captureTimestamp.time), captureTimestamp)
+
+        assertNull("Fallback expiry should be discarded", normalized)
+        assertEquals("Unknown", DateFormatter.getExpiryText(normalized))
+    }
+}


### PR DESCRIPTION
## Summary
- drop fallback expiry timestamps in `CouponInputManager` so coupons without explicit expiries stay null
- show "Unknown" for missing expiries across UI formatting helpers
- add a regression unit test to guard against capture-timestamp expiries resurfacing

## Testing
- ./gradlew test *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d92475a9ac8328894d56206c94d9cd