### PR TITLE
Fail two-stage detector initialization when stub assets used in production

### DIFF
--- a/app/src/androidTest/java/com/example/coupontracker/ml/TwoStageDetectorStubModeTest.kt
+++ b/app/src/androidTest/java/com/example/coupontracker/ml/TwoStageDetectorStubModeTest.kt
@@ -24,4 +24,36 @@ class TwoStageDetectorStubModeTest {
             message.contains("stub_mode", ignoreCase = true)
         )
     }
+
+    @Test
+    fun initializeModelsThrowsWhenInvokedManuallyInProduction() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+        val detector = TwoStageDetector(
+            context = context,
+            isDebugBuild = false,
+            initializeOnCreate = false
+        )
+
+        val initializeMethod = TwoStageDetector::class.java.getDeclaredMethod("initializeModels")
+        initializeMethod.isAccessible = true
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            try {
+                initializeMethod.invoke(detector)
+            } catch (invocationException: java.lang.reflect.InvocationTargetException) {
+                val cause = invocationException.cause
+                if (cause is IllegalStateException) {
+                    throw cause
+                }
+                throw invocationException
+            }
+        }
+
+        val message = exception.message ?: ""
+        assertTrue(
+            "Expected manual initialization to fail for stub_mode manifest",
+            message.contains("stub_mode", ignoreCase = true)
+        )
+    }
 }

