### PR TITLE
Improve store name extraction heuristics

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
@@ -144,16 +144,65 @@ class TextExtractor {
             return brand
         }
 
-        // Look for all caps words that are likely to be store names
-        val allCapsPattern = Pattern.compile("\\b([A-Z]{3,}\\b)")
-        val matcher = allCapsPattern.matcher(text)
+        val lowerText = text.lowercase(Locale.getDefault())
+        val wordFrequency = mutableMapOf<String, Int>()
+        val wordMatcher = Pattern.compile("\\b([A-Za-z][A-Za-z'\\-]*)\\b").matcher(text)
+        while (wordMatcher.find()) {
+            val word = wordMatcher.group(1)?.lowercase(Locale.getDefault()) ?: continue
+            wordFrequency[word] = wordFrequency.getOrDefault(word, 0) + 1
+        }
 
-        while (matcher.find()) {
-            val potentialName = matcher.group(1)
-            // Skip common words that might be in all caps but aren't store names
-            if (potentialName != null && !COMMON_WORDS.contains(potentialName.lowercase())) {
-                Log.d(TAG, "Found store name from all caps: $potentialName")
-                return potentialName
+        val candidateScores = mutableMapOf<String, Double>()
+        val candidateOriginal = mutableMapOf<String, String>()
+        val lines = text.lines()
+
+        fun addCandidate(raw: String?, isTitleCase: Boolean, lineIndex: Int) {
+            val candidate = raw?.trim()?.takeIf { it.length >= 3 } ?: return
+            val normalized = candidate.lowercase(Locale.getDefault())
+            if (COMMON_WORDS.contains(normalized)) {
+                return
+            }
+
+            val baseScore = if (isTitleCase) 4.0 else 2.0
+            val frequency = wordFrequency[normalized] ?: 1
+            val frequencyScore = if (frequency > 1) frequency * 2.5 else frequency.toDouble()
+            val lineBonus = (lines.size - lineIndex).coerceAtLeast(1)
+            val firstIndex = lowerText.indexOf(normalized)
+            val positionScore = if (firstIndex >= 0 && text.isNotEmpty()) {
+                (text.length - firstIndex).toDouble() / text.length.toDouble() * 3.0
+            } else {
+                0.0
+            }
+
+            val totalScore = baseScore + frequencyScore + lineBonus + positionScore
+            val currentScore = candidateScores[normalized]
+            if (currentScore == null || totalScore > currentScore) {
+                candidateScores[normalized] = totalScore
+                candidateOriginal[normalized] = candidate
+            }
+        }
+
+        val titlePattern = Pattern.compile("\\b([A-Z][a-z]{2,})\\b")
+        val allCapsPattern = Pattern.compile("\\b([A-Z]{3,})\\b")
+
+        lines.forEachIndexed { index, line ->
+            val titleMatcher = titlePattern.matcher(line)
+            while (titleMatcher.find()) {
+                addCandidate(titleMatcher.group(1), true, index)
+            }
+
+            val capsMatcher = allCapsPattern.matcher(line)
+            while (capsMatcher.find()) {
+                addCandidate(capsMatcher.group(1), false, index)
+            }
+        }
+
+        if (candidateScores.isNotEmpty()) {
+            val bestKey = candidateScores.maxByOrNull { it.value }!!.key
+            val bestCandidate = candidateOriginal[bestKey]
+            if (bestCandidate != null) {
+                Log.d(TAG, "Selected store name candidate: $bestCandidate")
+                return bestCandidate
             }
         }
 
@@ -919,7 +968,8 @@ class TextExtractor {
     companion object {
         private val COMMON_WORDS = setOf(
             "the", "and", "for", "with", "off", "use", "get", "code", "coupon",
-            "offer", "valid", "till", "from", "upto", "free", "save", "discount"
+            "offer", "valid", "till", "from", "upto", "free", "save", "discount",
+            "multi", "product", "products", "kit", "combo", "pack", "value", "special"
         )
 
         private val CATEGORIES = listOf(

--- a/app/src/test/java/com/example/coupontracker/util/TextExtractorTest.kt
+++ b/app/src/test/java/com/example/coupontracker/util/TextExtractorTest.kt
@@ -195,10 +195,23 @@ class TextExtractorTest {
             Code: SWGGS01BO719GFHS
             Claim Now
         """.trimIndent()
-        
+
         val cashbackAmount = extractor.extractCashbackAmount(text)
         assertNotNull("Cashback amount should not be null", cashbackAmount)
         assertEquals(30.0, cashbackAmount!!, 0.01)
+    }
+
+    @Test
+    fun `extractStoreName prefers repeated proper nouns over generic all caps words`() {
+        val text = """
+            Minimalist Skincare
+            Minimalist… MULTI PRODUCT KIT
+            Save 10% on your first order
+        """.trimIndent()
+
+        val storeName = extractor.extractStoreName(text)
+
+        assertEquals("Minimalist", storeName)
     }
     
     @Test


### PR DESCRIPTION
## Summary
- rank potential store names in `TextExtractor.extractStoreName` based on frequency, position, and formatting rather than returning the first all-caps match
- extend the common-word filter to exclude generic adjectives so they no longer surface as store names
- add a regression test that ensures "Minimalist" is selected when OCR text contains "Minimalist… MULTI PRODUCT KIT"

## Testing
- `./gradlew test --tests com.example.coupontracker.util.TextExtractorTest` *(fails: Android SDK is not configured in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d926857bdc83289618bef5e45419f8