### PR TITLE
Allow demo mode to override stub mode

### DIFF
--- a/app/src/main/assets/models/multi_coupon/manifest.json
+++ b/app/src/main/assets/models/multi_coupon/manifest.json
@@ -25,7 +25,7 @@
   ],
   "confidence_threshold": 0.5,
   "iou_threshold": 0.4,
-  "stub_mode": false,
+  "stub_mode": true,
   "stub_notes": "Demo mode: Returns synthetic multi-coupon detections for testing UI",
   "demo_mode": true
 }

--- a/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
@@ -204,14 +204,21 @@ class TwoStageDetector(private val context: Context, initializeOnCreate: Boolean
             return emptyList()
         }
         
+        if (demoMode) {
+            if (stubMode) {
+                Log.i(
+                    TAG,
+                    "TwoStageDetector is running in demo mode with stub assets; returning synthetic detections."
+                )
+            } else {
+                Log.i(TAG, "TwoStageDetector is running in demo mode; returning synthetic detections.")
+            }
+            return createDemoDetections(bitmap)
+        }
+
         if (stubMode) {
             Log.w(TAG, "TwoStageDetector is running in stub mode; multi-coupon detections are disabled.")
             return emptyList()
-        }
-        
-        if (demoMode) {
-            Log.i(TAG, "TwoStageDetector is running in demo mode; returning synthetic detections.")
-            return createDemoDetections(bitmap)
         }
 
         val stage1Interpreter = this.stage1Interpreter


### PR DESCRIPTION
## Summary
- ensure demo detections run even when stub assets are marked in the manifest
- update the manifest stub flag to reflect placeholder assets while still enabling demo detections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9393b29f483289566785756929271