### PR TITLE
Handle stub mode detector failures in production builds

### DIFF
--- a/app/src/androidTest/java/com/example/coupontracker/ml/TwoStageDetectorStubModeTest.kt
+++ b/app/src/androidTest/java/com/example/coupontracker/ml/TwoStageDetectorStubModeTest.kt
@@ -1,0 +1,27 @@
+package com.example.coupontracker.ml
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TwoStageDetectorStubModeTest {
+
+    @Test
+    fun stubModeProductionBuildThrows() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            TwoStageDetector(context, isDebugBuild = false)
+        }
+
+        val message = exception.message ?: ""
+        assertTrue(
+            "Expected error message to mention stub_mode flag",
+            message.contains("stub_mode", ignoreCase = true)
+        )
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
@@ -8,6 +8,7 @@ import android.os.Parcelable
 import android.util.DisplayMetrics
 import android.util.Log
 import androidx.annotation.VisibleForTesting
+import com.example.coupontracker.BuildConfig
 import com.example.coupontracker.util.BitmapManager
 import com.example.coupontracker.util.CouponInstanceValidator
 import kotlinx.coroutines.runBlocking
@@ -35,7 +36,11 @@ import kotlinx.parcelize.Parcelize
  * - Partial coupon screenshots (top/bottom cut-off)
  * - Scrollable coupon lists
  */
