### PR TITLE
Fix GGUF magic constant to accept MiniCPM models

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/llm/GgufModelLoader.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/GgufModelLoader.kt
@@ -20,7 +20,7 @@ class GgufModelLoader @Inject constructor(
 ) {
     companion object {
         private const val TAG = "GgufModelLoader"
-        private const val GGUF_MAGIC = 0x46554747  // "GGUF"
+        private const val GGUF_MAGIC = 0x47475546  // "GGUF"
     }
     
     data class GgufMetadata(


### PR DESCRIPTION
## Summary
- update the GGUF magic constant to match the ASCII value used in valid MiniCPM model files

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dccaf3702c8328a8bf179b23ead6a9