### PR TITLE
Run TwoStageDetector production regression as instrumentation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,16 @@ python coupon_trainer_cli.py --url <URL> --output-dir <OUTPUT_DIR>
 ## 🧪 Testing
 
 ### **Instrumentation (Connected) Tests**
-Run the connected test suite to verify on-device TensorFlow Lite integration, including the `TwoStageDetectorProductionTest` that exercises the demo detections:
+Run the connected test suite to verify on-device TensorFlow Lite integration, including the `TwoStageDetectorProductionTest` that exercises the production detector with the device/emulator's native TensorFlow Lite runtime:
 
 ```bash
 ./gradlew connectedAndroidTest
+```
+
+For CI or local scripting workflows, use the helper wrapper which simply forwards to the same Gradle task from the project root:
+
+```bash
+./scripts/run_connected_android_tests.sh
 ```
 
 ## 📊 Key Features

--- a/app/src/androidTest/java/com/example/coupontracker/ml/TwoStageDetectorProductionTest.kt
+++ b/app/src/androidTest/java/com/example/coupontracker/ml/TwoStageDetectorProductionTest.kt
@@ -4,7 +4,8 @@ import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.After
-import org.junit.Assert.assertNull
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -28,29 +29,26 @@ class TwoStageDetectorProductionTest {
     }
 
     @Test
-    fun demoManifestInitializesWithoutInterpretersButProvidesDetections() {
+    fun productionModelsLoadAndReturnRealDetections() {
         val modelInfo = detector.getModelInfo()
         val isInitialized = modelInfo["isInitialized"] as? Boolean ?: false
+        val demoModeEnabled = readPrivateField<Boolean>("demoMode")
+        val stubModeEnabled = readPrivateField<Boolean>("stubMode")
+
+        assertFalse("Detector should not initialize in demo mode", demoModeEnabled)
+        assertFalse("Detector should not initialize in stub mode", stubModeEnabled)
         assertTrue("Detector should report initialized when manifest is present", isInitialized)
 
         val stage1Interpreter = readPrivateField<Interpreter?>("stage1Interpreter")
         val stage2Interpreter = readPrivateField<Interpreter?>("stage2Interpreter")
 
-        assertNull("Stage 1 interpreter should not initialize in stub/demo mode", stage1Interpreter)
-        assertNull("Stage 2 interpreter should not initialize in stub/demo mode", stage2Interpreter)
+        assertNotNull("Stage 1 interpreter should initialize in production mode", stage1Interpreter)
+        assertNotNull("Stage 2 interpreter should initialize in production mode", stage2Interpreter)
 
         val bitmap = Bitmap.createBitmap(1280, 720, Bitmap.Config.ARGB_8888)
         val detections = detector.detectMultiCoupons(bitmap)
 
-        assertTrue("Demo detections should be returned when demo_mode is true", detections.isNotEmpty())
-        assertTrue(
-            "Each detection should include code and benefit regions",
-            detections.all { instance ->
-                val fields = instance.fields
-                fields.any { it.fieldType == FieldType.CODE_REGION } &&
-                    fields.any { it.fieldType == FieldType.BENEFIT_REGION }
-            }
-        )
+        assertTrue("Production detector should not return demo detections on blank input", detections.isEmpty())
 
         detector.releaseInstances(detections)
         bitmap.recycle()

--- a/app/src/main/assets/models/multi_coupon/manifest.json
+++ b/app/src/main/assets/models/multi_coupon/manifest.json
@@ -1,5 +1,5 @@
 {
-  "model_version": "1.0.0-demo",
+  "model_version": "1.0.0",
   "model_type": "two_stage_yolo",
   "stage1_model": "stage1_coupon_detector.tflite",
   "stage2_model": "stage2_field_detector.tflite",
@@ -25,7 +25,7 @@
   ],
   "confidence_threshold": 0.5,
   "iou_threshold": 0.4,
-  "stub_mode": true,
-  "stub_notes": "Demo mode: Returns synthetic multi-coupon detections for testing UI",
-  "demo_mode": true
+  "stub_mode": false,
+  "stub_notes": "Production mode: Loads trained TensorFlow Lite interpreters",
+  "demo_mode": false
 }

--- a/scripts/run_connected_android_tests.sh
+++ b/scripts/run_connected_android_tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "$PROJECT_ROOT"
+
+./gradlew connectedAndroidTest


### PR DESCRIPTION
## Summary
- switch TwoStageDetectorProductionTest to an AndroidJUnit4 instrumentation test that reads the instrumentation context and verifies production interpreters
- enable production mode in the multi-coupon manifest so TensorFlow Lite models load instead of falling back to demo detections
- document and script the connected Android test command for CI consumption

## Testing
- not run (emulator not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbb8901f708328aadd5fa3d954e461