### PR TITLE
Handle lowercase brand coupons with decimal discounts

### DIFF
--- a/enhanced_field_extractor.py
+++ b/enhanced_field_extractor.py
@@ -9,11 +9,85 @@ and context-aware algorithms for better coupon information extraction.
 import re
 import json
 import logging
-import numpy as np
-from datetime import datetime, timedelta
+from datetime import datetime
+from difflib import SequenceMatcher
 from typing import Dict, List, Tuple, Optional
-import dateutil.parser as date_parser
-from fuzzywuzzy import fuzz, process
+
+
+MONTH_NORMALIZATION = {
+    'jan.': 'Jan',
+    'feb.': 'Feb',
+    'mar.': 'Mar',
+    'apr.': 'Apr',
+    'jun.': 'Jun',
+    'jul.': 'Jul',
+    'aug.': 'Aug',
+    'sep.': 'Sep',
+    'sep': 'Sep',
+    'sept': 'Sep',
+    'sept.': 'Sep',
+    'oct.': 'Oct',
+    'nov.': 'Nov',
+    'dec.': 'Dec',
+}
+
+
+EXPIRY_DATE_FORMATS = [
+    '%d/%m/%Y',
+    '%d/%m/%y',
+    '%d-%m-%Y',
+    '%d-%m-%y',
+    '%Y-%m-%d',
+    '%d %m %Y',
+    '%d %b %Y',
+    '%d %b, %Y',
+    '%d %B %Y',
+    '%d %B, %Y',
+    '%d %b %Y %H:%M',
+    '%d %b, %Y %H:%M',
+    '%d %B %Y %H:%M',
+    '%d %B, %Y %H:%M',
+    '%d %b %Y, %H:%M',
+    '%d %b, %Y, %H:%M',
+    '%d %B %Y, %H:%M',
+    '%d %B, %Y, %H:%M',
+    '%d %b %Y %I:%M %p',
+    '%d %b, %Y %I:%M %p',
+    '%d %B %Y %I:%M %p',
+    '%d %B, %Y %I:%M %p',
+    '%d %b %Y, %I:%M %p',
+    '%d %b, %Y, %I:%M %p',
+    '%d %B %Y, %I:%M %p',
+    '%d %B, %Y, %I:%M %p',
+]
+
+
+def _partial_ratio(needle: str, haystack: str) -> int:
+    """Lightweight partial ratio implementation without external dependencies."""
+
+    if not needle or not haystack:
+        return 0
+
+    needle = needle.lower()
+    haystack = haystack.lower()
+
+    if needle in haystack:
+        return 100
+
+    matcher = SequenceMatcher()
+    matcher.set_seq2(needle)
+
+    best = 0.0
+    window = len(needle)
+
+    for start in range(0, len(haystack) - window + 1):
+        segment = haystack[start:start + window]
+        matcher.set_seq1(segment)
+        best = max(best, matcher.ratio())
+        if best >= 0.99:
+            break
+
+    return int(round(best * 100))
 
 # Configure logging
 logging.basicConfig(
@@ -160,7 +234,7 @@ class EnhancedCouponFieldExtractor:
         
         # Calculate overall confidence
         confidences = [field.get('confidence', 0) for field in fields.values() if isinstance(field, dict)]
-        overall_confidence = np.mean(confidences) if confidences else 0.0
+        overall_confidence = sum(confidences) / len(confidences) if confidences else 0.0
         
         fields['overall_confidence'] = overall_confidence
         fields['extraction_metadata'] = {
@@ -221,7 +295,7 @@ class EnhancedCouponFieldExtractor:
             
             # Use fuzzy matching for partial matches
             for identifier in store_data['identifiers']:
-                ratio = fuzz.partial_ratio(identifier, text_lower)
+                ratio = _partial_ratio(identifier, text_lower)
                 if ratio > 80:
                     confidence = max(confidence, ratio / 100.0 * 0.8)
             
@@ -344,7 +418,7 @@ class EnhancedCouponFieldExtractor:
             for pattern in store_patterns:
                 matches = re.findall(pattern, text, re.IGNORECASE)
                 for match in matches:
-                    if not any(char.isdigit() for char in match):
+                    if not self._is_plausible_code(match):
                         continue
                     candidates.append({
                         'code': match,
@@ -356,8 +430,7 @@ class EnhancedCouponFieldExtractor:
         for pattern in self.general_code_patterns:
             matches = re.findall(pattern, text, re.IGNORECASE)
             for match in matches:
-                # Filter out common false positives
-                if not any(char.isdigit() for char in match):
+                if not self._is_plausible_code(match):
                     continue
                 if not self._is_likely_false_positive(match):
                     candidates.append({
@@ -376,6 +449,10 @@ class EnhancedCouponFieldExtractor:
         for pattern in code_indicator_patterns:
             matches = re.findall(pattern, text, re.IGNORECASE)
             for match in matches:
+                if not self._is_plausible_code(match):
+                    continue
+                if self._is_likely_false_positive(match):
+                    continue
                 candidates.append({
                     'code': match,
                     'confidence': 0.95,
@@ -535,36 +612,76 @@ class EnhancedCouponFieldExtractor:
         Returns:
             Dict: Expiry date extraction result
         """
-        best_match = {'date': None, 'confidence': 0.0, 'raw_text': None, 'parsed_date': None}
+        best_match = {'date': None, 'confidence': 0.0, 'raw_text': None, 'parsed_date': None, 'is_expired': None}
         
         for pattern, confidence in self.expiry_patterns:
             matches = re.findall(pattern, text, re.IGNORECASE)
             for match in matches:
-                try:
-                    # Try to parse the date
-                    parsed_date = date_parser.parse(match, fuzzy=True)
-                    
-                    # Check if date is in the future (reasonable for expiry)
-                    if parsed_date.date() >= datetime.now().date():
-                        if confidence > best_match['confidence']:
-                            best_match = {
-                                'date': match,
-                                'confidence': confidence,
-                                'raw_text': match,
-                                'parsed_date': parsed_date.isoformat()
-                            }
-                    
-                except (ValueError, TypeError):
-                    # If parsing fails, still record with lower confidence
+                parsed_date = self._parse_expiry_candidate(match)
+
+                if parsed_date:
+                    is_expired = parsed_date.date() < datetime.now().date()
+                    effective_confidence = confidence
+
+                    if effective_confidence > best_match['confidence']:
+                        best_match = {
+                            'date': match,
+                            'confidence': effective_confidence,
+                            'raw_text': match,
+                            'parsed_date': parsed_date.isoformat(),
+                            'is_expired': is_expired
+                        }
+                else:
                     if confidence * 0.5 > best_match['confidence']:
                         best_match = {
                             'date': match,
                             'confidence': confidence * 0.5,
                             'raw_text': match,
-                            'parsed_date': None
+                            'parsed_date': None,
+                            'is_expired': None
                         }
-        
+
         return best_match
+
+    def _parse_expiry_candidate(self, value: str) -> Optional[datetime]:
+        """Parse a matched expiry string using known date formats."""
+
+        if not value:
+            return None
+
+        normalized = value.strip()
+        normalized = re.sub(r'(\d{1,2})(st|nd|rd|th)', r'\1', normalized, flags=re.IGNORECASE)
+        normalized = re.sub(r'\s+', ' ', normalized)
+
+        lowered = normalized.lower()
+        for source, target in MONTH_NORMALIZATION.items():
+            lowered = re.sub(r'\b' + re.escape(source) + r'\b', target.lower(), lowered)
+
+        # Restore title case for month tokens
+        lowered = re.sub(
+            r'\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\b',
+            lambda m: m.group(0).title(),
+            lowered,
+            flags=re.IGNORECASE
+        )
+        lowered = re.sub(
+            r'\b(january|february|march|april|may|june|july|august|september|october|november|december)\b',
+            lambda m: m.group(0).title(),
+            lowered,
+            flags=re.IGNORECASE
+        )
+
+        # Remove stray periods after normalization
+        normalized = re.sub(r'\.(?=\s|$)', '', lowered)
+
+        for fmt in EXPIRY_DATE_FORMATS:
+            try:
+                parsed = datetime.strptime(normalized, fmt)
+                return parsed
+            except ValueError:
+                continue
+
+        return None
     
     def _extract_min_order(self, text: str) -> Dict:
         """Extract minimum order amount with confidence.
@@ -698,33 +815,66 @@ class EnhancedCouponFieldExtractor:
 
         return {'text': None, 'confidence': 0.0, 'source': 'none'}
     
-    def _is_likely_false_positive(self, code: str) -> bool:
-        """Check if a potential code is likely a false positive.
-        
-        Args:
-            code (str): Potential coupon code
-            
-        Returns:
-            bool: True if likely false positive
-        """
-        false_positive_patterns = [
-            r'^\d+$',  # Only numbers
-            r'^[A-Z]+$',  # Only letters
-            r'(AMAZON|FLIPKART|MYNTRA|SWIGGY|ZOMATO)',  # Store names
-            r'(INDIA|DELHI|MUMBAI|BANGALORE)',  # City names
-            r'(MONDAY|TUESDAY|WEDNESDAY|THURSDAY|FRIDAY|SATURDAY|SUNDAY)',  # Days
-            r'(JANUARY|FEBRUARY|MARCH|APRIL|MAY|JUNE|JULY|AUGUST|SEPTEMBER|OCTOBER|NOVEMBER|DECEMBER)',  # Months
-        ]
-        
-        for pattern in false_positive_patterns:
-            if re.match(pattern, code, re.IGNORECASE):
-                return True
-        
-        # Check for common English words
-        common_words = ['CODE', 'COUPON', 'OFFER', 'DEAL', 'SAVE', 'FREE', 'EXTRA']
-        if code.upper() in common_words:
+    def _is_plausible_code(self, code: str) -> bool:
+        """Determine if a detected token looks like a real coupon code."""
+
+        cleaned = code.strip()
+        if not cleaned:
+            return False
+
+        if any(char.isdigit() for char in cleaned):
             return True
-        
+
+        if cleaned.isalpha() and len(cleaned) >= 6:
+            return True
+
+        return False
+
+    def _is_likely_false_positive(self, code: str) -> bool:
+        """Check if a potential code is likely a false positive."""
+
+        cleaned = code.strip()
+        if not cleaned:
+            return True
+
+        upper_code = cleaned.upper()
+
+        if cleaned.isdigit():
+            return True
+
+        generic_words = {
+            'CODE', 'COUPON', 'OFFER', 'DEAL', 'SAVE', 'FREE', 'EXTRA',
+            'FLAT', 'DISCOUNT', 'SHOP', 'STORE', 'SUPER', 'SPECIAL'
+        }
+
+        if upper_code in generic_words:
+            return True
+
+        store_names = {'AMAZON', 'FLIPKART', 'MYNTRA', 'SWIGGY', 'ZOMATO', 'AHA', 'PUMA'}
+        if upper_code in store_names:
+            return True
+
+        cities = {'INDIA', 'DELHI', 'MUMBAI', 'BANGALORE', 'CHENNAI', 'HYDERABAD'}
+        if upper_code in cities:
+            return True
+
+        weekdays = {
+            'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY'
+        }
+        if upper_code in weekdays:
+            return True
+
+        months = {
+            'JANUARY', 'FEBRUARY', 'MARCH', 'APRIL', 'MAY', 'JUNE',
+            'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER',
+            'JAN', 'FEB', 'MAR', 'APR', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'
+        }
+        if upper_code in months:
+            return True
+
+        if cleaned.isalpha() and len(cleaned) <= 4:
+            return True
+
         return False
     
     def validate_extracted_fields(self, fields: Dict) -> Dict:

--- a/enhanced_field_extractor.py
+++ b/enhanced_field_extractor.py
@@ -59,6 +59,14 @@ EXPIRY_DATE_FORMATS = [
     '%d %b, %Y, %I:%M %p',
     '%d %B %Y, %I:%M %p',
     '%d %B, %Y, %I:%M %p',
+    '%d %b %Y %I:%M%p',
+    '%d %b, %Y %I:%M%p',
+    '%d %B %Y %I:%M%p',
+    '%d %B, %Y %I:%M%p',
+    '%d %b %Y, %I:%M%p',
+    '%d %b, %Y, %I:%M%p',
+    '%d %B %Y, %I:%M%p',
+    '%d %B, %Y, %I:%M%p',
 ]
 
 
@@ -187,9 +195,9 @@ class EnhancedCouponFieldExtractor:
             (r'valid\s*(?:till|until)\s*(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})', 0.9),
             (r'expires?\s*(?:on|at)?\s*(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})', 0.9),
             (r'expiry\s*:?\s*(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})', 0.9),
-            (r'valid\s*(?:till|until)\s*(\d{1,2}\s+\w+,?\s+\d{2,4}(?:,\s*\d{1,2}:\d{2}\s*(?:am|pm))?)', 0.95),
-            (r'expires?\s*(?:on|at)?\s*(\d{1,2}\s+\w+,?\s+\d{2,4}(?:,\s*\d{1,2}:\d{2}\s*(?:am|pm))?)', 0.95),
-            (r'(\d{1,2}\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*\s+\d{2,4})', 0.85),
+            (r'valid\s*(?:till|until)\s*(\d{1,2}(?:st|nd|rd|th)?\s+\w+,?\s+\d{2,4}(?:,?\s*\d{1,2}:\d{2}\s*(?:am|pm))?)', 0.95),
+            (r'expires?\s*(?:on|at)?\s*(\d{1,2}(?:st|nd|rd|th)?\s+\w+,?\s+\d{2,4}(?:,?\s*\d{1,2}:\d{2}\s*(?:am|pm))?)', 0.95),
+            (r'(\d{1,2}(?:st|nd|rd|th)?\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*\s+\d{2,4})', 0.85),
         ]
         
         # Minimum order patterns
@@ -215,7 +223,6 @@ class EnhancedCouponFieldExtractor:
         Returns:
             Dict: Extracted fields with confidence scores
         """
-        text_lower = text.lower()
         text_clean = self._clean_text(text)
         
         # Detect store first to apply store-specific patterns
@@ -652,6 +659,7 @@ class EnhancedCouponFieldExtractor:
         normalized = value.strip()
         normalized = re.sub(r'(\d{1,2})(st|nd|rd|th)', r'\1', normalized, flags=re.IGNORECASE)
         normalized = re.sub(r'\s+', ' ', normalized)
+        normalized = re.sub(r'(\d)(am|pm)\b', r'\1 \2', normalized, flags=re.IGNORECASE)
 
         lowered = normalized.lower()
         for source, target in MONTH_NORMALIZATION.items():
@@ -670,6 +678,7 @@ class EnhancedCouponFieldExtractor:
             lowered,
             flags=re.IGNORECASE
         )
+        lowered = re.sub(r'\b(am|pm)\b', lambda m: m.group(0).upper(), lowered, flags=re.IGNORECASE)
 
         # Remove stray periods after normalization
         normalized = re.sub(r'\.(?=\s|$)', '', lowered)

--- a/enhanced_field_extractor.py
+++ b/enhanced_field_extractor.py
@@ -137,6 +137,16 @@ class EnhancedCouponFieldExtractor:
                 'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'flat\s*(\d+(?:\.\d+)?)%', r'buy\s*\d+\s*get\s*\d+'],
                 'common_terms': ['fashion', 'style', 'brands', 'clothing']
             },
+            'puma': {
+                'display_name': 'PUMA',
+                'identifiers': ['puma', 'puma.com', 'puma.in'],
+                'code_patterns': [r'[A-Z0-9]{6,12}'],
+                'discount_patterns': [
+                    r'(?:up\s*to|upto)\s*(\d+(?:\.\d+)?)%\s*(?:off|discount)',
+                    r'extra\s*(\d+(?:\.\d+)?)%\s*(?:off|discount)'
+                ],
+                'common_terms': ['sneakers', 'sports', 'athleisure', 'store']
+            },
             'swiggy': {
                 'display_name': 'Swiggy',
                 'identifiers': ['swiggy', 'swiggy.com'],
@@ -322,7 +332,16 @@ class EnhancedCouponFieldExtractor:
                 r'(?:from)\s+([A-Z][A-Za-z&]*(?:\s+[A-Z][A-Za-z&]*){0,2})',
             ]
             location_candidates: List[Tuple[str, int]] = []
-            generic_suffixes = re.compile(r'\b(store|stores|shop|shops|outlet|outlets|mall|malls|retail|online|sale|offer)s?\b', re.IGNORECASE)
+            generic_suffixes = re.compile(
+                r'\b(store|stores|shop|shops|outlet|outlets|mall|malls|retail|online|sale|offer)s?\b',
+                re.IGNORECASE
+            )
+
+            trailing_tokens = {
+                'code', 'codes', 'coupon', 'coupons', 'promo', 'promocode',
+                'deal', 'deals', 'offer', 'offers', 'use'
+            }
+            skip_tokens = {'the', 'at', 'and'} | trailing_tokens
 
             for pattern in location_patterns:
                 for match in re.finditer(pattern, text):
@@ -333,9 +352,13 @@ class EnhancedCouponFieldExtractor:
                         words = candidate.split()
                         cleaned_words = []
                         for word in words:
-                            if word.lower() in {'the', 'at', 'and'}:
+                            cleaned_word = word.rstrip(':,.')
+                            if cleaned_word.lower() in skip_tokens:
                                 continue
-                            cleaned_words.append(word)
+                            cleaned_words.append(cleaned_word)
+
+                        while cleaned_words and cleaned_words[-1].lower() in trailing_tokens:
+                            cleaned_words.pop()
                         if cleaned_words:
                             cleaned = ' '.join(cleaned_words)
                             location_candidates.append((cleaned, match.start()))
@@ -355,8 +378,8 @@ class EnhancedCouponFieldExtractor:
                     r'\b[A-Z]{2,8}\b'  # All caps words
                 ]
 
-                stopwords = {'redeem', 'super', 'mega', 'offer', 'offers', 'coupon', 'coupons', 'multi', 'valid', 'expires',
-                             'get', 'save', 'extra', 'flat', 'cashback', 'discount'}
+                stopwords = {'redeem', 'super', 'mega', 'offer', 'offers', 'coupon', 'coupons', 'code', 'codes', 'use', 'multi',
+                             'valid', 'expires', 'get', 'save', 'extra', 'flat', 'cashback', 'discount'}
 
                 selected = None
                 for pattern in brand_patterns:

--- a/enhanced_field_extractor.py
+++ b/enhanced_field_extractor.py
@@ -37,56 +37,69 @@ class EnhancedCouponFieldExtractor:
             'amazon': {
                 'identifiers': ['amazon', 'amzn', 'amazon.in'],
                 'code_patterns': [r'[A-Z0-9]{8,12}'],
-                'discount_patterns': [r'(\d+)%\s*off', r'save\s*₹(\d+)', r'flat\s*(\d+)%'],
+                'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'save\s*₹(\d+)', r'flat\s*(\d+(?:\.\d+)?)%'],
                 'common_terms': ['prime', 'delivery', 'shopping', 'cart']
             },
             'flipkart': {
                 'identifiers': ['flipkart', 'fkrt', 'flipkart.com'],
                 'code_patterns': [r'[A-Z]{2,4}\d{4,8}', r'FK[A-Z0-9]{6,10}'],
-                'discount_patterns': [r'(\d+)%\s*off', r'extra\s*(\d+)%', r'flat\s*₹(\d+)'],
+                'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'extra\s*(\d+(?:\.\d+)?)%', r'flat\s*₹(\d+)'],
                 'common_terms': ['plus', 'supercoins', 'delivery', 'exchange']
             },
             'myntra': {
                 'identifiers': ['myntra', 'myntra.com'],
                 'code_patterns': [r'[A-Z]{3,5}\d{3,6}', r'MYNTRA[0-9]{4,8}'],
-                'discount_patterns': [r'(\d+)%\s*off', r'flat\s*(\d+)%', r'buy\s*\d+\s*get\s*\d+'],
+                'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'flat\s*(\d+(?:\.\d+)?)%', r'buy\s*\d+\s*get\s*\d+'],
                 'common_terms': ['fashion', 'style', 'brands', 'clothing']
             },
             'swiggy': {
                 'identifiers': ['swiggy', 'swiggy.com'],
                 'code_patterns': [r'[A-Z]{4,6}\d{2,4}', r'SWIGGY[0-9]{3,6}'],
-                'discount_patterns': [r'(\d+)%\s*off', r'flat\s*₹(\d+)', r'free\s*delivery'],
+                'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'flat\s*₹(\d+)', r'free\s*delivery'],
                 'common_terms': ['food', 'delivery', 'restaurant', 'order']
             },
             'zomato': {
                 'identifiers': ['zomato', 'zomato.com'],
                 'code_patterns': [r'[A-Z]{4,6}\d{2,4}', r'ZOMATO[0-9]{3,6}'],
-                'discount_patterns': [r'(\d+)%\s*off', r'flat\s*₹(\d+)', r'free\s*delivery'],
+                'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'flat\s*₹(\d+)', r'free\s*delivery'],
                 'common_terms': ['food', 'delivery', 'dining', 'restaurant']
+            },
+            'aha': {
+                'identifiers': ['aha'],
+                'code_patterns': [],
+                'discount_patterns': [r'flat\s*(\d+(?:\.\d+)?)%'],
+                'common_terms': ['telugu', 'plan', 'subscription']
             }
         }
         
         # Common coupon code patterns
         self.general_code_patterns = [
-            r'\b[A-Z]{3,6}\d{2,6}\b',  # 3-6 letters + 2-6 digits
-            r'\b[A-Z0-9]{6,12}\b',     # 6-12 alphanumeric
-            r'\b[A-Z]{2,4}[0-9]{4,8}\b',  # Letters + numbers
-            r'\bCODE\s*[A-Z0-9]{4,10}\b',  # CODE prefix
-            r'\bUSE\s*[A-Z0-9]{4,10}\b',   # USE prefix
+            r'\b[A-Za-z]{3,6}\d{2,6}\b',  # 3-6 letters + 2-6 digits
+            r'\b[A-Za-z]{2,4}[0-9]{4,8}\b',  # Letters + numbers
+            r'\b[A-Za-z0-9]{6,12}\b',     # 6-12 alphanumeric
+            r'\bCODE\s*[A-Za-z0-9]{4,10}\b',  # CODE prefix
+            r'\bUSE\s*[A-Za-z0-9]{4,10}\b',   # USE prefix
         ]
         
         # Discount patterns with confidence scoring
+        self.discount_phrase_patterns = [
+            r'(?:up\s*to|upto)\s*\d+(?:\.\d+)?%[^\w]*(?:off|discount)',
+            r'extra\s*\d+(?:\.\d+)?%[^\w]*(?:off|discount)',
+            r'flat\s*\d+(?:\.\d+)?%[^\w]*(?:off|discount)',
+            r'\d+(?:\.\d+)?%[^\w]*(?:off|discount)'
+        ]
+
         self.discount_patterns = [
-            (r'(\d+)%\s*(?:off|discount)', 0.9, 'percentage'),
-            (r'flat\s*(\d+)%\s*(?:off|discount)', 0.9, 'percentage'),
-            (r'extra\s*(\d+)%\s*(?:off|discount)', 0.85, 'percentage'),
-            (r'upto\s*(\d+)%\s*(?:off|discount)', 0.8, 'percentage'),
+            (r'(\d+(?:\.\d+)?)%\s*(?:off|discount)', 0.9, 'percentage'),
+            (r'flat\s*(\d+(?:\.\d+)?)%\s*(?:off|discount)', 0.9, 'percentage'),
+            (r'extra\s*(\d+(?:\.\d+)?)%\s*(?:off|discount)', 0.85, 'percentage'),
+            (r'upto\s*(\d+(?:\.\d+)?)%\s*(?:off|discount)', 0.8, 'percentage'),
             (r'save\s*₹(\d+)', 0.9, 'amount'),
             (r'flat\s*₹(\d+)\s*(?:off|discount)', 0.9, 'amount'),
             (r'₹(\d+)\s*(?:off|discount)', 0.8, 'amount'),
             (r'rs\.?\s*(\d+)\s*(?:off|discount)', 0.8, 'amount'),
             (r'get\s*₹(\d+)\s*(?:back|cashback)', 0.85, 'cashback'),
-            (r'(\d+)\s*rs\.?\s*(?:off|discount)', 0.75, 'amount'),
+            (r'(?<!%)\b(\d+)\s*(?:off|discount|cashback)', 0.75, 'amount'),
         ]
         
         # Expiry date patterns
@@ -94,8 +107,8 @@ class EnhancedCouponFieldExtractor:
             (r'valid\s*(?:till|until)\s*(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})', 0.9),
             (r'expires?\s*(?:on|at)?\s*(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})', 0.9),
             (r'expiry\s*:?\s*(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})', 0.9),
-            (r'valid\s*(?:till|until)\s*(\d{1,2}\s+\w+\s+\d{2,4})', 0.95),
-            (r'expires?\s*(?:on|at)?\s*(\d{1,2}\s+\w+\s+\d{2,4})', 0.95),
+            (r'valid\s*(?:till|until)\s*(\d{1,2}\s+\w+,?\s+\d{2,4}(?:,\s*\d{1,2}:\d{2}\s*(?:am|pm))?)', 0.95),
+            (r'expires?\s*(?:on|at)?\s*(\d{1,2}\s+\w+,?\s+\d{2,4}(?:,\s*\d{1,2}:\d{2}\s*(?:am|pm))?)', 0.95),
             (r'(\d{1,2}\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*\s+\d{2,4})', 0.85),
         ]
         
@@ -215,21 +228,91 @@ class EnhancedCouponFieldExtractor:
         
         # If no store detected, try to extract any brand-like words
         if best_match['confidence'] < 0.5:
-            brand_patterns = [
-                r'\b[A-Z][a-z]+\s*(?:\.com|\.in)?\b',  # Domain-like
-                r'\b[A-Z]{2,8}\b'  # All caps words
+            # Try to capture "at <Brand>" constructs first
+            location_patterns = [
+                r'(?:at|@)\s+([A-Z][A-Za-z&]*(?:\s+[A-Z][A-Za-z&]*){0,2})',
+                r'(?:from)\s+([A-Z][A-Za-z&]*(?:\s+[A-Z][A-Za-z&]*){0,2})',
             ]
-            
-            for pattern in brand_patterns:
-                matches = re.findall(pattern, text)
-                if matches:
+            location_candidates: List[Tuple[str, int]] = []
+            generic_suffixes = re.compile(r'\b(store|stores|shop|shops|outlet|outlets|mall|malls|retail|online|sale|offer)s?\b', re.IGNORECASE)
+
+            for pattern in location_patterns:
+                for match in re.finditer(pattern, text):
+                    candidate = match.group(1).strip()
+                    candidate = generic_suffixes.sub('', candidate).strip()
+                    candidate = re.sub(r'\s{2,}', ' ', candidate)
+                    if candidate:
+                        words = candidate.split()
+                        cleaned_words = []
+                        for word in words:
+                            if word.lower() in {'the', 'at', 'and'}:
+                                continue
+                            cleaned_words.append(word)
+                        if cleaned_words:
+                            cleaned = ' '.join(cleaned_words)
+                            location_candidates.append((cleaned, match.start()))
+
+            if location_candidates:
+                # Prefer the candidate that appears first but prioritise longer names
+                location_candidates.sort(key=lambda item: (-len(item[0]), item[1]))
+                best_match = {
+                    'name': location_candidates[0][0].strip(),
+                    'confidence': 0.45,
+                    'type': 'extracted'
+                }
+            else:
+                brand_patterns = [
+                    r'\b[A-Z][a-z]+\s*(?:\.com|\.in)?\b',  # Domain-like
+                    r'\b[A-Z]{2,8}\b'  # All caps words
+                ]
+
+                stopwords = {'redeem', 'super', 'mega', 'offer', 'offers', 'coupon', 'coupons', 'multi', 'valid', 'expires',
+                             'get', 'save', 'extra', 'flat', 'cashback', 'discount'}
+
+                selected = None
+                for pattern in brand_patterns:
+                    matches = re.findall(pattern, text)
+                    if not matches:
+                        continue
+
+                    for match in matches:
+                        candidate = match.strip()
+                        if candidate.lower() in stopwords:
+                            continue
+                        selected = candidate
+                        break
+
+                    if selected:
+                        break
+
+                if selected:
                     best_match = {
-                        'name': matches[0].strip(),
+                        'name': selected,
                         'confidence': 0.4,
                         'type': 'extracted'
                     }
-                    break
-        
+                else:
+                    lowercase_stopwords = stopwords | {'purchase', 'details', 'terms', 'condition', 'conditions', 'plan',
+                                                       'plans', 'annual', 'telugu', 'unknown', 'couponcode', 'code'}
+
+                    words = re.findall(r'\b[a-z]{3,}\b', text_lower)
+                    frequency: Dict[str, int] = {}
+                    for word in words:
+                        if word in lowercase_stopwords:
+                            continue
+                        frequency[word] = frequency.get(word, 0) + 1
+
+                    if frequency:
+                        candidate_word, count = max(frequency.items(), key=lambda item: (item[1], len(item[0])))
+                        if count > 1:
+                            match = re.search(r'\b' + re.escape(candidate_word) + r'\b', text, re.IGNORECASE)
+                            name = match.group(0) if match else candidate_word
+                            best_match = {
+                                'name': name,
+                                'confidence': 0.38,
+                                'type': 'extracted'
+                            }
+
         return best_match
     
     def _extract_coupon_code(self, text: str, store_info: Dict) -> Dict:
@@ -250,6 +333,8 @@ class EnhancedCouponFieldExtractor:
             for pattern in store_patterns:
                 matches = re.findall(pattern, text, re.IGNORECASE)
                 for match in matches:
+                    if not any(char.isdigit() for char in match):
+                        continue
                     candidates.append({
                         'code': match,
                         'confidence': 0.9,
@@ -261,6 +346,8 @@ class EnhancedCouponFieldExtractor:
             matches = re.findall(pattern, text, re.IGNORECASE)
             for match in matches:
                 # Filter out common false positives
+                if not any(char.isdigit() for char in match):
+                    continue
                 if not self._is_likely_false_positive(match):
                     candidates.append({
                         'code': match,
@@ -270,9 +357,9 @@ class EnhancedCouponFieldExtractor:
         
         # Look for explicit code indicators
         code_indicator_patterns = [
-            r'(?:code|coupon)\s*:?\s*([A-Z0-9]{4,12})',
-            r'use\s+(?:code\s+)?([A-Z0-9]{4,12})',
-            r'promo\s*code\s*:?\s*([A-Z0-9]{4,12})'
+            r'(?:code|coupon)\s*:?\s*([A-Za-z0-9]{4,12})',
+            r'use\s+(?:code\s+)?([A-Za-z0-9]{4,12})',
+            r'promo\s*code\s*:?\s*([A-Za-z0-9]{4,12})'
         ]
         
         for pattern in code_indicator_patterns:
@@ -300,41 +387,132 @@ class EnhancedCouponFieldExtractor:
         Returns:
             Dict: Discount extraction result
         """
-        best_match = {'value': None, 'type': None, 'confidence': 0.0, 'raw_text': None}
-        
+        best_match = {
+            'value': None,
+            'type': None,
+            'confidence': 0.0,
+            'raw_text': None,
+            'text': None,
+            'components': []
+        }
+
+        # First try to capture composite discount phrases like
+        # "Up to 50% off + Extra 33% off"
+        phrase_matches: List[Tuple[int, str]] = []
+        for pattern in self.discount_phrase_patterns:
+            for match in re.finditer(pattern, text, re.IGNORECASE):
+                phrase_matches.append((match.start(), match.group(0)))
+
+        if phrase_matches:
+            phrase_matches.sort(key=lambda item: item[0])
+            normalized_phrases: List[str] = []
+
+            for _, phrase in phrase_matches:
+                normalized = re.sub(r'\s+', ' ', phrase.strip(' ,;:+-*')).strip()
+                normalized = normalized.lower().replace('upto', 'up to')
+                normalized = re.sub(r'(\d+)\.0+%', r'\1%', normalized)
+                if normalized and normalized not in normalized_phrases:
+                    normalized_phrases.append(normalized)
+
+            if normalized_phrases:
+                filtered_phrases = []
+                for phrase in normalized_phrases:
+                    if any(phrase != other and phrase in other for other in normalized_phrases):
+                        continue
+                    filtered_phrases.append(phrase)
+                normalized_phrases = filtered_phrases
+
+            if normalized_phrases:
+                pretty_phrases = []
+                for phrase in normalized_phrases:
+                    pretty = phrase
+                    pretty = re.sub(r'\bup to\b', 'Up to', pretty)
+                    pretty = re.sub(r'\bextra\b', 'Extra', pretty)
+                    pretty = re.sub(r'\bflat\b', 'Flat', pretty)
+                    pretty = re.sub(r'\boff\b', 'Off', pretty)
+                    pretty = re.sub(r'(\d+)\.0+%', r'\1%', pretty)
+                    pretty_phrases.append(pretty)
+
+                combined_phrase = ' + '.join(pretty_phrases)
+                percentages = [
+                    float(num)
+                    for phrase in normalized_phrases
+                    for num in re.findall(r'(\d+(?:\.\d+)?)%', phrase)
+                ]
+
+                if percentages:
+                    max_value = max(percentages)
+                    if abs(max_value - int(max_value)) < 1e-6:
+                        max_value = int(max_value)
+                    best_match = {
+                        'value': max_value,
+                        'type': 'percentage',
+                        'confidence': 0.92,
+                        'raw_text': combined_phrase,
+                        'text': combined_phrase,
+                        'components': pretty_phrases
+                    }
+
         for pattern, confidence, discount_type in self.discount_patterns:
-            matches = re.findall(pattern, text, re.IGNORECASE)
-            for match in matches:
+            for match in re.finditer(pattern, text, re.IGNORECASE):
                 try:
-                    # Extract numeric value
-                    if isinstance(match, tuple):
-                        value = int(match[0])
-                        raw_text = match[1] if len(match) > 1 else str(match)
+                    groups = match.groups()
+                    value_str = None
+                    if groups:
+                        for group in groups:
+                            if group and group.strip().replace('.', '', 1).isdigit():
+                                value_str = group
+                                break
+                    if value_str is None:
+                        digits = re.search(r'\d+', match.group(0))
+                        value_str = digits.group(0) if digits else None
+
+                    if not value_str:
+                        continue
+
+                    if '.' in value_str:
+                        value = float(value_str)
                     else:
-                        value = int(match)
-                        raw_text = match
-                    
+                        value = int(value_str)
+
+                    raw_text = re.sub(r'\s+', ' ', match.group(0).strip())
+                    raw_text = re.sub(r'(\d+)\.0+%', r'\1%', raw_text)
+                    normalized_text = raw_text
+
+                    # If the raw text contains a percentage symbol, ensure we treat it as percentage
+                    normalized_type = 'percentage' if '%' in raw_text else discount_type
+
                     # Validate reasonable discount values
-                    if discount_type == 'percentage' and 1 <= value <= 99:
-                        if confidence > best_match['confidence']:
-                            best_match = {
-                                'value': value,
-                                'type': discount_type,
-                                'confidence': confidence,
-                                'raw_text': raw_text
-                            }
-                    elif discount_type in ['amount', 'cashback'] and 10 <= value <= 10000:
-                        if confidence > best_match['confidence']:
-                            best_match = {
-                                'value': value,
-                                'type': discount_type,
-                                'confidence': confidence,
-                                'raw_text': raw_text
-                            }
-                
+                    if normalized_type == 'percentage':
+                        numeric_value = float(value)
+                        if 1 <= numeric_value <= 99:
+                            output_value = int(numeric_value) if abs(numeric_value - int(numeric_value)) < 1e-6 else numeric_value
+                            if confidence > best_match['confidence']:
+                                best_match = {
+                                    'value': output_value,
+                                    'type': 'percentage',
+                                    'confidence': confidence,
+                                    'raw_text': normalized_text,
+                                    'text': normalized_text,
+                                    'components': [normalized_text]
+                                }
+                    elif normalized_type in ['amount', 'cashback']:
+                        numeric_value = float(value)
+                        if 10 <= numeric_value <= 10000:
+                            output_value = int(numeric_value) if abs(numeric_value - int(numeric_value)) < 1e-6 else numeric_value
+                            if confidence > best_match['confidence']:
+                                best_match = {
+                                    'value': output_value,
+                                    'type': normalized_type,
+                                    'confidence': confidence,
+                                    'raw_text': normalized_text,
+                                    'text': normalized_text,
+                                    'components': [normalized_text]
+                                }
+
                 except (ValueError, IndexError):
                     continue
-        
+
         return best_match
     
     def _extract_expiry_date(self, text: str) -> Dict:
@@ -466,25 +644,47 @@ class EnhancedCouponFieldExtractor:
         terms_keywords = [
             'terms', 'conditions', 'applicable', 'valid', 'offer',
             'cannot be combined', 'not applicable', 'restrictions',
-            'one time use', 'limited period'
+            'one time use', 'limited period', 'purchase', 'plan'
         ]
-        
-        terms_text = []
-        for keyword in terms_keywords:
-            if keyword in text.lower():
-                # Find sentences containing terms keywords
-                sentences = re.split(r'[.!?]', text)
-                for sentence in sentences:
-                    if keyword in sentence.lower():
-                        terms_text.append(sentence.strip())
-        
-        if terms_text:
+
+        sentences = [s.strip() for s in re.split(r'[.!?]', text) if s.strip()]
+        collected_terms: List[str] = []
+
+        for sentence in sentences:
+            lower_sentence = sentence.lower()
+            if any(keyword in lower_sentence for keyword in terms_keywords):
+                collected_terms.append(sentence)
+
+        amount_pattern = re.compile(r'₹\s*(\d+(?:,\d{3})*)')
+        for sentence in sentences:
+            lower_sentence = sentence.lower()
+            amounts = amount_pattern.findall(sentence)
+            if amounts and ('plan' in lower_sentence or 'subscription' in lower_sentence or 'purchase' in lower_sentence):
+                descriptor_match = re.search(r'([A-Za-z&\s]{3,}?\bplan[s]?)', sentence, re.IGNORECASE)
+                if descriptor_match:
+                    descriptor = descriptor_match.group(1).strip()
+                else:
+                    descriptor = 'this offer'
+
+                unique_amounts: List[str] = []
+                for amount in amounts:
+                    normalized_amount = amount.replace(',', '')
+                    if normalized_amount not in unique_amounts:
+                        unique_amounts.append(normalized_amount)
+
+                formatted_amounts = ', '.join(f'₹{amt}' for amt in unique_amounts)
+                formatted_sentence = f"Valid on {descriptor} of {formatted_amounts}"
+
+                if formatted_sentence not in collected_terms:
+                    collected_terms.append(formatted_sentence)
+
+        if collected_terms:
             return {
-                'text': '. '.join(terms_text),
+                'text': '. '.join(collected_terms),
                 'confidence': 0.7,
                 'source': 'keyword_match'
             }
-        
+
         return {'text': None, 'confidence': 0.0, 'source': 'none'}
     
     def _is_likely_false_positive(self, code: str) -> bool:

--- a/enhanced_field_extractor.py
+++ b/enhanced_field_extractor.py
@@ -1,952 +1,714 @@
 #!/usr/bin/env python3
-"""
-Enhanced Field Extractor - ML-based coupon field extraction.
+"""Utility helpers for extracting structured coupon details from OCR text."""
 
-This module provides intelligent field extraction using machine learning
-and context-aware algorithms for better coupon information extraction.
-"""
+from __future__ import annotations
 
-import re
-import json
 import logging
+import re
 from datetime import datetime
 from difflib import SequenceMatcher
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 
 MONTH_NORMALIZATION = {
-    'jan.': 'Jan',
-    'feb.': 'Feb',
-    'mar.': 'Mar',
-    'apr.': 'Apr',
-    'jun.': 'Jun',
-    'jul.': 'Jul',
-    'aug.': 'Aug',
-    'sep.': 'Sep',
-    'sep': 'Sep',
-    'sept': 'Sep',
-    'sept.': 'Sep',
-    'oct.': 'Oct',
-    'nov.': 'Nov',
-    'dec.': 'Dec',
+    "jan.": "Jan",
+    "feb.": "Feb",
+    "mar.": "Mar",
+    "apr.": "Apr",
+    "jun.": "Jun",
+    "jul.": "Jul",
+    "aug.": "Aug",
+    "sept": "Sep",
+    "sept.": "Sep",
+    "sep.": "Sep",
+    "oct.": "Oct",
+    "nov.": "Nov",
+    "dec.": "Dec",
 }
 
-
 EXPIRY_DATE_FORMATS = [
-    '%d/%m/%Y',
-    '%d/%m/%y',
-    '%d-%m-%Y',
-    '%d-%m-%y',
-    '%Y-%m-%d',
-    '%d %m %Y',
-    '%d %b %Y',
-    '%d %b, %Y',
-    '%d %B %Y',
-    '%d %B, %Y',
-    '%d %b %Y %H:%M',
-    '%d %b, %Y %H:%M',
-    '%d %B %Y %H:%M',
-    '%d %B, %Y %H:%M',
-    '%d %b %Y, %H:%M',
-    '%d %b, %Y, %H:%M',
-    '%d %B %Y, %H:%M',
-    '%d %B, %Y, %H:%M',
-    '%d %b %Y %I:%M %p',
-    '%d %b, %Y %I:%M %p',
-    '%d %B %Y %I:%M %p',
-    '%d %B, %Y %I:%M %p',
-    '%d %b %Y, %I:%M %p',
-    '%d %b, %Y, %I:%M %p',
-    '%d %B %Y, %I:%M %p',
-    '%d %B, %Y, %I:%M %p',
-    '%d %b %Y %I:%M%p',
-    '%d %b, %Y %I:%M%p',
-    '%d %B %Y %I:%M%p',
-    '%d %B, %Y %I:%M%p',
-    '%d %b %Y, %I:%M%p',
-    '%d %b, %Y, %I:%M%p',
-    '%d %B %Y, %I:%M%p',
-    '%d %B, %Y, %I:%M%p',
+    "%d/%m/%Y",
+    "%d/%m/%y",
+    "%d-%m-%Y",
+    "%d-%m-%y",
+    "%Y-%m-%d",
+    "%d %m %Y",
+    "%d %b %Y",
+    "%d %b, %Y",
+    "%d %B %Y",
+    "%d %B, %Y",
+    "%d %b %Y %H:%M",
+    "%d %b, %Y %H:%M",
+    "%d %B %Y %H:%M",
+    "%d %B, %Y %H:%M",
+    "%d %b %Y, %H:%M",
+    "%d %b, %Y, %H:%M",
+    "%d %B %Y, %H:%M",
+    "%d %B, %Y, %H:%M",
+    "%d %b %Y %I:%M %p",
+    "%d %b, %Y %I:%M %p",
+    "%d %B %Y %I:%M %p",
+    "%d %B, %Y %I:%M %p",
+    "%d %b %Y, %I:%M %p",
+    "%d %b, %Y, %I:%M %p",
+    "%d %B %Y, %I:%M %p",
+    "%d %B, %Y, %I:%M %p",
+    "%d %b %Y %I:%M%p",
+    "%d %b, %Y %I:%M%p",
+    "%d %B %Y %I:%M%p",
+    "%d %B, %Y %I:%M%p",
+    "%d %b %Y, %I:%M%p",
+    "%d %b, %Y, %I:%M%p",
+    "%d %B %Y, %I:%M%p",
+    "%d %B, %Y, %I:%M%p",
 ]
 
 
-def _partial_ratio(needle: str, haystack: str) -> int:
-    """Lightweight partial ratio implementation without external dependencies."""
+STORE_PROFILES: Dict[str, Dict[str, Iterable[str]]] = {
+    "amazon": {
+        "display_name": "Amazon",
+        "identifiers": ("amazon", "amzn", "amazon.in"),
+        "code_patterns": (r"[A-Z0-9]{8,12}",),
+    },
+    "flipkart": {
+        "display_name": "Flipkart",
+        "identifiers": ("flipkart", "fkrt", "flipkart.com"),
+        "code_patterns": (r"[A-Z]{2,4}\d{4,8}", r"FK[A-Z0-9]{6,10}"),
+    },
+    "myntra": {
+        "display_name": "Myntra",
+        "identifiers": ("myntra", "myntra.com"),
+        "code_patterns": (r"[A-Z]{3,5}\d{3,6}",),
+    },
+    "swiggy": {
+        "display_name": "Swiggy",
+        "identifiers": ("swiggy", "swiggy.com"),
+        "code_patterns": (r"[A-Z]{4,6}\d{2,4}",),
+    },
+    "zomato": {
+        "display_name": "Zomato",
+        "identifiers": ("zomato", "zomato.com"),
+        "code_patterns": (r"[A-Z]{4,6}\d{2,4}",),
+    },
+    "puma": {
+        "display_name": "PUMA",
+        "identifiers": ("puma", "puma.in", "puma.com"),
+        "code_patterns": (r"[A-Z0-9]{6,12}",),
+    },
+    "aha": {
+        "display_name": "Aha",
+        "identifiers": ("aha", "aha.video", "aha app"),
+        "code_patterns": (r"[A-Za-z0-9]{6,12}",),
+    },
+}
+
+TRAILING_STORE_TOKENS = {
+    "code",
+    "codes",
+    "coupon",
+    "coupons",
+    "offer",
+    "offers",
+    "promo",
+    "promocode",
+    "store",
+    "stores",
+    "outlet",
+    "outlets",
+    "shop",
+    "shops",
+}
+
+STORE_STOPWORDS = {
+    "redeem",
+    "coupon",
+    "coupons",
+    "code",
+    "codes",
+    "offer",
+    "offers",
+    "flat",
+    "discount",
+    "save",
+    "multi",
+    "mega",
+    "super",
+    "valid",
+    "expires",
+    "get",
+    "extra",
+    "cashback",
+    "details",
+    "unknown",
+    "purchase",
+}
+
+CODE_FALSE_POSITIVES = {
+    "CODE",
+    "COUPON",
+    "COUPONCODE",
+    "OFFER",
+    "OFFERS",
+    "DISCOUNT",
+    "STORE",
+    "STORES",
+    "SHOP",
+    "SHOPPING",
+    "SAVE",
+    "FREE",
+    "EXTRA",
+    "FLAT",
+    "SPECIAL",
+    "PUMA",
+    "AHA",
+    "AMAZON",
+    "FLIPKART",
+    "MYNTRA",
+    "SWIGGY",
+    "ZOMATO",
+}
+
+PERCENT_COMPONENT_PATTERN = re.compile(
+    r"((?:up\s*to|upto|flat|extra|save)\s*\d+(?:\.\d+)?%\s*(?:off|discount)?)",
+    re.IGNORECASE,
+)
+COMBINED_PERCENT_PATTERN = re.compile(
+    r"((?:up\s*to|upto|flat|extra|save)\s*\d+(?:\.\d+)?%\s*(?:off|discount)?\s*(?:\+|&|and)\s*)+"
+    r"(?:up\s*to|upto|flat|extra|save)\s*\d+(?:\.\d+)?%\s*(?:off|discount)?",
+    re.IGNORECASE,
+)
+AMOUNT_PATTERN = re.compile(r"₹\s*(\d+(?:,\d{3})*)(?:\s*(?:off|discount))?", re.IGNORECASE)
+EXPLICIT_CODE_PATTERNS = (
+    r"(?:code|coupon|promo\s*code)\s*:?\s*([A-Za-z0-9]{4,12})",
+    r"use\s+(?:code\s+)?([A-Za-z0-9]{4,12})",
+)
+
+EXPIRY_LINE_HINTS = ("expire", "valid", "expiry", "until", "till")
+DATE_PATTERNS = (
+    r"(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]{3,9}\.?[,]?\s+\d{2,4}(?:,?\s*\d{1,2}:\d{2}\s*(?:[AP]M|am|pm)?)?)",
+    r"(\d{1,2}[/-]\d{1,2}[/-]\d{2,4}(?:\s*\d{1,2}:\d{2}\s*(?:[AP]M|am|pm)?)?)",
+)
+
+MIN_ORDER_PATTERNS = (
+    (re.compile(r"minimum\s*(?:order|purchase)\s*₹\s*(\d+(?:,\d{3})*)", re.IGNORECASE), 0.9),
+    (re.compile(r"order\s*above\s*₹\s*(\d+(?:,\d{3})*)", re.IGNORECASE), 0.8),
+    (re.compile(r"min\.?\s*order\s*₹\s*(\d+(?:,\d{3})*)", re.IGNORECASE), 0.75),
+)
+
+
+def _partial_ratio(needle: str, haystack: str) -> float:
+    """Return a lightweight partial ratio similar to fuzzy matching."""
+
+    needle = needle.strip().lower()
+    haystack = haystack.strip().lower()
 
     if not needle or not haystack:
-        return 0
-
-    needle = needle.lower()
-    haystack = haystack.lower()
+        return 0.0
 
     if needle in haystack:
-        return 100
+        return 1.0
 
     matcher = SequenceMatcher()
     matcher.set_seq2(needle)
 
-    best = 0.0
     window = len(needle)
-
-    for start in range(0, len(haystack) - window + 1):
-        segment = haystack[start:start + window]
+    best = 0.0
+    for start in range(0, max(1, len(haystack) - window + 1)):
+        segment = haystack[start : start + window]
         matcher.set_seq1(segment)
         best = max(best, matcher.ratio())
-        if best >= 0.99:
+        if best > 0.98:
             break
+    return best
 
-    return int(round(best * 100))
-
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler("enhanced_field_extractor.log"),
-        logging.StreamHandler()
-    ]
-)
-logger = logging.getLogger("enhanced_field_extractor")
 
 class EnhancedCouponFieldExtractor:
-    """Enhanced field extraction with ML and context awareness."""
-    
-    def __init__(self):
-        """Initialize the enhanced field extractor."""
-        
-        # Store-specific patterns (learned from data)
-        self.store_patterns = {
-            'amazon': {
-                'display_name': 'Amazon',
-                'identifiers': ['amazon', 'amzn', 'amazon.in'],
-                'code_patterns': [r'[A-Z0-9]{8,12}'],
-                'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'save\s*₹(\d+)', r'flat\s*(\d+(?:\.\d+)?)%'],
-                'common_terms': ['prime', 'delivery', 'shopping', 'cart']
-            },
-            'flipkart': {
-                'display_name': 'Flipkart',
-                'identifiers': ['flipkart', 'fkrt', 'flipkart.com'],
-                'code_patterns': [r'[A-Z]{2,4}\d{4,8}', r'FK[A-Z0-9]{6,10}'],
-                'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'extra\s*(\d+(?:\.\d+)?)%', r'flat\s*₹(\d+)'],
-                'common_terms': ['plus', 'supercoins', 'delivery', 'exchange']
-            },
-            'myntra': {
-                'display_name': 'Myntra',
-                'identifiers': ['myntra', 'myntra.com'],
-                'code_patterns': [r'[A-Z]{3,5}\d{3,6}', r'MYNTRA[0-9]{4,8}'],
-                'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'flat\s*(\d+(?:\.\d+)?)%', r'buy\s*\d+\s*get\s*\d+'],
-                'common_terms': ['fashion', 'style', 'brands', 'clothing']
-            },
-            'puma': {
-                'display_name': 'PUMA',
-                'identifiers': ['puma', 'puma.com', 'puma.in'],
-                'code_patterns': [r'[A-Z0-9]{6,12}'],
-                'discount_patterns': [
-                    r'(?:up\s*to|upto)\s*(\d+(?:\.\d+)?)%\s*(?:off|discount)',
-                    r'extra\s*(\d+(?:\.\d+)?)%\s*(?:off|discount)'
-                ],
-                'common_terms': ['sneakers', 'sports', 'athleisure', 'store']
-            },
-            'swiggy': {
-                'display_name': 'Swiggy',
-                'identifiers': ['swiggy', 'swiggy.com'],
-                'code_patterns': [r'[A-Z]{4,6}\d{2,4}', r'SWIGGY[0-9]{3,6}'],
-                'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'flat\s*₹(\d+)', r'free\s*delivery'],
-                'common_terms': ['food', 'delivery', 'restaurant', 'order']
-            },
-            'zomato': {
-                'display_name': 'Zomato',
-                'identifiers': ['zomato', 'zomato.com'],
-                'code_patterns': [r'[A-Z]{4,6}\d{2,4}', r'ZOMATO[0-9]{3,6}'],
-                'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'flat\s*₹(\d+)', r'free\s*delivery'],
-                'common_terms': ['food', 'delivery', 'dining', 'restaurant']
-            },
-            'aha': {
-                'display_name': 'Aha',
-                'identifiers': ['aha'],
-                'code_patterns': [],
-                'discount_patterns': [r'flat\s*(\d+(?:\.\d+)?)%'],
-                'common_terms': ['telugu', 'plan', 'subscription']
-            }
-        }
-        
-        # Common coupon code patterns
-        self.general_code_patterns = [
-            r'\b[A-Za-z]{3,6}\d{2,6}\b',  # 3-6 letters + 2-6 digits
-            r'\b[A-Za-z]{2,4}[0-9]{4,8}\b',  # Letters + numbers
-            r'\b[A-Za-z0-9]{6,12}\b',     # 6-12 alphanumeric
-            r'\bCODE\s*[A-Za-z0-9]{4,10}\b',  # CODE prefix
-            r'\bUSE\s*[A-Za-z0-9]{4,10}\b',   # USE prefix
-        ]
-        
-        # Discount patterns with confidence scoring
-        self.discount_phrase_patterns = [
-            r'(?:up\s*to|upto)\s*\d+(?:\.\d+)?%[^\w]*(?:off|discount)',
-            r'extra\s*\d+(?:\.\d+)?%[^\w]*(?:off|discount)',
-            r'flat\s*\d+(?:\.\d+)?%[^\w]*(?:off|discount)',
-            r'\d+(?:\.\d+)?%[^\w]*(?:off|discount)'
-        ]
+    """Rule-driven coupon field extractor with lightweight heuristics."""
 
-        self.discount_patterns = [
-            (r'(\d+(?:\.\d+)?)%\s*(?:off|discount)', 0.9, 'percentage'),
-            (r'flat\s*(\d+(?:\.\d+)?)%\s*(?:off|discount)', 0.9, 'percentage'),
-            (r'extra\s*(\d+(?:\.\d+)?)%\s*(?:off|discount)', 0.85, 'percentage'),
-            (r'upto\s*(\d+(?:\.\d+)?)%\s*(?:off|discount)', 0.8, 'percentage'),
-            (r'save\s*₹(\d+)', 0.9, 'amount'),
-            (r'flat\s*₹(\d+)\s*(?:off|discount)', 0.9, 'amount'),
-            (r'₹(\d+)\s*(?:off|discount)', 0.8, 'amount'),
-            (r'rs\.?\s*(\d+)\s*(?:off|discount)', 0.8, 'amount'),
-            (r'get\s*₹(\d+)\s*(?:back|cashback)', 0.85, 'cashback'),
-            (r'(?<!%)\b(\d+)\s*(?:off|discount|cashback)', 0.75, 'amount'),
-        ]
-        
-        # Expiry date patterns
-        self.expiry_patterns = [
-            (r'valid\s*(?:till|until)\s*(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})', 0.9),
-            (r'expires?\s*(?:on|at)?\s*(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})', 0.9),
-            (r'expiry\s*:?\s*(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})', 0.9),
-            (r'valid\s*(?:till|until)\s*(\d{1,2}(?:st|nd|rd|th)?\s+\w+,?\s+\d{2,4}(?:,?\s*\d{1,2}:\d{2}\s*(?:am|pm))?)', 0.95),
-            (r'expires?\s*(?:on|at)?\s*(\d{1,2}(?:st|nd|rd|th)?\s+\w+,?\s+\d{2,4}(?:,?\s*\d{1,2}:\d{2}\s*(?:am|pm))?)', 0.95),
-            (r'(\d{1,2}(?:st|nd|rd|th)?\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*\s+\d{2,4})', 0.85),
-        ]
-        
-        # Minimum order patterns
-        self.min_order_patterns = [
-            (r'min(?:imum)?\s*order\s*₹(\d+)', 0.9),
-            (r'min(?:imum)?\s*order\s*rs\.?\s*(\d+)', 0.9),
-            (r'order\s*above\s*₹(\d+)', 0.85),
-            (r'order\s*above\s*rs\.?\s*(\d+)', 0.85),
-            (r'minimum\s*purchase\s*₹(\d+)', 0.8),
-        ]
-        
-        # Initialize confidence threshold
-        self.confidence_threshold = 0.7
-        
-        logger.info("Enhanced field extractor initialized")
-    
-    def extract_fields_with_confidence(self, text: str) -> Dict:
-        """Extract all coupon fields with confidence scores.
-        
-        Args:
-            text (str): OCR extracted text
-            
-        Returns:
-            Dict: Extracted fields with confidence scores
-        """
-        text_clean = self._clean_text(text)
-        
-        # Detect store first to apply store-specific patterns
-        store_info = self._detect_store(text_clean)
-        
-        # Extract all fields
-        fields = {
-            'store': store_info,
-            'coupon_code': self._extract_coupon_code(text_clean, store_info),
-            'discount': self._extract_discount(text_clean),
-            'expiry_date': self._extract_expiry_date(text_clean),
-            'min_order': self._extract_min_order(text_clean),
-            'description': self._extract_description(text_clean),
-            'terms': self._extract_terms(text_clean)
+    def __init__(self) -> None:
+        self.general_code_patterns: Tuple[str, ...] = (
+            r"\b[A-Z0-9]{6,12}\b",
+            r"\b[A-Za-z0-9]{4,12}(?=\s*(?:code|coupon))",
+        )
+        logger.debug("EnhancedCouponFieldExtractor initialised")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def extract_fields_with_confidence(self, text: str) -> Dict[str, Dict[str, object]]:
+        cleaned = self._clean_text(text)
+
+        store = self._detect_store(cleaned)
+        discount = self._extract_discount(cleaned)
+        expiry = self._extract_expiry_date(cleaned)
+        coupon_code = self._extract_coupon_code(cleaned, store)
+        min_order = self._extract_min_order(cleaned)
+        description = self._extract_description(cleaned)
+        terms = self._extract_terms(cleaned)
+
+        fields: Dict[str, Dict[str, object]] = {
+            "store": store,
+            "discount": discount,
+            "coupon_code": coupon_code,
+            "expiry_date": expiry,
+            "min_order": min_order,
+            "description": description,
+            "terms": terms,
         }
-        
-        # Calculate overall confidence
-        confidences = [field.get('confidence', 0) for field in fields.values() if isinstance(field, dict)]
+
+        confidences = [
+            value.get("confidence", 0.0)
+            for value in fields.values()
+            if isinstance(value, dict)
+        ]
         overall_confidence = sum(confidences) / len(confidences) if confidences else 0.0
-        
-        fields['overall_confidence'] = overall_confidence
-        fields['extraction_metadata'] = {
-            'text_length': len(text),
-            'processed_text_length': len(text_clean),
-            'store_detected': store_info.get('confidence', 0) > 0.5,
-            'fields_extracted': sum(1 for field in fields.values() 
-                                  if isinstance(field, dict) and field.get('confidence', 0) > self.confidence_threshold)
+        fields["overall_confidence"] = overall_confidence
+
+        metadata = {
+            "text_length": len(text),
+            "processed_text_length": len(cleaned),
+            "store_detected": store.get("confidence", 0.0) >= 0.5,
+            "fields_extracted": sum(1 for c in confidences if c >= 0.7),
         }
-        
+        fields["extraction_metadata"] = metadata
         return fields
-    
+
+    # ------------------------------------------------------------------
+    # Cleaning utilities
+    # ------------------------------------------------------------------
     def _clean_text(self, text: str) -> str:
-        """Clean and normalize text for processing.
-        
-        Args:
-            text (str): Raw text
-            
-        Returns:
-            str: Cleaned text
-        """
-        # Remove extra whitespace
-        cleaned = re.sub(r'\s+', ' ', text.strip())
-        
-        # Normalize currency symbols
-        cleaned = re.sub(r'rs\.?|rupees?', '₹', cleaned, flags=re.IGNORECASE)
-        
-        # Normalize common terms
-        cleaned = re.sub(r'\boff\b', 'off', cleaned, flags=re.IGNORECASE)
-        cleaned = re.sub(r'\bdiscount\b', 'discount', cleaned, flags=re.IGNORECASE)
-        
+        if not text:
+            return ""
+
+        cleaned = text.strip()
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        cleaned = re.sub(r"rs\.?", "₹", cleaned, flags=re.IGNORECASE)
+        cleaned = cleaned.replace("₹ ", "₹")
         return cleaned
-    
-    def _detect_store(self, text: str) -> Dict:
-        """Detect store name with confidence.
-        
-        Args:
-            text (str): Cleaned text
-            
-        Returns:
-            Dict: Store detection result
-        """
-        text_lower = text.lower()
-        best_match = {'name': None, 'confidence': 0.0, 'type': 'unknown', 'key': None}
-        
-        for store_name, store_data in self.store_patterns.items():
-            confidence = 0.0
-            
-            # Check direct identifiers
-            for identifier in store_data['identifiers']:
-                if identifier in text_lower:
-                    confidence = max(confidence, 0.9)
-            
-            # Check common terms (weighted less)
-            term_matches = sum(1 for term in store_data['common_terms'] if term in text_lower)
-            if term_matches > 0:
-                confidence = max(confidence, 0.3 + (term_matches * 0.1))
-            
-            # Use fuzzy matching for partial matches
-            for identifier in store_data['identifiers']:
-                ratio = _partial_ratio(identifier, text_lower)
-                if ratio > 80:
-                    confidence = max(confidence, ratio / 100.0 * 0.8)
-            
-            if confidence > best_match['confidence']:
-                best_match = {
-                    'name': store_data.get('display_name', store_name),
-                    'confidence': confidence,
-                    'type': 'identified',
-                    'key': store_name
-                }
-        
-        # If no store detected, try to extract any brand-like words
-        if best_match['confidence'] < 0.5:
-            # Try to capture "at <Brand>" constructs first
-            location_patterns = [
-                r'(?:at|@)\s+([A-Z][A-Za-z&]*(?:\s+[A-Z][A-Za-z&]*){0,2})',
-                r'(?:from)\s+([A-Z][A-Za-z&]*(?:\s+[A-Z][A-Za-z&]*){0,2})',
-            ]
-            location_candidates: List[Tuple[str, int]] = []
-            generic_suffixes = re.compile(
-                r'\b(store|stores|shop|shops|outlet|outlets|mall|malls|retail|online|sale|offer)s?\b',
-                re.IGNORECASE
-            )
 
-            trailing_tokens = {
-                'code', 'codes', 'coupon', 'coupons', 'promo', 'promocode',
-                'deal', 'deals', 'offer', 'offers', 'use'
-            }
-            skip_tokens = {'the', 'at', 'and'} | trailing_tokens
-
-            for pattern in location_patterns:
-                for match in re.finditer(pattern, text):
-                    candidate = match.group(1).strip()
-                    candidate = generic_suffixes.sub('', candidate).strip()
-                    candidate = re.sub(r'\s{2,}', ' ', candidate)
-                    if candidate:
-                        words = candidate.split()
-                        cleaned_words = []
-                        for word in words:
-                            cleaned_word = word.rstrip(':,.')
-                            if cleaned_word.lower() in skip_tokens:
-                                continue
-                            cleaned_words.append(cleaned_word)
-
-                        while cleaned_words and cleaned_words[-1].lower() in trailing_tokens:
-                            cleaned_words.pop()
-                        if cleaned_words:
-                            cleaned = ' '.join(cleaned_words)
-                            location_candidates.append((cleaned, match.start()))
-
-            if location_candidates:
-                # Prefer the candidate that appears first but prioritise longer names
-                location_candidates.sort(key=lambda item: (-len(item[0]), item[1]))
-                best_match = {
-                    'name': location_candidates[0][0].strip(),
-                    'confidence': 0.45,
-                    'type': 'extracted',
-                    'key': None
-                }
-            else:
-                brand_patterns = [
-                    r'\b[A-Z][a-z]+\s*(?:\.com|\.in)?\b',  # Domain-like
-                    r'\b[A-Z]{2,8}\b'  # All caps words
-                ]
-
-                stopwords = {'redeem', 'super', 'mega', 'offer', 'offers', 'coupon', 'coupons', 'code', 'codes', 'use', 'multi',
-                             'valid', 'expires', 'get', 'save', 'extra', 'flat', 'cashback', 'discount'}
-
-                selected = None
-                for pattern in brand_patterns:
-                    matches = re.findall(pattern, text)
-                    if not matches:
-                        continue
-
-                    for match in matches:
-                        candidate = match.strip()
-                        if candidate.lower() in stopwords:
-                            continue
-                        selected = candidate
-                        break
-
-                    if selected:
-                        break
-
-                if selected:
-                    best_match = {
-                        'name': selected,
-                        'confidence': 0.4,
-                        'type': 'extracted',
-                        'key': None
-                    }
-                else:
-                    lowercase_stopwords = stopwords | {'purchase', 'details', 'terms', 'condition', 'conditions', 'plan',
-                                                       'plans', 'annual', 'telugu', 'unknown', 'couponcode', 'code'}
-
-                    words = re.findall(r'\b[a-z]{3,}\b', text_lower)
-                    frequency: Dict[str, int] = {}
-                    for word in words:
-                        if word in lowercase_stopwords:
-                            continue
-                        frequency[word] = frequency.get(word, 0) + 1
-
-                    if frequency:
-                        candidate_word, count = max(frequency.items(), key=lambda item: (item[1], len(item[0])))
-                        if count > 1:
-                            match = re.search(r'\b' + re.escape(candidate_word) + r'\b', text, re.IGNORECASE)
-                            name = match.group(0) if match else candidate_word
-                            best_match = {
-                                'name': name,
-                                'confidence': 0.38,
-                                'type': 'extracted',
-                                'key': None
-                            }
-
-        return best_match
-    
-    def _extract_coupon_code(self, text: str, store_info: Dict) -> Dict:
-        """Extract coupon code with confidence.
-        
-        Args:
-            text (str): Cleaned text
-            store_info (Dict): Store detection result
-            
-        Returns:
-            Dict: Coupon code extraction result
-        """
-        candidates = []
-        
-        # Try store-specific patterns first
-        store_key = store_info.get('key')
-        if store_key and store_key in self.store_patterns:
-            store_patterns = self.store_patterns[store_key]['code_patterns']
-            for pattern in store_patterns:
-                matches = re.findall(pattern, text, re.IGNORECASE)
-                for match in matches:
-                    if not self._is_plausible_code(match):
-                        continue
-                    candidates.append({
-                        'code': match,
-                        'confidence': 0.9,
-                        'source': 'store_specific'
-                    })
-        
-        # Try general patterns
-        for pattern in self.general_code_patterns:
-            matches = re.findall(pattern, text, re.IGNORECASE)
-            for match in matches:
-                if not self._is_plausible_code(match):
-                    continue
-                if not self._is_likely_false_positive(match):
-                    candidates.append({
-                        'code': match,
-                        'confidence': 0.7,
-                        'source': 'general_pattern'
-                    })
-        
-        # Look for explicit code indicators
-        code_indicator_patterns = [
-            r'(?:code|coupon)\s*:?\s*([A-Za-z0-9]{4,12})',
-            r'use\s+(?:code\s+)?([A-Za-z0-9]{4,12})',
-            r'promo\s*code\s*:?\s*([A-Za-z0-9]{4,12})'
-        ]
-        
-        for pattern in code_indicator_patterns:
-            matches = re.findall(pattern, text, re.IGNORECASE)
-            for match in matches:
-                if not self._is_plausible_code(match):
-                    continue
-                if self._is_likely_false_positive(match):
-                    continue
-                candidates.append({
-                    'code': match,
-                    'confidence': 0.95,
-                    'source': 'explicit_indicator'
-                })
-        
-        # Select best candidate
-        if candidates:
-            best_candidate = max(candidates, key=lambda x: x['confidence'])
-            return best_candidate
-        
-        return {'code': None, 'confidence': 0.0, 'source': 'none'}
-    
-    def _extract_discount(self, text: str) -> Dict:
-        """Extract discount information with confidence.
-        
-        Args:
-            text (str): Cleaned text
-            
-        Returns:
-            Dict: Discount extraction result
-        """
-        best_match = {
-            'value': None,
-            'type': None,
-            'confidence': 0.0,
-            'raw_text': None,
-            'text': None,
-            'components': []
+    # ------------------------------------------------------------------
+    # Store detection
+    # ------------------------------------------------------------------
+    def _detect_store(self, text: str) -> Dict[str, object]:
+        lowered = text.lower()
+        best_match: Dict[str, object] = {
+            "name": None,
+            "confidence": 0.0,
+            "type": "unknown",
+            "key": None,
         }
 
-        # First try to capture composite discount phrases like
-        # "Up to 50% off + Extra 33% off"
-        phrase_matches: List[Tuple[int, str]] = []
-        for pattern in self.discount_phrase_patterns:
-            for match in re.finditer(pattern, text, re.IGNORECASE):
-                phrase_matches.append((match.start(), match.group(0)))
-
-        if phrase_matches:
-            phrase_matches.sort(key=lambda item: item[0])
-            normalized_phrases: List[str] = []
-
-            for _, phrase in phrase_matches:
-                normalized = re.sub(r'\s+', ' ', phrase.strip(' ,;:+-*')).strip()
-                normalized = normalized.lower().replace('upto', 'up to')
-                normalized = re.sub(r'(\d+)\.0+%', r'\1%', normalized)
-                if normalized and normalized not in normalized_phrases:
-                    normalized_phrases.append(normalized)
-
-            if normalized_phrases:
-                filtered_phrases = []
-                for phrase in normalized_phrases:
-                    if any(phrase != other and phrase in other for other in normalized_phrases):
-                        continue
-                    filtered_phrases.append(phrase)
-                normalized_phrases = filtered_phrases
-
-            if normalized_phrases:
-                pretty_phrases = []
-                for phrase in normalized_phrases:
-                    pretty = phrase
-                    pretty = re.sub(r'\bup to\b', 'Up to', pretty)
-                    pretty = re.sub(r'\bextra\b', 'Extra', pretty)
-                    pretty = re.sub(r'\bflat\b', 'Flat', pretty)
-                    pretty = re.sub(r'\boff\b', 'Off', pretty)
-                    pretty = re.sub(r'(\d+)\.0+%', r'\1%', pretty)
-                    pretty_phrases.append(pretty)
-
-                combined_phrase = ' + '.join(pretty_phrases)
-                percentages = [
-                    float(num)
-                    for phrase in normalized_phrases
-                    for num in re.findall(r'(\d+(?:\.\d+)?)%', phrase)
-                ]
-
-                if percentages:
-                    max_value = max(percentages)
-                    if abs(max_value - int(max_value)) < 1e-6:
-                        max_value = int(max_value)
-                    best_match = {
-                        'value': max_value,
-                        'type': 'percentage',
-                        'confidence': 0.92,
-                        'raw_text': combined_phrase,
-                        'text': combined_phrase,
-                        'components': pretty_phrases
-                    }
-
-        for pattern, confidence, discount_type in self.discount_patterns:
-            for match in re.finditer(pattern, text, re.IGNORECASE):
-                try:
-                    groups = match.groups()
-                    value_str = None
-                    if groups:
-                        for group in groups:
-                            if group and group.strip().replace('.', '', 1).isdigit():
-                                value_str = group
-                                break
-                    if value_str is None:
-                        digits = re.search(r'\d+', match.group(0))
-                        value_str = digits.group(0) if digits else None
-
-                    if not value_str:
-                        continue
-
-                    if '.' in value_str:
-                        value = float(value_str)
-                    else:
-                        value = int(value_str)
-
-                    raw_text = re.sub(r'\s+', ' ', match.group(0).strip())
-                    raw_text = re.sub(r'(\d+)\.0+%', r'\1%', raw_text)
-                    normalized_text = raw_text
-
-                    # If the raw text contains a percentage symbol, ensure we treat it as percentage
-                    normalized_type = 'percentage' if '%' in raw_text else discount_type
-
-                    # Validate reasonable discount values
-                    if normalized_type == 'percentage':
-                        numeric_value = float(value)
-                        if 1 <= numeric_value <= 99:
-                            output_value = int(numeric_value) if abs(numeric_value - int(numeric_value)) < 1e-6 else numeric_value
-                            if confidence > best_match['confidence']:
-                                best_match = {
-                                    'value': output_value,
-                                    'type': 'percentage',
-                                    'confidence': confidence,
-                                    'raw_text': normalized_text,
-                                    'text': normalized_text,
-                                    'components': [normalized_text]
-                                }
-                    elif normalized_type in ['amount', 'cashback']:
-                        numeric_value = float(value)
-                        if 10 <= numeric_value <= 10000:
-                            output_value = int(numeric_value) if abs(numeric_value - int(numeric_value)) < 1e-6 else numeric_value
-                            if confidence > best_match['confidence']:
-                                best_match = {
-                                    'value': output_value,
-                                    'type': normalized_type,
-                                    'confidence': confidence,
-                                    'raw_text': normalized_text,
-                                    'text': normalized_text,
-                                    'components': [normalized_text]
-                                }
-
-                except (ValueError, IndexError):
-                    continue
-
-        return best_match
-    
-    def _extract_expiry_date(self, text: str) -> Dict:
-        """Extract expiry date with confidence.
-        
-        Args:
-            text (str): Cleaned text
-            
-        Returns:
-            Dict: Expiry date extraction result
-        """
-        best_match = {'date': None, 'confidence': 0.0, 'raw_text': None, 'parsed_date': None, 'is_expired': None}
-        
-        for pattern, confidence in self.expiry_patterns:
-            matches = re.findall(pattern, text, re.IGNORECASE)
-            for match in matches:
-                parsed_date = self._parse_expiry_candidate(match)
-
-                if parsed_date:
-                    is_expired = parsed_date.date() < datetime.now().date()
-                    effective_confidence = confidence
-
-                    if effective_confidence > best_match['confidence']:
-                        best_match = {
-                            'date': match,
-                            'confidence': effective_confidence,
-                            'raw_text': match,
-                            'parsed_date': parsed_date.isoformat(),
-                            'is_expired': is_expired
-                        }
+        for key, profile in STORE_PROFILES.items():
+            confidence = 0.0
+            for identifier in profile.get("identifiers", []):
+                if identifier and identifier.lower() in lowered:
+                    confidence = max(confidence, 0.9)
                 else:
-                    if confidence * 0.5 > best_match['confidence']:
-                        best_match = {
-                            'date': match,
-                            'confidence': confidence * 0.5,
-                            'raw_text': match,
-                            'parsed_date': None,
-                            'is_expired': None
-                        }
+                    ratio = _partial_ratio(identifier, lowered)
+                    confidence = max(confidence, 0.65 * ratio)
+
+            if confidence > best_match["confidence"]:
+                best_match = {
+                    "name": profile.get("display_name", key.title()),
+                    "confidence": confidence,
+                    "type": "identified",
+                    "key": key,
+                }
+
+        if best_match["confidence"] >= 0.5:
+            return best_match
+
+        candidate = self._extract_store_from_location(text)
+        if candidate:
+            return candidate
+
+        fallback = self._most_frequent_capitalised_word(text)
+        if fallback:
+            return fallback
 
         return best_match
 
-    def _parse_expiry_candidate(self, value: str) -> Optional[datetime]:
-        """Parse a matched expiry string using known date formats."""
+    def _extract_store_from_location(self, text: str) -> Optional[Dict[str, object]]:
+        location_patterns = (
+            r"(?:redeem|shop|buy|available|only)\s+at\s+([A-Z][A-Za-z&]*(?:\s+[A-Z][A-Za-z&]*){0,2})",
+            r"(?:at|from)\s+([A-Z][A-Za-z&]*(?:\s+[A-Z][A-Za-z&]*){0,2})",
+        )
 
-        if not value:
+        candidates: List[Tuple[str, float, int]] = []
+        for pattern in location_patterns:
+            for match in re.finditer(pattern, text):
+                raw = match.group(1).strip()
+                words = raw.split()
+                cleaned_words: List[str] = []
+                for word in words:
+                    normalised = word.rstrip(":,.")
+                    if normalised.lower() in TRAILING_STORE_TOKENS:
+                        break
+                    cleaned_words.append(normalised)
+                if not cleaned_words:
+                    continue
+                candidate = " ".join(cleaned_words)
+                score = 0.45 + 0.05 * (len(cleaned_words) - 1)
+                candidates.append((candidate, min(score, 0.6), match.start()))
+
+        if not candidates:
             return None
 
-        normalized = value.strip()
-        normalized = re.sub(r'(\d{1,2})(st|nd|rd|th)', r'\1', normalized, flags=re.IGNORECASE)
-        normalized = re.sub(r'\s+', ' ', normalized)
-        normalized = re.sub(r'(\d)(am|pm)\b', r'\1 \2', normalized, flags=re.IGNORECASE)
+        candidates.sort(key=lambda item: (-item[1], -len(item[0]), item[2]))
+        best_name, score, _ = candidates[0]
+        return {
+            "name": best_name,
+            "confidence": score,
+            "type": "extracted",
+            "key": None,
+        }
 
-        lowered = normalized.lower()
+    def _most_frequent_capitalised_word(self, text: str) -> Optional[Dict[str, object]]:
+        tokens = re.findall(r"\b[A-Za-z][A-Za-z&]{2,}\b", text)
+        counts: Dict[str, int] = {}
+        for token in tokens:
+            lower = token.lower()
+            if lower in STORE_STOPWORDS:
+                continue
+            counts[token] = counts.get(token, 0) + 1
+        if not counts:
+            return None
+        selected = max(counts.items(), key=lambda item: (item[1], len(item[0])))
+        if selected[1] < 2:
+            return None
+        return {
+            "name": selected[0],
+            "confidence": 0.38,
+            "type": "extracted",
+            "key": None,
+        }
+
+    # ------------------------------------------------------------------
+    # Coupon code extraction
+    # ------------------------------------------------------------------
+    def _extract_coupon_code(self, text: str, store: Dict[str, object]) -> Dict[str, object]:
+        candidates: List[Dict[str, object]] = []
+
+        store_key = store.get("key")
+        if store_key and store_key in STORE_PROFILES:
+            for pattern in STORE_PROFILES[store_key].get("code_patterns", []):
+                for match in re.findall(pattern, text, flags=re.IGNORECASE):
+                    if self._is_plausible_code(match):
+                        candidates.append(
+                            {
+                                "code": match,
+                                "confidence": 0.9,
+                                "source": "store_pattern",
+                            }
+                        )
+
+        for pattern in EXPLICIT_CODE_PATTERNS:
+            for match in re.findall(pattern, text, flags=re.IGNORECASE):
+                if self._is_plausible_code(match):
+                    candidates.append(
+                        {
+                            "code": match,
+                            "confidence": 0.95,
+                            "source": "explicit_indicator",
+                        }
+                    )
+
+        for pattern in self.general_code_patterns:
+            for match in re.findall(pattern, text):
+                if self._is_plausible_code(match):
+                    candidates.append(
+                        {
+                            "code": match,
+                            "confidence": 0.7,
+                            "source": "general_pattern",
+                        }
+                    )
+
+        if not candidates:
+            return {"code": None, "confidence": 0.0, "source": "none"}
+
+        candidates.sort(key=lambda item: (item["confidence"], len(item.get("code", ""))), reverse=True)
+        best = candidates[0].copy()
+        best["code"] = best["code"].strip()
+        return best
+
+    def _is_plausible_code(self, code: str) -> bool:
+        if not code:
+            return False
+        cleaned = code.strip()
+        if len(cleaned) < 4:
+            return False
+        upper = cleaned.upper()
+        if upper in CODE_FALSE_POSITIVES:
+            return False
+        if cleaned.isdigit():
+            return False
+        if cleaned.isalpha() and len(cleaned) < 6:
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Discount extraction
+    # ------------------------------------------------------------------
+    def _extract_discount(self, text: str) -> Dict[str, object]:
+        normalised_text = re.sub(r"upto", "up to", text, flags=re.IGNORECASE)
+        normalised_text = normalised_text.replace("% off", "% Off")
+        normalised_text = normalised_text.replace("*", "")
+
+        composite_match = COMBINED_PERCENT_PATTERN.search(normalised_text)
+        if composite_match:
+            phrase = composite_match.group(0)
+            components = [
+                self._normalise_percentage_component(comp)
+                for comp in PERCENT_COMPONENT_PATTERN.findall(phrase)
+            ]
+            components = [c for c in components if c]
+            if components:
+                value = max(self._percentage_value(component) for component in components)
+                raw_text = " + ".join(components)
+                return {
+                    "type": "percentage",
+                    "value": value,
+                    "confidence": 0.92,
+                    "raw_text": raw_text,
+                    "components": components,
+                }
+
+        single_match = PERCENT_COMPONENT_PATTERN.search(normalised_text)
+        if single_match:
+            component = self._normalise_percentage_component(single_match.group(0))
+            value = self._percentage_value(component)
+            return {
+                "type": "percentage",
+                "value": value,
+                "confidence": 0.85,
+                "raw_text": component,
+                "components": [component],
+            }
+
+        amount_match = AMOUNT_PATTERN.search(text)
+        if amount_match:
+            amount = self._amount_value(amount_match.group(1))
+            raw_text = amount_match.group(0).replace("  ", " ").strip()
+            return {
+                "type": "amount",
+                "value": amount,
+                "confidence": 0.75,
+                "raw_text": raw_text,
+                "components": [raw_text],
+            }
+
+        return {
+            "type": None,
+            "value": None,
+            "confidence": 0.0,
+            "raw_text": None,
+            "components": [],
+        }
+
+    def _normalise_percentage_component(self, component: str) -> str:
+        cleaned = component.strip().replace("*", "")
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        cleaned = re.sub(r"upto", "Up to", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"up\s+to", "Up to", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"flat", "Flat", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"extra", "Extra", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"save", "Save", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"(\d+)\.0%", r"\1%", cleaned)
+        cleaned = re.sub(r"\s*%\s*", "% ", cleaned).replace("% Off", "% Off")
+        cleaned = cleaned.replace("% Discount", "% Discount")
+        if not re.search(r"(Off|Discount)", cleaned, flags=re.IGNORECASE):
+            cleaned = cleaned.rstrip() + " Off"
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        cleaned = cleaned.replace("% Discount", "% Discount")
+        cleaned = cleaned.replace(" %", "%")
+        cleaned = cleaned.replace("Off Off", "Off")
+        cleaned = cleaned.replace("Discount Discount", "Discount")
+        return cleaned
+
+    def _percentage_value(self, component: str) -> int:
+        match = re.search(r"(\d+(?:\.\d+)?)%", component)
+        if not match:
+            return 0
+        return int(round(float(match.group(1))))
+
+    def _amount_value(self, amount: str) -> int:
+        return int(amount.replace(",", ""))
+
+    # ------------------------------------------------------------------
+    # Expiry extraction
+    # ------------------------------------------------------------------
+    def _extract_expiry_date(self, text: str) -> Dict[str, object]:
+        best_candidate: Optional[Tuple[str, float]] = None
+
+        for segment in re.split(r"[\n\.]", text):
+            segment = segment.strip()
+            if not segment:
+                continue
+            lowered = segment.lower()
+            if not any(hint in lowered for hint in EXPIRY_LINE_HINTS):
+                continue
+            candidate = self._find_date_in_segment(segment)
+            if candidate:
+                confidence = 0.95 if "," in candidate or any(x in lowered for x in (",", ":")) else 0.88
+                if not best_candidate or confidence > best_candidate[1]:
+                    best_candidate = (candidate, confidence)
+
+        if not best_candidate:
+            return {"raw_text": None, "parsed_date": None, "confidence": 0.0, "is_expired": False}
+
+        raw_text, confidence = best_candidate
+        parsed = self._parse_date_value(raw_text)
+        parsed_iso = parsed.isoformat() if parsed else None
+        is_expired = False
+        if parsed:
+            is_expired = parsed < datetime.now()
+
+        return {
+            "raw_text": raw_text,
+            "parsed_date": parsed_iso,
+            "confidence": confidence if parsed else confidence * 0.8,
+            "is_expired": is_expired,
+        }
+
+    def _find_date_in_segment(self, segment: str) -> Optional[str]:
+        for pattern in DATE_PATTERNS:
+            match = re.search(pattern, segment, flags=re.IGNORECASE)
+            if match:
+                return match.group(1).strip()
+        return None
+
+    def _parse_date_value(self, value: str) -> Optional[datetime]:
+        cleaned = value.strip()
+        cleaned = re.sub(r"(\d{1,2})(st|nd|rd|th)", r"\1", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        cleaned = re.sub(r"(\d)(am|pm)\b", r"\1 \2", cleaned, flags=re.IGNORECASE)
+        lowered = cleaned.lower()
         for source, target in MONTH_NORMALIZATION.items():
-            lowered = re.sub(r'\b' + re.escape(source) + r'\b', target.lower(), lowered)
-
-        # Restore title case for month tokens
+            lowered = re.sub(r"\b" + re.escape(source) + r"\b", target.lower(), lowered)
         lowered = re.sub(
-            r'\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\b',
+            r"\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\b",
             lambda m: m.group(0).title(),
             lowered,
-            flags=re.IGNORECASE
         )
         lowered = re.sub(
-            r'\b(january|february|march|april|may|june|july|august|september|october|november|december)\b',
+            r"\b(january|february|march|april|may|june|july|august|september|october|november|december)\b",
             lambda m: m.group(0).title(),
             lowered,
-            flags=re.IGNORECASE
         )
-        lowered = re.sub(r'\b(am|pm)\b', lambda m: m.group(0).upper(), lowered, flags=re.IGNORECASE)
-
-        # Remove stray periods after normalization
-        normalized = re.sub(r'\.(?=\s|$)', '', lowered)
+        lowered = re.sub(r"\b(am|pm)\b", lambda m: m.group(0).upper(), lowered)
+        normalized = lowered.replace(" ,", ",")
+        normalized = normalized.replace(",", ", ")
+        normalized = re.sub(r"\s+", " ", normalized).strip()
+        normalized = normalized.replace(" ", " ")
 
         for fmt in EXPIRY_DATE_FORMATS:
             try:
-                parsed = datetime.strptime(normalized, fmt)
-                return parsed
+                return datetime.strptime(normalized, fmt)
             except ValueError:
                 continue
-
         return None
-    
-    def _extract_min_order(self, text: str) -> Dict:
-        """Extract minimum order amount with confidence.
-        
-        Args:
-            text (str): Cleaned text
-            
-        Returns:
-            Dict: Minimum order extraction result
-        """
-        best_match = {'amount': None, 'confidence': 0.0, 'raw_text': None}
-        
-        for pattern, confidence in self.min_order_patterns:
-            matches = re.findall(pattern, text, re.IGNORECASE)
-            for match in matches:
-                try:
-                    amount = int(match)
-                    
-                    # Validate reasonable minimum order amounts
-                    if 50 <= amount <= 50000:
-                        if confidence > best_match['confidence']:
-                            best_match = {
-                                'amount': amount,
-                                'confidence': confidence,
-                                'raw_text': match
-                            }
-                
-                except ValueError:
-                    continue
-        
-        return best_match
-    
-    def _extract_description(self, text: str) -> Dict:
-        """Extract coupon description.
-        
-        Args:
-            text (str): Cleaned text
-            
-        Returns:
-            Dict: Description extraction result
-        """
-        # Look for descriptive phrases
-        description_patterns = [
-            r'(get\s+\w+\s+off\s+on\s+[^.!?]+)',
-            r'(save\s+[^.!?]+)',
-            r'(flat\s+\d+%\s+off\s+on\s+[^.!?]+)',
-            r'(extra\s+\d+%\s+off\s+on\s+[^.!?]+)',
-            r'(free\s+delivery\s+on\s+[^.!?]+)',
-            r'(buy\s+\d+\s+get\s+\d+[^.!?]+)'
-        ]
-        
-        descriptions = []
-        for pattern in description_patterns:
-            matches = re.findall(pattern, text, re.IGNORECASE)
-            descriptions.extend(matches)
-        
-        if descriptions:
-            # Take the longest description
-            best_description = max(descriptions, key=len)
-            return {
-                'text': best_description.strip(),
-                'confidence': 0.8,
-                'source': 'pattern_match'
-            }
-        
-        # Fallback: take first sentence-like structure
-        sentences = re.split(r'[.!?]', text)
-        if sentences:
-            longest_sentence = max(sentences, key=len).strip()
-            if len(longest_sentence) > 20:
-                return {
-                    'text': longest_sentence,
-                    'confidence': 0.5,
-                    'source': 'longest_sentence'
+
+    # ------------------------------------------------------------------
+    # Minimum order
+    # ------------------------------------------------------------------
+    def _extract_min_order(self, text: str) -> Dict[str, object]:
+        best: Dict[str, object] = {"amount": None, "confidence": 0.0, "raw_text": None}
+        for pattern, confidence in MIN_ORDER_PATTERNS:
+            match = pattern.search(text)
+            if not match:
+                continue
+            amount = self._amount_value(match.group(1))
+            if amount < 50 or amount > 50000:
+                continue
+            if confidence > best["confidence"]:
+                best = {
+                    "amount": amount,
+                    "confidence": confidence,
+                    "raw_text": match.group(0).strip(),
                 }
-        
-        return {'text': None, 'confidence': 0.0, 'source': 'none'}
-    
-    def _extract_terms(self, text: str) -> Dict:
-        """Extract terms and conditions.
-        
-        Args:
-            text (str): Cleaned text
-            
-        Returns:
-            Dict: Terms extraction result
-        """
-        terms_keywords = [
-            'terms', 'conditions', 'applicable', 'valid', 'offer',
-            'cannot be combined', 'not applicable', 'restrictions',
-            'one time use', 'limited period', 'purchase', 'plan'
-        ]
+        return best
 
-        sentences = [s.strip() for s in re.split(r'[.!?]', text) if s.strip()]
-        collected_terms: List[str] = []
+    # ------------------------------------------------------------------
+    # Description and terms
+    # ------------------------------------------------------------------
+    def _extract_description(self, text: str) -> Dict[str, object]:
+        description_patterns = (
+            r"(get\s+[^.?!]+off[^.?!]*)",
+            r"(save\s+[^.?!]+)",
+            r"(free\s+delivery[^.?!]*)",
+            r"(buy\s+\d+\s+get\s+\d+[^.?!]*)",
+        )
+        for pattern in description_patterns:
+            match = re.search(pattern, text, flags=re.IGNORECASE)
+            if match:
+                snippet = match.group(1).strip()
+                return {"text": snippet, "confidence": 0.75, "source": "pattern"}
 
+        sentences = [s.strip() for s in re.split(r"[.!?]", text) if s.strip()]
+        if sentences:
+            longest = max(sentences, key=len)
+            if len(longest) > 20:
+                return {"text": longest, "confidence": 0.5, "source": "fallback"}
+        return {"text": None, "confidence": 0.0, "source": "none"}
+
+    def _extract_terms(self, text: str) -> Dict[str, object]:
+        sentences = [s.strip() for s in re.split(r"[.!?]", text) if s.strip()]
+        collected: List[str] = []
+
+        keywords = ("terms", "condition", "applicable", "valid", "plan", "subscription", "purchase")
         for sentence in sentences:
-            lower_sentence = sentence.lower()
-            if any(keyword in lower_sentence for keyword in terms_keywords):
-                collected_terms.append(sentence)
-
-        amount_pattern = re.compile(r'₹\s*(\d+(?:,\d{3})*)')
-        for sentence in sentences:
-            lower_sentence = sentence.lower()
-            amounts = amount_pattern.findall(sentence)
-            if amounts and ('plan' in lower_sentence or 'subscription' in lower_sentence or 'purchase' in lower_sentence):
-                descriptor_match = re.search(r'([A-Za-z&\s]{3,}?\bplan[s]?)', sentence, re.IGNORECASE)
-                if descriptor_match:
-                    descriptor = descriptor_match.group(1).strip()
-                else:
-                    descriptor = 'this offer'
-
+            lowered = sentence.lower()
+            if any(keyword in lowered for keyword in keywords):
+                amounts = re.findall(r"₹\s*(\d+(?:,\d{3})*)", sentence)
                 unique_amounts: List[str] = []
                 for amount in amounts:
-                    normalized_amount = amount.replace(',', '')
-                    if normalized_amount not in unique_amounts:
-                        unique_amounts.append(normalized_amount)
+                    normalized = amount.replace(",", "")
+                    if normalized not in unique_amounts:
+                        unique_amounts.append(normalized)
+                if unique_amounts:
+                    descriptor_match = re.search(r"([A-Za-z& ]{3,}?Plan[s]?)", sentence, flags=re.IGNORECASE)
+                    descriptor = descriptor_match.group(1).strip() if descriptor_match else "this offer"
+                    formatted_amounts = ", ".join(f"₹{amt}" for amt in unique_amounts)
+                    formatted = f"Valid on {descriptor} of {formatted_amounts}"
+                    if formatted not in collected:
+                        collected.append(formatted)
+                else:
+                    collected.append(sentence)
 
-                formatted_amounts = ', '.join(f'₹{amt}' for amt in unique_amounts)
-                formatted_sentence = f"Valid on {descriptor} of {formatted_amounts}"
+        if collected:
+            return {"text": ". ".join(collected), "confidence": 0.7, "source": "keyword"}
+        return {"text": None, "confidence": 0.0, "source": "none"}
 
-                if formatted_sentence not in collected_terms:
-                    collected_terms.append(formatted_sentence)
+    # ------------------------------------------------------------------
+    # Validation helper (optional public API)
+    # ------------------------------------------------------------------
+    def validate_extracted_fields(self, fields: Dict[str, Dict[str, object]]) -> Dict[str, object]:
+        validated = dict(fields)
+        discount = fields.get("discount", {})
+        expiry = fields.get("expiry_date", {})
+        store = fields.get("store", {})
+        code = fields.get("coupon_code", {})
 
-        if collected_terms:
-            return {
-                'text': '. '.join(collected_terms),
-                'confidence': 0.7,
-                'source': 'keyword_match'
-            }
+        overall = fields.get("overall_confidence", 0.0)
+        if expiry.get("parsed_date") and expiry.get("confidence", 0.0) >= 0.7:
+            overall = min(1.0, overall + 0.1)
+        if store.get("confidence", 0.0) >= 0.7 and code.get("confidence", 0.0) >= 0.7:
+            overall = min(1.0, overall + 0.15)
+        if discount.get("type") == "percentage" and (discount.get("value") or 0) > 90:
+            discount_conf = discount.get("confidence", 0.0) * 0.7
+            validated.setdefault("discount", discount).update({"confidence": discount_conf})
 
-        return {'text': None, 'confidence': 0.0, 'source': 'none'}
-    
-    def _is_plausible_code(self, code: str) -> bool:
-        """Determine if a detected token looks like a real coupon code."""
-
-        cleaned = code.strip()
-        if not cleaned:
-            return False
-
-        if any(char.isdigit() for char in cleaned):
-            return True
-
-        if cleaned.isalpha() and len(cleaned) >= 6:
-            return True
-
-        return False
-
-    def _is_likely_false_positive(self, code: str) -> bool:
-        """Check if a potential code is likely a false positive."""
-
-        cleaned = code.strip()
-        if not cleaned:
-            return True
-
-        upper_code = cleaned.upper()
-
-        if cleaned.isdigit():
-            return True
-
-        generic_words = {
-            'CODE', 'COUPON', 'OFFER', 'DEAL', 'SAVE', 'FREE', 'EXTRA',
-            'FLAT', 'DISCOUNT', 'SHOP', 'STORE', 'SUPER', 'SPECIAL'
+        validated["overall_confidence"] = overall
+        validated["validation_flags"] = {
+            "has_essential_fields": code.get("confidence", 0.0) >= 0.5
+            or discount.get("confidence", 0.0) >= 0.5,
+            "has_store_info": store.get("confidence", 0.0) >= 0.5,
+            "has_expiry_info": expiry.get("confidence", 0.0) >= 0.5,
+            "overall_quality": "high"
+            if overall > 0.8
+            else "medium" if overall > 0.5 else "low",
         }
-
-        if upper_code in generic_words:
-            return True
-
-        store_names = {'AMAZON', 'FLIPKART', 'MYNTRA', 'SWIGGY', 'ZOMATO', 'AHA', 'PUMA'}
-        if upper_code in store_names:
-            return True
-
-        cities = {'INDIA', 'DELHI', 'MUMBAI', 'BANGALORE', 'CHENNAI', 'HYDERABAD'}
-        if upper_code in cities:
-            return True
-
-        weekdays = {
-            'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY'
-        }
-        if upper_code in weekdays:
-            return True
-
-        months = {
-            'JANUARY', 'FEBRUARY', 'MARCH', 'APRIL', 'MAY', 'JUNE',
-            'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER',
-            'JAN', 'FEB', 'MAR', 'APR', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'
-        }
-        if upper_code in months:
-            return True
-
-        if cleaned.isalpha() and len(cleaned) <= 4:
-            return True
-
-        return False
-    
-    def validate_extracted_fields(self, fields: Dict) -> Dict:
-        """Validate and cross-check extracted fields.
-        
-        Args:
-            fields (Dict): Extracted fields
-            
-        Returns:
-            Dict: Validated fields with updated confidence scores
-        """
-        validated = fields.copy()
-        
-        # Cross-validation rules
-        
-        # 1. If expiry date is detected and parsed, boost overall confidence
-        if (fields['expiry_date'].get('parsed_date') and 
-            fields['expiry_date'].get('confidence', 0) > 0.7):
-            validated['overall_confidence'] = min(1.0, validated['overall_confidence'] + 0.1)
-        
-        # 2. If store and coupon code are both detected with high confidence
-        if (fields['store'].get('confidence', 0) > 0.7 and 
-            fields['coupon_code'].get('confidence', 0) > 0.7):
-            validated['overall_confidence'] = min(1.0, validated['overall_confidence'] + 0.15)
-        
-        # 3. If discount value seems unrealistic, reduce confidence
-        discount = fields['discount']
-        if discount.get('type') == 'percentage' and discount.get('value', 0) > 90:
-            validated['discount']['confidence'] *= 0.7
-        
-        # 4. Add validation flags
-        validated['validation_flags'] = {
-            'has_essential_fields': (
-                fields['coupon_code'].get('confidence', 0) > 0.5 or 
-                fields['discount'].get('confidence', 0) > 0.5
-            ),
-            'has_store_info': fields['store'].get('confidence', 0) > 0.5,
-            'has_expiry_info': fields['expiry_date'].get('confidence', 0) > 0.5,
-            'overall_quality': 'high' if validated['overall_confidence'] > 0.8 else 
-                             'medium' if validated['overall_confidence'] > 0.5 else 'low'
-        }
-        
         return validated

--- a/enhanced_field_extractor.py
+++ b/enhanced_field_extractor.py
@@ -35,36 +35,42 @@ class EnhancedCouponFieldExtractor:
         # Store-specific patterns (learned from data)
         self.store_patterns = {
             'amazon': {
+                'display_name': 'Amazon',
                 'identifiers': ['amazon', 'amzn', 'amazon.in'],
                 'code_patterns': [r'[A-Z0-9]{8,12}'],
                 'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'save\s*₹(\d+)', r'flat\s*(\d+(?:\.\d+)?)%'],
                 'common_terms': ['prime', 'delivery', 'shopping', 'cart']
             },
             'flipkart': {
+                'display_name': 'Flipkart',
                 'identifiers': ['flipkart', 'fkrt', 'flipkart.com'],
                 'code_patterns': [r'[A-Z]{2,4}\d{4,8}', r'FK[A-Z0-9]{6,10}'],
                 'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'extra\s*(\d+(?:\.\d+)?)%', r'flat\s*₹(\d+)'],
                 'common_terms': ['plus', 'supercoins', 'delivery', 'exchange']
             },
             'myntra': {
+                'display_name': 'Myntra',
                 'identifiers': ['myntra', 'myntra.com'],
                 'code_patterns': [r'[A-Z]{3,5}\d{3,6}', r'MYNTRA[0-9]{4,8}'],
                 'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'flat\s*(\d+(?:\.\d+)?)%', r'buy\s*\d+\s*get\s*\d+'],
                 'common_terms': ['fashion', 'style', 'brands', 'clothing']
             },
             'swiggy': {
+                'display_name': 'Swiggy',
                 'identifiers': ['swiggy', 'swiggy.com'],
                 'code_patterns': [r'[A-Z]{4,6}\d{2,4}', r'SWIGGY[0-9]{3,6}'],
                 'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'flat\s*₹(\d+)', r'free\s*delivery'],
                 'common_terms': ['food', 'delivery', 'restaurant', 'order']
             },
             'zomato': {
+                'display_name': 'Zomato',
                 'identifiers': ['zomato', 'zomato.com'],
                 'code_patterns': [r'[A-Z]{4,6}\d{2,4}', r'ZOMATO[0-9]{3,6}'],
                 'discount_patterns': [r'(\d+(?:\.\d+)?)%\s*off', r'flat\s*₹(\d+)', r'free\s*delivery'],
                 'common_terms': ['food', 'delivery', 'dining', 'restaurant']
             },
             'aha': {
+                'display_name': 'Aha',
                 'identifiers': ['aha'],
                 'code_patterns': [],
                 'discount_patterns': [r'flat\s*(\d+(?:\.\d+)?)%'],
@@ -198,7 +204,7 @@ class EnhancedCouponFieldExtractor:
             Dict: Store detection result
         """
         text_lower = text.lower()
-        best_match = {'name': None, 'confidence': 0.0, 'type': 'unknown'}
+        best_match = {'name': None, 'confidence': 0.0, 'type': 'unknown', 'key': None}
         
         for store_name, store_data in self.store_patterns.items():
             confidence = 0.0
@@ -221,9 +227,10 @@ class EnhancedCouponFieldExtractor:
             
             if confidence > best_match['confidence']:
                 best_match = {
-                    'name': store_name,
+                    'name': store_data.get('display_name', store_name),
                     'confidence': confidence,
-                    'type': 'identified'
+                    'type': 'identified',
+                    'key': store_name
                 }
         
         # If no store detected, try to extract any brand-like words
@@ -258,7 +265,8 @@ class EnhancedCouponFieldExtractor:
                 best_match = {
                     'name': location_candidates[0][0].strip(),
                     'confidence': 0.45,
-                    'type': 'extracted'
+                    'type': 'extracted',
+                    'key': None
                 }
             else:
                 brand_patterns = [
@@ -289,7 +297,8 @@ class EnhancedCouponFieldExtractor:
                     best_match = {
                         'name': selected,
                         'confidence': 0.4,
-                        'type': 'extracted'
+                        'type': 'extracted',
+                        'key': None
                     }
                 else:
                     lowercase_stopwords = stopwords | {'purchase', 'details', 'terms', 'condition', 'conditions', 'plan',
@@ -310,7 +319,8 @@ class EnhancedCouponFieldExtractor:
                             best_match = {
                                 'name': name,
                                 'confidence': 0.38,
-                                'type': 'extracted'
+                                'type': 'extracted',
+                                'key': None
                             }
 
         return best_match
@@ -328,8 +338,9 @@ class EnhancedCouponFieldExtractor:
         candidates = []
         
         # Try store-specific patterns first
-        if store_info.get('name') in self.store_patterns:
-            store_patterns = self.store_patterns[store_info['name']]['code_patterns']
+        store_key = store_info.get('key')
+        if store_key and store_key in self.store_patterns:
+            store_patterns = self.store_patterns[store_key]['code_patterns']
             for pattern in store_patterns:
                 matches = re.findall(pattern, text, re.IGNORECASE)
                 for match in matches:

--- a/tests/test_store_detection.py
+++ b/tests/test_store_detection.py
@@ -5,27 +5,6 @@ from pathlib import Path
 
 import pytest
 
-# Provide lightweight stubs for optional heavy dependencies so the module can be imported
-if 'numpy' not in sys.modules:
-    sys.modules['numpy'] = types.SimpleNamespace(mean=lambda values: sum(values) / len(values) if values else 0.0)
-
-if 'fuzzywuzzy' not in sys.modules:
-    fuzz_module = types.SimpleNamespace(partial_ratio=lambda a, b: 0)
-    process_module = types.SimpleNamespace()
-    fuzzy_module = types.ModuleType('fuzzywuzzy')
-    fuzzy_module.fuzz = fuzz_module
-    fuzzy_module.process = process_module
-    sys.modules['fuzzywuzzy'] = fuzzy_module
-    sys.modules['fuzzywuzzy.fuzz'] = fuzz_module
-    sys.modules['fuzzywuzzy.process'] = process_module
-
-if 'dateutil' not in sys.modules:
-    parser_module = types.SimpleNamespace(parse=lambda value, fuzzy=False: datetime.now())
-    dateutil_module = types.ModuleType('dateutil')
-    dateutil_module.parser = parser_module
-    sys.modules['dateutil'] = dateutil_module
-    sys.modules['dateutil.parser'] = parser_module
-
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from enhanced_field_extractor import EnhancedCouponFieldExtractor
@@ -82,6 +61,7 @@ def test_extract_expiry_date_with_comma_and_time():
     assert expiry['raw_text'] == '05 May, 2025, 11:59 PM'
     assert expiry['confidence'] > 0.9
     assert expiry['parsed_date'] is not None
+    assert expiry['is_expired'] is True
 
 
 def test_aha_coupon_fields_are_preserved():
@@ -114,3 +94,25 @@ def test_aha_coupon_fields_are_preserved():
     assert '₹499' in terms['text']
     assert '₹699' in terms['text']
     assert '₹999' in terms['text']
+
+
+def test_extract_fields_with_confidence_handles_combined_offer():
+    extractor = EnhancedCouponFieldExtractor()
+
+    ocr_text = """
+        PUMA Coupon Up to 50.0% off + Extra 33% Off
+        Redeem at PUMA outlets today
+        Use code KQSKLBLBIR before it expires
+        Expires on 05 May, 2025, 11:59 PM
+    """
+
+    fields = extractor.extract_fields_with_confidence(ocr_text)
+
+    assert fields['store']['name'] == 'PUMA'
+    assert fields['discount']['type'] == 'percentage'
+    assert fields['discount']['raw_text'] == 'Up to 50% Off + Extra 33% Off'
+    assert fields['discount']['components'] == ['Up to 50% Off', 'Extra 33% Off']
+    assert fields['coupon_code']['code'] == 'KQSKLBLBIR'
+    assert fields['expiry_date']['raw_text'] == '05 May, 2025, 11:59 PM'
+    assert fields['expiry_date']['is_expired'] is True
+    assert fields['overall_confidence'] > 0

--- a/tests/test_store_detection.py
+++ b/tests/test_store_detection.py
@@ -64,6 +64,22 @@ def test_extract_expiry_date_with_comma_and_time():
     assert expiry['is_expired'] is True
 
 
+def test_extract_expiry_date_handles_ordinals_and_compact_meridiem():
+    extractor = EnhancedCouponFieldExtractor()
+
+    ocr_text = """
+        Expires 30th Sept 2025 11:59pm
+    """
+
+    cleaned_text = extractor._clean_text(ocr_text)
+    expiry = extractor._extract_expiry_date(cleaned_text)
+
+    assert expiry['raw_text'] == '30th Sept 2025 11:59pm'
+    assert expiry['parsed_date'] is not None
+    assert expiry['parsed_date'].startswith('2025-09-30T23:59:00')
+    assert expiry['confidence'] >= 0.9
+
+
 def test_aha_coupon_fields_are_preserved():
     extractor = EnhancedCouponFieldExtractor()
 

--- a/tests/test_store_detection.py
+++ b/tests/test_store_detection.py
@@ -97,7 +97,7 @@ def test_aha_coupon_fields_are_preserved():
     cleaned_text = extractor._clean_text(ocr_text)
 
     store = extractor._detect_store(cleaned_text)
-    assert store['name'] == 'aha'
+    assert store['name'] == 'Aha'
 
     discount = extractor._extract_discount(cleaned_text)
     assert discount['type'] == 'percentage'

--- a/tests/test_store_detection.py
+++ b/tests/test_store_detection.py
@@ -48,3 +48,69 @@ def test_detect_store_prefers_mixed_case_brand_over_short_all_caps():
 
     assert result['type'] == 'extracted'
     assert result['name'] == 'Minimalist'
+
+
+def test_extract_discount_handles_combined_percentage_phrases():
+    extractor = EnhancedCouponFieldExtractor()
+
+    ocr_text = """
+        Get Upto 50% Off* + Extra 33% Off
+        at PUMA
+        Code: KQSKLBLBIR
+        Expires on 05 May, 2025, 11:59 PM
+    """
+
+    cleaned_text = extractor._clean_text(ocr_text)
+    discount = extractor._extract_discount(cleaned_text)
+
+    assert discount['type'] == 'percentage'
+    assert discount['value'] == 50
+    assert discount['raw_text'] == 'Up to 50% Off + Extra 33% Off'
+    assert discount['components'] == ['Up to 50% Off', 'Extra 33% Off']
+
+
+def test_extract_expiry_date_with_comma_and_time():
+    extractor = EnhancedCouponFieldExtractor()
+
+    ocr_text = """
+        Expires on 05 May, 2025, 11:59 PM
+    """
+
+    cleaned_text = extractor._clean_text(ocr_text)
+    expiry = extractor._extract_expiry_date(cleaned_text)
+
+    assert expiry['raw_text'] == '05 May, 2025, 11:59 PM'
+    assert expiry['confidence'] > 0.9
+    assert expiry['parsed_date'] is not None
+
+
+def test_aha_coupon_fields_are_preserved():
+    extractor = EnhancedCouponFieldExtractor()
+
+    ocr_text = """
+        Get Flat 20.0% off
+        on purchase of aha Telugu Annual Plan of ₹499, ₹699 or ₹999
+        Code: ahappe20
+        Expires on 30 Sep, 2025, 11:59 PM
+    """
+
+    cleaned_text = extractor._clean_text(ocr_text)
+
+    store = extractor._detect_store(cleaned_text)
+    assert store['name'] == 'aha'
+
+    discount = extractor._extract_discount(cleaned_text)
+    assert discount['type'] == 'percentage'
+    assert discount['raw_text'] == 'Flat 20% Off'
+    assert discount['components'] == ['Flat 20% Off']
+
+    expiry = extractor._extract_expiry_date(cleaned_text)
+    assert expiry['raw_text'] == '30 Sep, 2025, 11:59 PM'
+
+    code = extractor._extract_coupon_code(cleaned_text, store)
+    assert code['code'] == 'ahappe20'
+
+    terms = extractor._extract_terms(cleaned_text)
+    assert '₹499' in terms['text']
+    assert '₹699' in terms['text']
+    assert '₹999' in terms['text']

--- a/tests/test_store_detection.py
+++ b/tests/test_store_detection.py
@@ -29,6 +29,39 @@ def test_detect_store_prefers_mixed_case_brand_over_short_all_caps():
     assert result['name'] == 'Minimalist'
 
 
+def test_detect_store_ignores_trailing_code_token_for_known_brand():
+    extractor = EnhancedCouponFieldExtractor()
+
+    ocr_text = """
+        Exclusive coupon launch
+        Redeem at PUMA
+        Code: KQSKLBLBIR
+    """
+
+    cleaned_text = extractor._clean_text(ocr_text)
+    result = extractor._detect_store(cleaned_text)
+
+    assert result['type'] == 'identified'
+    assert result['name'] == 'PUMA'
+    assert result['confidence'] >= 0.9
+
+
+def test_detect_store_trims_trailing_code_word_when_brand_unknown():
+    extractor = EnhancedCouponFieldExtractor()
+
+    ocr_text = """
+        Redeem now at Glow Code
+        Use code GLOW2025 today
+    """
+
+    cleaned_text = extractor._clean_text(ocr_text)
+    result = extractor._detect_store(cleaned_text)
+
+    assert result['type'] == 'extracted'
+    assert result['name'] == 'Glow'
+    assert result['confidence'] >= 0.4
+
+
 def test_extract_discount_handles_combined_percentage_phrases():
     extractor = EnhancedCouponFieldExtractor()
 


### PR DESCRIPTION
## Summary
- add dedicated handling for Aha coupons and refine fallback brand heuristics to ignore stopwords and promote repeated lowercase brand names
- expand discount and code parsing to keep decimal percentages, preserve lowercase codes, and normalize combined phrases while preventing currency misreads
- extract plan pricing terms for amount lists and back the scenario with an end-to-end Aha coupon regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d976c52e68832899c8b65b696599f4