-class TwoStageDetector(private val context: Context, initializeOnCreate: Boolean = true) {
+class TwoStageDetector(
+    private val context: Context,
+    private val isDebugBuild: Boolean = BuildConfig.DEBUG,
+    initializeOnCreate: Boolean = true
+) {
     
     companion object {
         private const val TAG = "TwoStageDetector"
@@ -85,21 +90,27 @@ class TwoStageDetector(private val context: Context, initializeOnCreate: Boolean
     private fun initializeModels() {
         try {
             Log.d(TAG, "Initializing two-stage detection models...")
-            
+
             // Load model manifest
             loadModelManifest()
-            
+
             if (stubMode) {
-                Log.w(
-                    TAG,
-                    "Multi-coupon manifest is marked as stub_mode. Skipping TensorFlow Lite interpreter initialization. " +
-                        "Replace the placeholder assets with trained binaries for production use."
-                )
-                stage1Interpreter = null
-                stage2Interpreter = null
-                initializeImageProcessors()
-                isInitialized = true
-                return
+                if (isDebugBuild) {
+                    Log.w(
+                        TAG,
+                        "Multi-coupon manifest is marked as stub_mode. Skipping TensorFlow Lite interpreter initialization. " +
+                            "Replace the placeholder assets with trained binaries for production use."
+                    )
+                    stage1Interpreter = null
+                    stage2Interpreter = null
+                    initializeImageProcessors()
+                    isInitialized = true
+                    return
+                } else {
+                    val message = "Two-stage detector manifest is marked stub_mode=true; trained assets are required for production builds."
+                    Log.e(TAG, message)
+                    throw IllegalStateException(message)
+                }
             }
 
             // Try to load models, but fallback gracefully if they're placeholders
@@ -110,13 +121,13 @@ class TwoStageDetector(private val context: Context, initializeOnCreate: Boolean
 
                 // Load Stage 2 Model (Field Detection)
                 loadStage2Model()
-                
+
                 modelsLoaded = true
                 Log.i(TAG, "Production models loaded successfully")
-                
+
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to load production models (likely placeholders): ${e.message}")
-                
+
                 if (demoMode) {
                     Log.i(TAG, "Demo mode enabled - continuing with placeholder models for synthetic detections")
                     stage1Interpreter = null
@@ -132,17 +143,18 @@ class TwoStageDetector(private val context: Context, initializeOnCreate: Boolean
                 // Initialize image processors
                 initializeImageProcessors()
                 isInitialized = true
-                
+
                 if (demoMode) {
                     Log.i(TAG, "Two-stage detector initialized in demo mode")
                 } else {
                     Log.i(TAG, "Two-stage detector initialized with production models")
                 }
             }
-            
+
         } catch (e: Exception) {
             Log.e(TAG, "Error initializing models", e)
             isInitialized = false
+            throw e
         }
     }
     

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
@@ -37,16 +37,42 @@ class BatchScannerViewModel @Inject constructor(
 
     private val multiEngineOCR = com.example.coupontracker.util.MultiEngineOCR(context)
     private val uriPersistenceManager = com.example.coupontracker.util.UriPersistenceManager(context)
-    private val twoStageDetector = com.example.coupontracker.ml.TwoStageDetector(context)  // V2: LEGACY detector (not injected)
+    private val detectorInitializationResult = initializeTwoStageDetector()
+    private val twoStageDetector = detectorInitializationResult.detector
+    private val detectorInitErrorMessage = detectorInitializationResult.errorMessage
 
     companion object {
         private const val TAG = "BatchScannerViewModel"
+    }
+
+    private data class DetectorInitializationResult(
+        val detector: com.example.coupontracker.ml.TwoStageDetector?,
+        val errorMessage: String?
+    )
+
+    private fun initializeTwoStageDetector(): DetectorInitializationResult {
+        return try {
+            DetectorInitializationResult(com.example.coupontracker.ml.TwoStageDetector(context), null)
+        } catch (e: IllegalStateException) {
+            val message = e.message ?: "Multi-coupon detector assets are not available for this build."
+            Log.e(TAG, "TwoStageDetector initialization blocked", e)
+            DetectorInitializationResult(null, message)
+        } catch (e: Exception) {
+            val message = e.message ?: "Failed to initialize multi-coupon detector."
+            Log.e(TAG, "TwoStageDetector initialization failed", e)
+            DetectorInitializationResult(null, message)
+        }
     }
 
     init {
         // V2: Enable OCR network availability (critical for OCR_FIRST and HYBRID strategies)
         multiEngineOCR.setNetworkAvailability(true)
         Log.d(TAG, "MultiEngineOCR network availability enabled for batch processing")
+
+        detectorInitErrorMessage?.let { error ->
+            Log.e(TAG, "TwoStageDetector unavailable for batch scanning: $error")
+            updateState { it.copy(error = error) }
+        }
     }
 
     /**
@@ -98,7 +124,14 @@ class BatchScannerViewModel @Inject constructor(
                 // V2: Get active strategy
                 val strategy = com.example.coupontracker.util.ExtractionConfig.getStrategy()
                 Log.d(TAG, "Batch: Starting with strategy ${strategy.name}, ${_uiState.value.selectedImages.size} images")
-                
+
+                if (twoStageDetector == null) {
+                    val message = detectorInitErrorMessage ?: "Multi-coupon detector is unavailable."
+                    Log.e(TAG, "Batch: TwoStageDetector unavailable - aborting processing")
+                    updateState { it.copy(isProcessing = false, error = message) }
+                    return@launch
+                }
+
                 updateState { it.copy(isProcessing = true, processedCount = 0, error = null) }
 
                 val images = _uiState.value.selectedImages
@@ -252,9 +285,12 @@ class BatchScannerViewModel @Inject constructor(
      */
     private suspend fun processWithLegacyPath(uri: Uri, bitmap: android.graphics.Bitmap): Coupon {
         return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            val detector = twoStageDetector
+                ?: throw IllegalStateException(detectorInitErrorMessage ?: "Multi-coupon detector is unavailable.")
+
             // Run two-stage detection
-            val couponInstances = twoStageDetector.detectMultiCoupons(bitmap)
-            
+            val couponInstances = detector.detectMultiCoupons(bitmap)
+
             try {
                 if (couponInstances.isNotEmpty()) {
                     // Take first coupon for batch processing
@@ -269,7 +305,7 @@ class BatchScannerViewModel @Inject constructor(
                 }
             } finally {
                 // Release detector-managed crops immediately after processing
-                twoStageDetector.releaseInstances(couponInstances)
+                detector.releaseInstances(couponInstances)
             }
         }
     }
@@ -801,7 +837,7 @@ class BatchScannerViewModel @Inject constructor(
         super.onCleared()
         // V2: Cleanup detector bitmap crops to prevent memory leaks
         try {
-            twoStageDetector.cleanupBitmaps()
+            twoStageDetector?.cleanupBitmaps()
             Log.d(TAG, "Cleaned up TwoStageDetector bitmap crops")
         } catch (e: Exception) {
             Log.e(TAG, "Error cleaning up TwoStageDetector", e)

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -53,7 +53,9 @@ class ScannerViewModel @Inject constructor(
     val uiState: StateFlow<ScannerUiState> = _uiState.asStateFlow()
 
     private val multiEngineOCR: MultiEngineOCR = MultiEngineOCR(context)
-    private val twoStageDetector: TwoStageDetector = TwoStageDetector(context)
+    private val detectorInitializationResult = initializeTwoStageDetector()
+    private val twoStageDetector: TwoStageDetector? = detectorInitializationResult.detector
+    private val detectorInitErrorMessage: String? = detectorInitializationResult.errorMessage
     private val uriPersistenceManager = UriPersistenceManager(context)
     private val fieldHeuristics: GenericFieldHeuristics = GenericFieldHeuristics
     private val manualOverrides = mutableMapOf<String, CouponInstance>()
@@ -134,13 +136,59 @@ class ScannerViewModel @Inject constructor(
         }
     }
 
+    private data class DetectorInitializationResult(
+        val detector: TwoStageDetector?,
+        val errorMessage: String?
+    )
+
+    private fun initializeTwoStageDetector(): DetectorInitializationResult {
+        return try {
+            DetectorInitializationResult(TwoStageDetector(context), null)
+        } catch (e: IllegalStateException) {
+            val message = e.message ?: "Multi-coupon detector assets are not available for this build."
+            Log.e(TAG, "TwoStageDetector initialization blocked", e)
+            telemetryService.trackExtractionResult(
+                ExtractResult.Failed(
+                    stage = ExtractionStage.TWO_STAGE_DETECTION,
+                    error = e
+                ),
+                RunPath(
+                    strategy = "LEGACY",
+                    final = "two_stage_detector_initialization_failure",
+                    reasons = mutableListOf("stub_mode_manifest")
+                )
+            )
+            DetectorInitializationResult(null, message)
+        } catch (e: Exception) {
+            val message = e.message ?: "Failed to initialize multi-coupon detector."
+            Log.e(TAG, "TwoStageDetector initialization failed", e)
+            telemetryService.trackExtractionResult(
+                ExtractResult.Failed(
+                    stage = ExtractionStage.TWO_STAGE_DETECTION,
+                    error = e
+                ),
+                RunPath(
+                    strategy = "LEGACY",
+                    final = "two_stage_detector_initialization_failure",
+                    reasons = mutableListOf("unexpected_initialization_error")
+                )
+            )
+            DetectorInitializationResult(null, message)
+        }
+    }
+
     init {
         // Assume network is available by default
         multiEngineOCR.setNetworkAvailability(true)
-        
-        // Log detector initialization
-        val modelInfo = twoStageDetector.getModelInfo()
-        Log.d(TAG, "TwoStageDetector initialized: $modelInfo")
+
+        // Surface detector initialization status
+        detectorInitErrorMessage?.let { error ->
+            Log.e(TAG, "TwoStageDetector unavailable: $error")
+            _uiState.value = ScannerUiState.Error(error)
+        } ?: run {
+            val modelInfo = twoStageDetector?.getModelInfo()
+            Log.d(TAG, "TwoStageDetector initialized: $modelInfo")
+        }
     }
 
     /**
@@ -202,31 +250,35 @@ class ScannerViewModel @Inject constructor(
     private suspend fun scanWithLegacyPath(imageUri: Uri, bitmap: Bitmap, persistImmediately: Boolean) {
         Log.d(TAG, "LEGACY path: Running two-stage detection")
 
-                // Run two-stage detection
-                val couponInstances = withContext(Dispatchers.IO) {
-                    twoStageDetector.detectMultiCoupons(bitmap)
-                }
+        val detector = twoStageDetector ?: run {
+            val message = detectorInitErrorMessage ?: "Multi-coupon detector is unavailable."
+            Log.e(TAG, "LEGACY path unavailable: $message")
+            _uiState.value = ScannerUiState.Error(message)
+            return
+        }
 
-                Log.d(TAG, "Two-stage detection completed: ${couponInstances.size} coupons detected")
+        // Run two-stage detection
+        val couponInstances = withContext(Dispatchers.IO) {
+            detector.detectMultiCoupons(bitmap)
+        }
 
-                when {
-                    couponInstances.isEmpty() -> {
-                // Try universal extraction first, then fallback to traditional OCR
+        Log.d(TAG, "Two-stage detection completed: ${couponInstances.size} coupons detected")
+
+        when {
+            couponInstances.isEmpty() -> {
                 Log.d(TAG, "No coupons detected, trying universal extraction first")
                 tryUniversalExtraction(imageUri, bitmap)
-                    }
-                    couponInstances.size == 1 -> {
-                        // Single coupon detected - process directly
-                        val couponInstance = couponInstances.first()
-                        processSingleCoupon(
-                            couponInstance = couponInstance,
-                            imageUri = imageUri.toString(),
-                            persistImmediately = persistImmediately
-                        )
-                    }
-                    else -> {
-                        // Multiple coupons detected - show selection interface
-                        _uiState.value = ScannerUiState.MultiCouponDetected(couponInstances, bitmap, imageUri.toString())
+            }
+            couponInstances.size == 1 -> {
+                val couponInstance = couponInstances.first()
+                processSingleCoupon(
+                    couponInstance = couponInstance,
+                    imageUri = imageUri.toString(),
+                    persistImmediately = persistImmediately
+                )
+            }
+            else -> {
+                _uiState.value = ScannerUiState.MultiCouponDetected(couponInstances, bitmap, imageUri.toString())
             }
         }
     }
@@ -716,9 +768,16 @@ class ScannerViewModel @Inject constructor(
                 _uiState.value = ScannerUiState.Scanning
                 Log.d(TAG, "Processing captured bitmap with two-stage detection")
 
+                val detector = twoStageDetector ?: run {
+                    val message = detectorInitErrorMessage ?: "Multi-coupon detector is unavailable."
+                    Log.e(TAG, "Captured image processing blocked: $message")
+                    _uiState.value = ScannerUiState.Error(message)
+                    return@launch
+                }
+
                 // Run two-stage detection
                 val couponInstances = withContext(Dispatchers.IO) {
-                    twoStageDetector.detectMultiCoupons(bitmap)
+                    detector.detectMultiCoupons(bitmap)
                 }
 
                 Log.d(TAG, "Two-stage detection on bitmap completed: ${couponInstances.size} coupons detected")
@@ -797,7 +856,7 @@ class ScannerViewModel @Inject constructor(
             Log.e(TAG, "Error processing single coupon", e)
             _uiState.value = ScannerUiState.Error("Error processing coupon: ${e.message}")
         } finally {
-            twoStageDetector.releaseInstances(listOf(couponInstance))
+            twoStageDetector?.releaseInstances(listOf(couponInstance))
         }
     }
 
@@ -989,7 +1048,7 @@ class ScannerViewModel @Inject constructor(
                 Log.e(TAG, "Error processing coupon $index", e)
                 // Continue with other coupons
             } finally {
-                twoStageDetector.releaseInstances(listOf(instance))
+                twoStageDetector?.releaseInstances(listOf(instance))
             }
         }
 
@@ -1643,7 +1702,7 @@ class ScannerViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         try {
-            twoStageDetector.cleanupBitmaps()
+            twoStageDetector?.cleanupBitmaps()
         } catch (e: Exception) {
             Log.e(TAG, "Error cleaning up TwoStageDetector", e)
         }


### PR DESCRIPTION
## Summary
- ensure the two-stage detector fails fast in production when the manifest is flagged stub_mode and allow injecting the debug flag for tests
- surface detector initialization errors in the scanner and batch scanner view models so the UI and logs reflect an unusable detector instead of proceeding
- add instrumentation coverage proving production builds with stub assets throw instead of returning empty detections

## Testing
- ⚠️ `./gradlew testDebugUnitTest` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb207e1788328a1ffce9005ece042