### PR TITLE
Adjust description sanitization for alphanumeric tokens

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
@@ -291,6 +291,43 @@ class EnhancedOCRHelper {
     }
     
     /**
+     * Sanitize a raw description by removing noisy tokens while preserving
+     * meaningful alphanumeric strings.
+     */
+    internal fun sanitizeDescription(description: String): String {
+        if (description.isBlank()) {
+            return description.trim()
+        }
+
+        val sanitizedSeparators = description
+            .replace("\n", " ")
+            .replace("\r", " ")
+            .replace("\t", " ")
+
+        val tokens = sanitizedSeparators
+            .split(Regex("\\s+"))
+            .filter { it.isNotBlank() }
+
+        if (tokens.isEmpty()) {
+            return ""
+        }
+
+        val vowels = setOf('a', 'e', 'i', 'o', 'u')
+
+        val filteredTokens = tokens.filter { token ->
+            val lettersOnly = token.all { it.isLetter() }
+            if (!lettersOnly) {
+                true
+            } else {
+                val hasVowel = token.any { it.lowercaseChar() in vowels }
+                hasVowel || token.length <= 2
+            }
+        }
+
+        return filteredTokens.joinToString(" ")
+    }
+
+    /**
      * Count words in the recognized text - useful for assessing OCR quality
      */
     fun countWords(text: String): Int {

--- a/app/src/test/java/com/example/coupontracker/util/EnhancedOCRHelperTest.kt
+++ b/app/src/test/java/com/example/coupontracker/util/EnhancedOCRHelperTest.kt
@@ -1,6 +1,7 @@
 package com.example.coupontracker.util
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class EnhancedOCRHelperTest {
@@ -28,5 +29,15 @@ class EnhancedOCRHelperTest {
         val result = helper.extractCouponInfo(text)
 
         assertEquals("₹100", result["amount"])
+    }
+
+    @Test
+    fun sanitizeDescription_preservesMixedAlphanumericTokens() {
+        val description = "New arrivals: B12 energy shots with SPF50 protection"
+
+        val sanitized = helper.sanitizeDescription(description)
+
+        assertTrue("Expected B12 to remain in sanitized description", sanitized.contains("B12"))
+        assertTrue("Expected SPF50 to remain in sanitized description", sanitized.contains("SPF50"))
     }
 }


### PR DESCRIPTION
## Summary
- add description sanitization helper that skips vowel filtering for mixed alphanumeric tokens
- cover alphanumeric token handling with a new EnhancedOCRHelper unit test

## Testing
- ./gradlew test *(fails: Android SDK not configured in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9605ec9588328b8546888e49b0a81