### PR TITLE
Handle two digit expiry dates

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.InputStream
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
@@ -61,6 +62,74 @@ class ScannerViewModel @Inject constructor(
 
     companion object {
         private const val TAG = "ScannerViewModel"
+
+        @VisibleForTesting
+        internal fun parseExpiryDate(
+            dateString: String?,
+            locale: Locale = Locale.getDefault()
+        ): Date? {
+            if (dateString.isNullOrBlank()) return null
+
+            val cleanedDate = dateString
+                .trim()
+                .replace("\u202F", " ")
+                .let {
+                    val timeRegex = Regex("\\s*(?:at\\s*)?\\d{1,2}:\\d{2}(?:\\s*[AaPp][Mm])?(?:\\s*[A-Za-z]+)?$")
+                    timeRegex.replace(it) { _ -> "" }.trim()
+                }
+
+            val dateFormats = listOf(
+                "dd/MM/yyyy",
+                "MM/dd/yyyy",
+                "yyyy/MM/dd",
+                "dd-MM-yyyy",
+                "MM-dd-yyyy",
+                "yyyy-MM-dd",
+                "dd.MM.yyyy",
+                "MM.dd.yyyy",
+                "yyyy.MM.dd",
+                "dd MMM yyyy",
+                "dd MMMM yyyy",
+                "dd MMM, yyyy",
+                "dd MMMM, yyyy",
+                "dd/MM/yy",
+                "MM/dd/yy",
+                "dd-MM-yy",
+                "MM-dd-yy",
+                "dd.MM.yy",
+                "MM.dd.yy",
+                "dd MMM yy",
+                "dd MMMM yy"
+            )
+
+            val twoDigitYearStart = Calendar.getInstance().apply {
+                set(Calendar.YEAR, 2000)
+                set(Calendar.MONTH, Calendar.JANUARY)
+                set(Calendar.DAY_OF_MONTH, 1)
+                set(Calendar.HOUR_OF_DAY, 0)
+                set(Calendar.MINUTE, 0)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }.time
+
+            for (format in dateFormats) {
+                try {
+                    val sdf = SimpleDateFormat(format, locale)
+                    sdf.isLenient = false
+                    if (format.contains("yy") && !format.contains("yyyy")) {
+                        sdf.set2DigitYearStart(twoDigitYearStart)
+                    }
+                    val parsed = sdf.parse(cleanedDate)
+                    if (parsed != null) {
+                        return parsed
+                    }
+                } catch (e: Exception) {
+                    // Try next format
+                }
+            }
+
+            return null // Don't return fallback date - use null if parsing fails
+        }
     }
 
     init {
@@ -881,46 +950,6 @@ class ScannerViewModel @Inject constructor(
     /**
      * Parse expiry date string to Date
      */
-    private fun parseExpiryDate(dateString: String?): Date? {
-        if (dateString.isNullOrBlank()) return null
-
-        val cleanedDate = dateString
-            .trim()
-            .replace("\u202F", " ")
-            .let {
-                val timeRegex = Regex("\\s*(?:at\\s*)?\\d{1,2}:\\d{2}(?:\\s*[AaPp][Mm])?(?:\\s*[A-Za-z]+)?$")
-                timeRegex.replace(it) { _ -> "" }.trim()
-            }
-
-        val dateFormats = listOf(
-            "dd/MM/yyyy",
-            "MM/dd/yyyy",
-            "yyyy/MM/dd",
-            "dd-MM-yyyy",
-            "MM-dd-yyyy",
-            "yyyy-MM-dd",
-            "dd MMM yyyy",
-            "dd MMMM yyyy",
-            "dd MMM, yyyy",
-            "dd MMMM, yyyy"
-        )
-
-        for (format in dateFormats) {
-            try {
-                val sdf = SimpleDateFormat(format, Locale.getDefault())
-                sdf.isLenient = false
-                val parsed = sdf.parse(cleanedDate)
-                if (parsed != null) {
-                    return parsed
-                }
-            } catch (e: Exception) {
-                // Try next format
-            }
-        }
-
-        return null // Don't return fallback date - use null if parsing fails
-    }
-
     /**
      * Confirm that the extraction was correct (positive feedback)
      */

--- a/app/src/test/java/com/example/coupontracker/ui/viewmodel/ScannerViewModelDateParsingTest.kt
+++ b/app/src/test/java/com/example/coupontracker/ui/viewmodel/ScannerViewModelDateParsingTest.kt
@@ -1,0 +1,22 @@
+package com.example.coupontracker.ui.viewmodel
+
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.util.Locale
+
+class ScannerViewModelDateParsingTest {
+
+    @Test
+    fun `parseExpiryDate handles slash separated two digit year`() {
+        val result = ScannerViewModel.parseExpiryDate("31/12/24", Locale.UK)
+
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `parseExpiryDate handles month text with two digit year`() {
+        val result = ScannerViewModel.parseExpiryDate("15 Aug 25", Locale.UK)
+
+        assertNotNull(result)
+    }
+}


### PR DESCRIPTION
## Summary
- extend the scanner expiry date parsing logic to handle additional separators and two-digit year formats
- pivot two-digit year parsing toward the 21st century and expose the helper for testing via the companion object
- add unit tests covering slash and textual month expiry strings with two-digit years

## Testing
- ./gradlew test *(fails: Android SDK not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dac22ce2b48328aab091a773f3328f