--- a/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ml/TwoStageDetector.kt
@@ -88,73 +88,69 @@ class TwoStageDetector(
      * Initialize both stage models and processors
      */
     private fun initializeModels() {
-        try {
-            Log.d(TAG, "Initializing two-stage detection models...")
+        Log.d(TAG, "Initializing two-stage detection models...")
 
-            // Load model manifest
-            loadModelManifest()
+        // Always assume initialization is incomplete until the end
+        isInitialized = false
 
-            if (stubMode) {
-                if (isDebugBuild) {
-                    Log.w(
-                        TAG,
-                        "Multi-coupon manifest is marked as stub_mode. Skipping TensorFlow Lite interpreter initialization. " +
-                            "Replace the placeholder assets with trained binaries for production use."
-                    )
-                    stage1Interpreter = null
-                    stage2Interpreter = null
-                    initializeImageProcessors()
-                    isInitialized = true
-                    return
-                } else {
-                    val message = "Two-stage detector manifest is marked stub_mode=true; trained assets are required for production builds."
-                    Log.e(TAG, message)
-                    throw IllegalStateException(message)
-                }
-            }
+        // Load model manifest
+        loadModelManifest()
 
-            // Try to load models, but fallback gracefully if they're placeholders
-            var modelsLoaded = false
-            try {
-                // Load Stage 1 Model (Coupon Detection)
-                loadStage1Model()
-
-                // Load Stage 2 Model (Field Detection)
-                loadStage2Model()
-
-                modelsLoaded = true
-                Log.i(TAG, "Production models loaded successfully")
-
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to load production models (likely placeholders): ${e.message}")
-
-                if (demoMode) {
-                    Log.i(TAG, "Demo mode enabled - continuing with placeholder models for synthetic detections")
-                    stage1Interpreter = null
-                    stage2Interpreter = null
-                    modelsLoaded = true // Allow demo mode to work
-                } else {
-                    Log.e(TAG, "No demo mode fallback available, initialization failed")
-                    throw e
-                }
-            }
-
-            if (modelsLoaded) {
-                // Initialize image processors
+        if (stubMode) {
+            if (isDebugBuild) {
+                Log.w(
+                    TAG,
+                    "Multi-coupon manifest is marked as stub_mode. Skipping TensorFlow Lite interpreter initialization. " +
+                        "Replace the placeholder assets with trained binaries for production use."
+                )
+                stage1Interpreter = null
+                stage2Interpreter = null
                 initializeImageProcessors()
                 isInitialized = true
-
-                if (demoMode) {
-                    Log.i(TAG, "Two-stage detector initialized in demo mode")
-                } else {
-                    Log.i(TAG, "Two-stage detector initialized with production models")
-                }
+                return
+            } else {
+                val message = "Two-stage detector manifest is marked stub_mode=true; trained assets are required for production builds."
+                Log.e(TAG, message)
+                throw IllegalStateException(message)
             }
+        }
+
+        // Try to load models, but fallback gracefully if they're placeholders
+        var modelsLoaded = false
+        try {
+            // Load Stage 1 Model (Coupon Detection)
+            loadStage1Model()
+
+            // Load Stage 2 Model (Field Detection)
+            loadStage2Model()
+
+            modelsLoaded = true
+            Log.i(TAG, "Production models loaded successfully")
 
         } catch (e: Exception) {
-            Log.e(TAG, "Error initializing models", e)
-            isInitialized = false
-            throw e
+            Log.w(TAG, "Failed to load production models (likely placeholders): ${e.message}")
+
+            if (demoMode) {
+                Log.i(TAG, "Demo mode enabled - continuing with placeholder models for synthetic detections")
+                stage1Interpreter = null
+                stage2Interpreter = null
+                modelsLoaded = true // Allow demo mode to work
+            } else {
+                Log.e(TAG, "No demo mode fallback available, initialization failed")
+                throw e
+            }
+        }
+
+        if (modelsLoaded) {
+            // Initialize image processors
+            initializeImageProcessors()
+            isInitialized = true
+
+            if (demoMode) {
+                Log.i(TAG, "Two-stage detector initialized in demo mode")
+            } else {
+                Log.i(TAG, "Two-stage detector initialized with production models")
+            }
         }
     }
     

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
@@ -47,20 +47,21 @@ class BatchScannerViewModel @Inject constructor(
 
     private data class DetectorInitializationResult(
         val detector: com.example.coupontracker.ml.TwoStageDetector?,
-        val errorMessage: String?
+        val errorMessage: String?,
+        val exception: Throwable?
     )
 
     private fun initializeTwoStageDetector(): DetectorInitializationResult {
         return try {
-            DetectorInitializationResult(com.example.coupontracker.ml.TwoStageDetector(context), null)
+            DetectorInitializationResult(com.example.coupontracker.ml.TwoStageDetector(context), null, null)
         } catch (e: IllegalStateException) {
             val message = e.message ?: "Multi-coupon detector assets are not available for this build."
             Log.e(TAG, "TwoStageDetector initialization blocked", e)
-            DetectorInitializationResult(null, message)
+            DetectorInitializationResult(null, message, e)
         } catch (e: Exception) {
             val message = e.message ?: "Failed to initialize multi-coupon detector."
             Log.e(TAG, "TwoStageDetector initialization failed", e)
-            DetectorInitializationResult(null, message)
+            DetectorInitializationResult(null, message, e)
         }
     }
 
@@ -70,8 +71,9 @@ class BatchScannerViewModel @Inject constructor(
         Log.d(TAG, "MultiEngineOCR network availability enabled for batch processing")
 
         detectorInitErrorMessage?.let { error ->
-            Log.e(TAG, "TwoStageDetector unavailable for batch scanning: $error")
-            updateState { it.copy(error = error) }
+            val message = "Multi-coupon detection unavailable: $error"
+            Log.e(TAG, message, detectorInitializationResult.exception)
+            updateState { it.copy(error = message) }
         }
     }
 

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -138,12 +138,13 @@ class ScannerViewModel @Inject constructor(
 
     private data class DetectorInitializationResult(
         val detector: TwoStageDetector?,
-        val errorMessage: String?
+        val errorMessage: String?,
+        val exception: Throwable?
     )
 
     private fun initializeTwoStageDetector(): DetectorInitializationResult {
         return try {
-            DetectorInitializationResult(TwoStageDetector(context), null)
+            DetectorInitializationResult(TwoStageDetector(context), null, null)
         } catch (e: IllegalStateException) {
             val message = e.message ?: "Multi-coupon detector assets are not available for this build."
             Log.e(TAG, "TwoStageDetector initialization blocked", e)
@@ -158,7 +159,7 @@ class ScannerViewModel @Inject constructor(
                     reasons = mutableListOf("stub_mode_manifest")
                 )
             )
-            DetectorInitializationResult(null, message)
+            DetectorInitializationResult(null, message, e)
         } catch (e: Exception) {
             val message = e.message ?: "Failed to initialize multi-coupon detector."
             Log.e(TAG, "TwoStageDetector initialization failed", e)
@@ -173,7 +174,7 @@ class ScannerViewModel @Inject constructor(
                     reasons = mutableListOf("unexpected_initialization_error")
                 )
             )
-            DetectorInitializationResult(null, message)
+            DetectorInitializationResult(null, message, e)
         }
     }
 
@@ -183,8 +184,9 @@ class ScannerViewModel @Inject constructor(
 
         // Surface detector initialization status
         detectorInitErrorMessage?.let { error ->
-            Log.e(TAG, "TwoStageDetector unavailable: $error")
-            _uiState.value = ScannerUiState.Error(error)
+            val message = "Multi-coupon detection unavailable: $error"
+            Log.e(TAG, message, detectorInitializationResult.exception)
+            _uiState.value = ScannerUiState.Error(message)
         } ?: run {
             val modelInfo = twoStageDetector?.getModelInfo()
             Log.d(TAG, "TwoStageDetector initialized: $modelInfo")


### PR DESCRIPTION
## Summary
- let `TwoStageDetector` surface stub manifest errors instead of continuing with uninitialized interpreters
- have scanner view models expose clear error messaging when detector initialization fails
- extend the stub-mode instrumentation test to cover manual initialization attempts

## Testing
- ./gradlew testDebugUnitTest *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb6af782483288c455658257edc9f