### PR TITLE
Ensure detector crops are released promptly

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
@@ -333,6 +333,16 @@ class TwoStageDetector(private val context: Context, initializeOnCreate: Boolean
             return emptyList()
         }
     }
+
+    /**
+     * Release managed crop bitmaps associated with the provided coupon instances.
+     * This ensures the detector's internal bitmap manager can recycle memory promptly.
+     */
+    fun releaseInstances(instances: Iterable<CouponInstance>) {
+        instances.forEach { instance ->
+            bitmapManager.releaseBitmap(instance.cropBitmap)
+        }
+    }
     
     /**
      * Stage 1: Detect coupon instances in the full image

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
@@ -268,14 +268,8 @@ class BatchScannerViewModel @Inject constructor(
                     buildPlaceholderCoupon(uri)
                 }
             } finally {
-                // CRITICAL: Release all detector crops to prevent memory leaks
-                // Each crop has refCount=1 from detectMultiCoupons, must be released
-                couponInstances.forEach { instance ->
-                    instance.cropBitmap?.let { crop ->
-                        bitmapManager.releaseBitmap(crop)
-                        Log.d(TAG, "Released detector crop: ${crop.width}x${crop.height}")
-                    }
-                }
+                // Release detector-managed crops immediately after processing
+                twoStageDetector.releaseInstances(couponInstances)
             }
         }
     }

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -796,6 +796,8 @@ class ScannerViewModel @Inject constructor(
         } catch (e: Exception) {
             Log.e(TAG, "Error processing single coupon", e)
             _uiState.value = ScannerUiState.Error("Error processing coupon: ${e.message}")
+        } finally {
+            twoStageDetector.releaseInstances(listOf(couponInstance))
         }
     }
 
@@ -986,6 +988,8 @@ class ScannerViewModel @Inject constructor(
             } catch (e: Exception) {
                 Log.e(TAG, "Error processing coupon $index", e)
                 // Continue with other coupons
+            } finally {
+                twoStageDetector.releaseInstances(listOf(instance))
             }
         }
 


### PR DESCRIPTION
## Summary
- expose a TwoStageDetector helper to release detector-managed crop bitmaps
- reuse the helper in the legacy batch pipeline cleanup instead of duplicating bitmap release logic
- release detector-managed crops after single and batch processing flows in the scanner view model

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbab47b2848328bfc07d0b9ef9c173