### PR TITLE
Stop returning placeholder OCR data and add fallback regression test

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/EnhancedOCRHelper.kt
@@ -51,11 +51,11 @@ class EnhancedOCRHelper {
                 Log.d(TAG, "Processing image from URI with preprocessing")
                 
                 // Use the real ML Kit implementation
-                try {
-                    return@withContext mlKitRealTextRecognition.processImageFromUri(context, imageUri)
+                return@withContext try {
+                    mlKitRealTextRecognition.processImageFromUri(context, imageUri)
                 } catch (e: Exception) {
-                    Log.e(TAG, "Real ML Kit processing failed, falling back to dummy text", e)
-                    return@withContext getDummyText()
+                    Log.e(TAG, "Real ML Kit processing failed", e)
+                    throw e
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Error processing image from URI", e)
@@ -73,30 +73,17 @@ class EnhancedOCRHelper {
                 Log.d(TAG, "Processing bitmap with preprocessing")
                 
                 // Use the real ML Kit implementation
-                try {
-                    return@withContext mlKitRealTextRecognition.processImageFromBitmap(bitmap)
+                return@withContext try {
+                    mlKitRealTextRecognition.processImageFromBitmap(bitmap)
                 } catch (e: Exception) {
-                    Log.e(TAG, "Real ML Kit processing failed, falling back to dummy text", e)
-                    return@withContext getDummyText()
+                    Log.e(TAG, "Real ML Kit processing failed", e)
+                    throw e
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Error processing bitmap", e)
                 throw e
             }
         }
-    }
-    
-    /**
-     * Create dummy text for testing
-     */
-    private fun getDummyText(): String {
-        return """
-            STORE: Example Store
-            CODE: EXAMPLE20
-            Get 20% off your next purchase
-            Valid until: 12/31/2023
-            Description: This is an example coupon for testing
-        """.trimIndent()
     }
     
     /**

--- a/app/src/main/kotlin/com/example/coupontracker/util/MultiEngineOCR.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/MultiEngineOCR.kt
@@ -42,14 +42,19 @@ class MultiEngineOCR(
                 }
                 
                 Log.d(TAG, "Processing image with OCR Engine")
-                try {
+                return@withContext try {
                     val text = ocrEngine.processImage(imageUri)
                     val extractedInfo = ocrEngine.extractCouponInfo(text)
-                    
-                    return@withContext OCRResult.Success(text, extractedInfo)
+
+                    if (text.isBlank() || isPlaceholderResult(text, extractedInfo)) {
+                        Log.w(TAG, "OCR returned placeholder or empty text")
+                        OCRResult.Error("OCR returned placeholder data")
+                    } else {
+                        OCRResult.Success(text, extractedInfo)
+                    }
                 } catch (e: Exception) {
                     Log.e(TAG, "OCR Engine failed", e)
-                    return@withContext OCRResult.Error("OCR processing failed: ${e.message}")
+                    OCRResult.Error("OCR processing failed: ${e.message}")
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "OCR processing failed", e)
@@ -70,19 +75,36 @@ class MultiEngineOCR(
                 }
                 
                 Log.d(TAG, "Processing bitmap with OCR Engine")
-                try {
+                return@withContext try {
                     val text = ocrEngine.processImage(bitmap)
                     val extractedInfo = ocrEngine.extractCouponInfo(text)
-                    
-                    return@withContext OCRResult.Success(text, extractedInfo)
+
+                    if (text.isBlank() || isPlaceholderResult(text, extractedInfo)) {
+                        Log.w(TAG, "OCR returned placeholder or empty text")
+                        OCRResult.Error("OCR returned placeholder data")
+                    } else {
+                        OCRResult.Success(text, extractedInfo)
+                    }
                 } catch (e: Exception) {
                     Log.e(TAG, "OCR Engine failed", e)
-                    return@withContext OCRResult.Error("OCR processing failed: ${e.message}")
+                    OCRResult.Error("OCR processing failed: ${e.message}")
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "OCR processing failed", e)
                 return@withContext OCRResult.Error("OCR processing failed: ${e.message}")
             }
+        }
+    }
+
+    private fun isPlaceholderResult(text: String, extractedInfo: Map<String, String>): Boolean {
+        val normalizedText = text.lowercase()
+        if (normalizedText.contains("example store") || normalizedText.contains("example20")) {
+            return true
+        }
+
+        val normalizedValues = extractedInfo.values.map { it.lowercase() }
+        return normalizedValues.any { value ->
+            value.contains("example store") || value.contains("example20")
         }
     }
     

--- a/app/src/test/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModelTest.kt
@@ -1,0 +1,121 @@
+package com.example.coupontracker.ui.viewmodel
+
+import android.app.Application
+import android.graphics.Bitmap
+import android.net.Uri
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.core.app.ApplicationProvider
+import com.example.coupontracker.data.model.Coupon
+import com.example.coupontracker.data.repository.CouponRepository
+import com.example.coupontracker.util.BitmapManager
+import com.example.coupontracker.util.ExtractResult
+import com.example.coupontracker.util.ExtractionSignals
+import com.example.coupontracker.util.ExtractionStage
+import com.example.coupontracker.util.LocalLlmOcrService
+import com.example.coupontracker.util.MultiEngineOCR
+import com.example.coupontracker.util.UriPersistenceManager
+import com.example.coupontracker.util.CouponInfo
+import com.example.coupontracker.universal.UniversalExtractionService
+import io.mockk.any
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.jvm.isAccessible
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class BatchScannerViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Test
+    fun `processWithOcrFirstPath falls back to LLM when OCR fails`() = runTest {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val repository = mockk<CouponRepository>(relaxed = true)
+        val bitmapManager = mockk<BitmapManager>(relaxed = true)
+        val llmService = mockk<LocalLlmOcrService>()
+        val universalExtractionService = mockk<UniversalExtractionService>(relaxed = true)
+
+        val viewModel = BatchScannerViewModel(
+            application,
+            application,
+            repository,
+            bitmapManager,
+            llmService,
+            universalExtractionService
+        )
+
+        val multiEngineMock = mockk<MultiEngineOCR>()
+        coEvery { multiEngineMock.processImage(any<Bitmap>()) } returns MultiEngineOCR.OCRResult.Error("ocr boom")
+
+        val uriPersistenceManagerMock = mockk<UriPersistenceManager>()
+        val persistedUri = Uri.parse("content://persisted")
+        coEvery { uriPersistenceManagerMock.persistUri(any()) } returns persistedUri
+
+        setPrivateField(viewModel, "multiEngineOCR", multiEngineMock)
+        setPrivateField(viewModel, "uriPersistenceManager", uriPersistenceManagerMock)
+
+        val couponInfo = CouponInfo(
+            storeName = "LLM Store",
+            description = "LLM description",
+            cashbackAmount = 10.0,
+            redeemCode = "LLM123",
+            discountType = "PERCENTAGE"
+        )
+        coEvery { llmService.processCouponImageTyped(any()) } returns ExtractResult.Good(
+            info = couponInfo,
+            signals = ExtractionSignals(
+                qualityScore = 95,
+                fieldConfidences = emptyMap(),
+                processingTimeMs = 12,
+                memoryUsageMB = 1.2f,
+                stage = ExtractionStage.LLM
+            )
+        )
+
+        val bitmap = Bitmap.createBitmap(8, 8, Bitmap.Config.ARGB_8888)
+        val uri = Uri.parse("content://test")
+
+        val result = callPrivateSuspend(viewModel, "processWithOcrFirstPath", uri, bitmap, true)
+
+        assertIs<Coupon>(result)
+        assertEquals("LLM Store", result.storeName)
+        assertEquals("LLM123", result.redeemCode)
+        assertFalse(result.storeName.contains("Example", ignoreCase = true))
+        assertEquals(persistedUri.toString(), result.imageUri)
+
+        coVerify { multiEngineMock.processImage(bitmap) }
+        coVerify { llmService.processCouponImageTyped(bitmap) }
+        coVerify { uriPersistenceManagerMock.persistUri(uri) }
+
+        bitmap.recycle()
+    }
+
+    private suspend fun callPrivateSuspend(
+        target: Any,
+        functionName: String,
+        vararg args: Any?
+    ): Any? {
+        val function = target::class.declaredFunctions.first { it.name == functionName }
+        function.isAccessible = true
+        return function.callSuspend(target, *args)
+    }
+
+    private fun setPrivateField(target: Any, fieldName: String, value: Any) {
+        val field = target::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+}


### PR DESCRIPTION
## Summary
- stop EnhancedOCRHelper from fabricating success text and surface ML Kit failures
- treat OCR engine exceptions or placeholder strings as MultiEngineOCR errors so fallbacks can engage
- add a BatchScannerViewModel regression test that verifies the OCR-first path falls back to LLM output when OCR fails

## Testing
- ./gradlew test --tests com.example.coupontracker.ui.viewmodel.BatchScannerViewModelTest *(fails: Android SDK not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbc3782e483288624b81bdc0f92e3