### PR TITLE
Add description sanitizer and noisy OCR tests

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
@@ -240,38 +240,38 @@ class EnhancedOCRHelper {
             // For Myntra, try to find their specific voucher description format
             findMatch(MYNTRA_DESCRIPTION_PATTERN, text)?.let {
                 val description = it.trim() + " up to ₹" + (result["amount"] ?: "").replace("₹", "")
-                result["description"] = description
+                result["description"] = sanitizeDescription(description)
                 descriptionFound = true
                 Log.d(TAG, "Found Myntra description: $description")
             }
-            
+
             // If that fails, look for a phrase containing "voucher" and "up to"
             if (!descriptionFound) {
                 val myntraDescRegex = "(?:you won a voucher|up to ₹\\d+)(.{5,30})".toRegex(RegexOption.IGNORE_CASE)
                 myntraDescRegex.find(text)?.let {
                     val desc = it.groupValues[0].trim()
                     if (desc.isNotBlank()) {
-                        result["description"] = desc
+                        result["description"] = sanitizeDescription(desc)
                         descriptionFound = true
                         Log.d(TAG, "Found Myntra description with alt pattern: $desc")
                     }
                 }
             }
         }
-        
+
         // If no description found yet, try standard pattern
         if (!descriptionFound) {
             findMatch(DESCRIPTION_PATTERN, text)?.let {
-                result["description"] = it.trim()
+                result["description"] = sanitizeDescription(it.trim())
                 descriptionFound = true
                 Log.d(TAG, "Found standard description: ${it.trim()}")
             }
         }
-        
+
         // If we couldn't extract any information, provide some defaults
         if (result.isEmpty()) {
             result["storeName"] = if (isMyntraCoupon) "Myntra" else "Unknown Store"
-            result["description"] = "Scanned coupon"
+            result["description"] = sanitizeDescription("Scanned coupon")
         }
         
         // Set default amount if not found
@@ -299,6 +299,53 @@ class EnhancedOCRHelper {
             matcher.group(2)
         } else {
             null
+        }
+    }
+
+    private fun sanitizeDescription(raw: String): String {
+        val tokens = raw.split(Regex("\\s+")).mapNotNull { token ->
+            val trimmed = token.trim()
+            if (trimmed.isEmpty()) {
+                null
+            } else {
+                trimmed
+            }
+        }
+
+        if (tokens.isEmpty()) {
+            return raw.trim()
+        }
+
+        val vowels = setOf('a', 'e', 'i', 'o', 'u')
+        val cleanedTokens = mutableListOf<String>()
+        var previousNormalized: String? = null
+
+        tokens.forEach { token ->
+            val strippedToken = token.trim { !it.isLetterOrDigit() && it != '.' && it != '%' && it != '₹' && it != '-' }
+            if (strippedToken.isEmpty()) {
+                return@forEach
+            }
+
+            val hasLetters = strippedToken.any { it.isLetter() }
+            val hasVowel = strippedToken.any { vowels.contains(it.lowercaseChar()) }
+
+            if (hasLetters && !hasVowel) {
+                return@forEach
+            }
+
+            val normalized = strippedToken.lowercase()
+            if (previousNormalized == normalized) {
+                return@forEach
+            }
+
+            cleanedTokens.add(strippedToken)
+            previousNormalized = normalized
+        }
+
+        return if (cleanedTokens.isEmpty()) {
+            raw.trim()
+        } else {
+            cleanedTokens.joinToString(" ")
         }
     }
 

--- a/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
@@ -303,25 +303,20 @@ class EnhancedOCRHelper {
     }
 
     private fun sanitizeDescription(raw: String): String {
-        val tokens = raw.split(Regex("\\s+")).mapNotNull { token ->
-            val trimmed = token.trim()
-            if (trimmed.isEmpty()) {
-                null
-            } else {
-                trimmed
-            }
-        }
-
-        if (tokens.isEmpty()) {
-            return raw.trim()
-        }
-
         val vowels = setOf('a', 'e', 'i', 'o', 'u')
         val cleanedTokens = mutableListOf<String>()
-        var previousNormalized: String? = null
+        var previousKey: String? = null
 
-        tokens.forEach { token ->
-            val strippedToken = token.trim { !it.isLetterOrDigit() && it != '.' && it != '%' && it != '₹' && it != '-' }
+        raw.split(Regex("\\s+")).forEach { token ->
+            val trimmed = token.trim()
+            if (trimmed.isEmpty()) {
+                return@forEach
+            }
+
+            val strippedToken = trimmed.trim { character ->
+                !character.isLetterOrDigit() && character != '.' && character != '%' && character != '₹' && character != '-'
+            }
+
             if (strippedToken.isEmpty()) {
                 return@forEach
             }
@@ -333,20 +328,20 @@ class EnhancedOCRHelper {
                 return@forEach
             }
 
-            val normalized = strippedToken.lowercase()
-            if (previousNormalized == normalized) {
+            val comparisonKey = strippedToken.lowercase().trim { !it.isLetterOrDigit() }
+            if (comparisonKey.isEmpty()) {
+                return@forEach
+            }
+
+            if (previousKey == comparisonKey) {
                 return@forEach
             }
 
             cleanedTokens.add(strippedToken)
-            previousNormalized = normalized
+            previousKey = comparisonKey
         }
 
-        return if (cleanedTokens.isEmpty()) {
-            raw.trim()
-        } else {
-            cleanedTokens.joinToString(" ")
-        }
+        return cleanedTokens.joinToString(" ").trim()
     }
 
     internal fun normalizeCouponCode(rawCode: String): String {

--- a/app/src/test/java/com/example/coupontracker/util/EnhancedOCRHelperTest.kt
+++ b/app/src/test/java/com/example/coupontracker/util/EnhancedOCRHelperTest.kt
@@ -13,4 +13,16 @@ class EnhancedOCRHelperTest {
         val normalized = helper.normalizeCouponCode(rawCode)
         assertEquals("MNPRRK10OUAPR255QYSG7A", normalized)
     }
+
+    @Test
+    fun extractCouponInfo_sanitizesNoisyDescription() {
+        val noisyText = """
+            STORE: Be Minimalist
+            DESCRIPTION: On   On Radiance   Kit Kit from beminimalist.co qwrty ZZZZZ
+        """.trimIndent()
+
+        val info = helper.extractCouponInfo(noisyText)
+
+        assertEquals("On Radiance Kit from beminimalist.co", info["description"])
+    }
 }

--- a/app/src/test/java/com/example/coupontracker/util/EnhancedOCRHelperTest.kt
+++ b/app/src/test/java/com/example/coupontracker/util/EnhancedOCRHelperTest.kt
@@ -25,4 +25,15 @@ class EnhancedOCRHelperTest {
 
         assertEquals("On Radiance Kit from beminimalist.co", info["description"])
     }
+
+    @Test
+    fun extractCouponInfo_handlesPunctuationWhenCollapsingDuplicates() {
+        val noisyText = """
+            DESCRIPTION: Save SAVE!!! on kit, kit -- from-store 123
+        """.trimIndent()
+
+        val info = helper.extractCouponInfo(noisyText)
+
+        assertEquals("Save on kit from-store 123", info["description"])
+    }
 }


### PR DESCRIPTION
## Summary
- sanitize extracted coupon descriptions to collapse duplicates, drop gibberish tokens, and normalize whitespace
- ensure Myntra-specific, pattern-based, and default descriptions use the sanitizer
- add a unit test covering noisy OCR input that now produces a clean description

## Testing
- `./gradlew test` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9390e0b58832896c600fdad19e5c0