### PR TITLE
Patch datetime.now in expiry tests

### DIFF
--- a/tests/test_store_detection.py
+++ b/tests/test_store_detection.py
@@ -69,7 +69,24 @@ def test_extract_discount_handles_combined_percentage_phrases():
     assert discount['components'] == ['Up to 50% Off', 'Extra 33% Off']
 
 
-def test_extract_expiry_date_with_comma_and_time():
+@pytest.fixture
+def frozen_datetime_now(monkeypatch):
+    fixed_now = datetime(2026, 1, 1, 0, 0, 0)
+
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return fixed_now
+            if fixed_now.tzinfo is None:
+                return fixed_now.replace(tzinfo=tz)
+            return fixed_now.astimezone(tz)
+
+    monkeypatch.setattr("enhanced_field_extractor.datetime", FrozenDateTime)
+    return fixed_now
+
+
+def test_extract_expiry_date_with_comma_and_time(frozen_datetime_now):
     extractor = EnhancedCouponFieldExtractor()
 
     ocr_text = """

--- a/tests/test_store_detection.py
+++ b/tests/test_store_detection.py
@@ -69,6 +69,38 @@ def test_extract_discount_handles_combined_percentage_phrases():
     assert discount['components'] == ['Up to 50% Off', 'Extra 33% Off']
 
 
+def test_extract_discount_allows_leading_verbs_before_percentage():
+    extractor = EnhancedCouponFieldExtractor()
+
+    ocr_text = """
+        Get 50% Off on all skincare
+    """
+
+    cleaned_text = extractor._clean_text(ocr_text)
+    discount = extractor._extract_discount(cleaned_text)
+
+    assert discount['type'] == 'percentage'
+    assert discount['value'] == 50
+    assert discount['raw_text'] == '50% Off'
+    assert discount['components'] == ['50% Off']
+
+
+def test_extract_discount_handles_leading_percentage_without_prefix():
+    extractor = EnhancedCouponFieldExtractor()
+
+    ocr_text = """
+        50% Off + Extra 10% Off on accessories
+    """
+
+    cleaned_text = extractor._clean_text(ocr_text)
+    discount = extractor._extract_discount(cleaned_text)
+
+    assert discount['type'] == 'percentage'
+    assert discount['value'] == 50
+    assert discount['raw_text'] == '50% Off + Extra 10% Off'
+    assert discount['components'] == ['50% Off', 'Extra 10% Off']
+
+
 @pytest.fixture
 def frozen_datetime_now(monkeypatch):
     fixed_now = datetime(2026, 1, 1, 0, 0, 0)


### PR DESCRIPTION
## Summary
- add a fixture that freezes `enhanced_field_extractor.datetime.now` to a future value during expiry-related tests
- ensure the expiry date parsing test runs with deterministic current time handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d98ed65484832891a5d5cd59e2b3cc