### PR TITLE
Fix cashback percent detection during v5 to v6 migration

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDatabase.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDatabase.kt
@@ -129,16 +129,24 @@ abstract class CouponDatabase : RoomDatabase() {
                 // Migrate existing cashbackAmount data to typed fields
                 // This query attempts to detect percentages vs amounts based on value and description
                 database.execSQL("""
-                    UPDATE coupons SET 
-                        cashbackType = CASE 
-                            WHEN cashbackAmount <= 100 AND (description LIKE '%off%' OR description LIKE '%%' OR description LIKE '%percent%') THEN 'percent'
+                    UPDATE coupons SET
+                        cashbackType = CASE
+                            WHEN cashbackAmount <= 100 AND (
+                                description LIKE '%off%'
+                                OR instr(description, '%') > 0
+                                OR description LIKE '%percent%'
+                            ) THEN 'percent'
                             ELSE 'amount'
                         END,
                         cashbackValueNum = cashbackAmount,
                         offerText = CASE
-                            WHEN cashbackAmount <= 100 AND (description LIKE '%off%' OR description LIKE '%%') THEN 
+                            WHEN cashbackAmount <= 100 AND (
+                                description LIKE '%off%'
+                                OR instr(description, '%') > 0
+                                OR description LIKE '%percent%'
+                            ) THEN
                                 CAST(CAST(cashbackAmount AS INTEGER) AS TEXT) || '% Off'
-                            ELSE 
+                            ELSE
                                 '₹' || CAST(CAST(cashbackAmount AS INTEGER) AS TEXT)
                         END
                     WHERE cashbackType IS NULL

--- a/app/src/test/java/com/example/coupontracker/data/local/CouponDatabaseMigrationTest.kt
+++ b/app/src/test/java/com/example/coupontracker/data/local/CouponDatabaseMigrationTest.kt
@@ -87,6 +87,32 @@ class CouponDatabaseMigrationTest {
         database.close()
     }
 
+    @Test
+    fun migrate5To6_classifiesPercentAndAmountCashbackCorrectly() = runBlocking {
+        createVersion5DatabaseWithCashbackSamples()
+
+        val database = Room.databaseBuilder(context, CouponDatabase::class.java, databaseName)
+            .addMigrations(CouponDatabase.MIGRATION_5_6)
+            .allowMainThreadQueries()
+            .build()
+
+        val percentCoupon = database.couponDao().getCouponById(1)
+        val amountCoupon = database.couponDao().getCouponById(2)
+
+        assertNotNull(percentCoupon)
+        assertEquals("percent", percentCoupon?.cashbackType)
+        assertEquals(20.0, percentCoupon?.cashbackValueNum ?: error("Expected percent cashback value"), 0.0)
+        assertEquals("20% Off", percentCoupon?.offerText)
+
+        assertNotNull(amountCoupon)
+        assertEquals("amount", amountCoupon?.cashbackType)
+        assertEquals(75.0, amountCoupon?.cashbackValueNum ?: error("Expected amount cashback value"), 0.0)
+        assertEquals("₹75", amountCoupon?.offerText)
+        assertEquals("INR", amountCoupon?.cashbackCurrency)
+
+        database.close()
+    }
+
     private fun createLegacyDatabase(storeName: String, description: String) {
         context.deleteDatabase(databaseName)
         val configuration = SupportSQLiteOpenHelper.Configuration.builder(context)
@@ -239,6 +265,105 @@ class CouponDatabaseMigrationTest {
         }
 
         db.insert("coupons", SupportSQLiteDatabase.CONFLICT_ABORT, values)
+        db.close()
+        openHelper.close()
+    }
+
+    private fun createVersion5DatabaseWithCashbackSamples() {
+        context.deleteDatabase(databaseName)
+        val configuration = SupportSQLiteOpenHelper.Configuration.builder(context)
+            .name(databaseName)
+            .callback(object : SupportSQLiteOpenHelper.Callback(5) {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS `coupons` (
+                            `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                            `storeName` TEXT NOT NULL,
+                            `description` TEXT NOT NULL,
+                            `normalizedDescription` TEXT,
+                            `expiryDate` INTEGER,
+                            `cashbackAmount` REAL NOT NULL,
+                            `redeemCode` TEXT,
+                            `imageUri` TEXT,
+                            `imagePhash` TEXT,
+                            `imageSignature` TEXT,
+                            `category` TEXT,
+                            `status` TEXT,
+                            `minimumPurchase` REAL,
+                            `maximumDiscount` REAL,
+                            `isPriority` INTEGER NOT NULL DEFAULT 0,
+                            `paymentMethod` TEXT,
+                            `usageLimit` INTEGER,
+                            `usageCount` INTEGER NOT NULL DEFAULT 0,
+                            `reminderDate` INTEGER,
+                            `platformType` TEXT,
+                            `rating` TEXT,
+                            `createdAt` INTEGER NOT NULL,
+                            `updatedAt` INTEGER NOT NULL
+                        )
+                        """
+                    )
+                }
+
+                override fun onUpgrade(
+                    db: SupportSQLiteDatabase,
+                    oldVersion: Int,
+                    newVersion: Int
+                ) {
+                    // No-op for test schema
+                }
+            })
+            .build()
+
+        val openHelper = FrameworkSQLiteOpenHelperFactory().create(configuration)
+        val db = openHelper.writableDatabase
+        val now = System.currentTimeMillis()
+
+        fun insertCoupon(id: Long, storeName: String, description: String, amount: Double) {
+            val values = ContentValues().apply {
+                put("id", id)
+                put("storeName", storeName)
+                put("description", description)
+                put("normalizedDescription", CouponDedupUtils.normalizeDescription(description))
+                put("expiryDate", now)
+                put("cashbackAmount", amount)
+                put("redeemCode", null as String?)
+                put("imageUri", null as String?)
+                put("imagePhash", null as String?)
+                put("imageSignature", null as String?)
+                put("category", "Test")
+                put("status", "Active")
+                put("minimumPurchase", null as Double?)
+                put("maximumDiscount", null as Double?)
+                put("isPriority", 0)
+                put("paymentMethod", null as String?)
+                put("usageLimit", null as Int?)
+                put("usageCount", 0)
+                put("reminderDate", null as Long?)
+                put("platformType", null as String?)
+                put("rating", null as String?)
+                put("createdAt", now)
+                put("updatedAt", now)
+            }
+
+            db.insert("coupons", SupportSQLiteDatabase.CONFLICT_ABORT, values)
+        }
+
+        insertCoupon(
+            id = 1,
+            storeName = "Percent Store",
+            description = "Save 20% off your purchase",
+            amount = 20.0
+        )
+
+        insertCoupon(
+            id = 2,
+            storeName = "Cashback Store",
+            description = "Get ₹75 cashback on orders",
+            amount = 75.0
+        )
+
         db.close()
         openHelper.close()
     }


### PR DESCRIPTION
## Summary
- tighten the v5→v6 migration heuristic so percent cashbacks require an actual percent indicator
- only build percent-style offer text when a percent sign or keyword is present, leaving rupee values as amounts
- add a migration regression test covering percent-off and rupee cashback records

## Testing
- ./gradlew test *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da92e97af48328a9ae7eef006ffb52