### PR TITLE
Ensure scanner UI state collection is lifecycle-aware

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/fragment/ScannerFragment.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/fragment/ScannerFragment.kt
@@ -20,7 +20,9 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.example.coupontracker.R
 import com.example.coupontracker.databinding.FragmentScannerBinding
@@ -144,13 +146,14 @@ class ScannerFragment : Fragment() {
         }
         
         // Observe processing state
-        lifecycleScope.launch {
-            viewModel.uiState.collect { state ->
-                when (state) {
-                    is ScannerUiState.Initial -> {
-                        binding.progressBar.visibility = View.GONE
-                        binding.captureButton.isEnabled = true
-                    }
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    when (state) {
+                        is ScannerUiState.Initial -> {
+                            binding.progressBar.visibility = View.GONE
+                            binding.captureButton.isEnabled = true
+                        }
                     is ScannerUiState.Scanning -> {
                         binding.progressBar.visibility = View.VISIBLE
                         binding.captureButton.isEnabled = false


### PR DESCRIPTION
## Summary
- observe `ScannerViewModel` state from `ScannerFragment` using `repeatOnLifecycle` so the capture controls reset correctly after multi-coupon selection returns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d92a667d948328be639fc8ef015d7c