### PR TITLE
Populate scanned coupon metadata into coupon form

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/CouponFormViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/CouponFormViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.example.coupontracker.data.model.Coupon
+import com.example.coupontracker.data.model.CashbackType
 import com.example.coupontracker.data.repository.CouponRepository
 import com.example.coupontracker.data.util.CouponDedupUtils
 import com.example.coupontracker.util.CouponInfo
@@ -19,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 
 /**
@@ -170,12 +172,33 @@ class CouponFormViewModel @Inject constructor(
      * Map a Coupon object to CouponInfo
      */
     private fun mapCouponToCouponInfo(coupon: Coupon): CouponInfo {
+        val cashbackInfo = coupon.getCashbackInfo()
+        val discountType = when (coupon.cashbackType?.lowercase(Locale.ROOT)) {
+            "percent" -> "PERCENTAGE"
+            "amount" -> "AMOUNT"
+            "text" -> "TEXT"
+            else -> when (cashbackInfo.type) {
+                CashbackType.PERCENT -> "PERCENTAGE"
+                CashbackType.AMOUNT -> "AMOUNT"
+                CashbackType.TEXT -> null
+            }
+        }
+
         return CouponInfo(
             storeName = coupon.storeName,
             description = coupon.description,
-            cashbackAmount = coupon.cashbackAmount,
+            expiryDate = coupon.expiryDate,
+            cashbackAmount = coupon.cashbackValueNum ?: cashbackInfo.valueNum,
             redeemCode = coupon.redeemCode,
-            expiryDate = coupon.expiryDate
+            category = coupon.category,
+            rating = coupon.rating,
+            status = coupon.status,
+            discountType = discountType,
+            minimumPurchase = coupon.minimumPurchase,
+            maximumDiscount = coupon.maximumDiscount,
+            paymentMethod = coupon.paymentMethod,
+            platformType = coupon.platformType,
+            usageLimit = coupon.usageLimit
         )
     }
 

--- a/app/src/main/kotlin/com/example/coupontracker/util/CouponInputManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/CouponInputManager.kt
@@ -216,16 +216,37 @@ class CouponInputManager(
                 }
 
                 // Convert CouponInfo to Coupon
+                val normalizedDiscountType = when (couponInfo.discountType?.uppercase(Locale.ROOT)) {
+                    "PERCENTAGE" -> "percent"
+                    "AMOUNT" -> "amount"
+                    "TEXT" -> "text"
+                    else -> null
+                }
+                val cashbackValueNum = couponInfo.cashbackAmount
+                val category = couponInfo.category?.takeIf { it.isNotBlank() }
+                val status = couponInfo.status?.takeIf { it.isNotBlank() }
+                val paymentMethod = couponInfo.paymentMethod?.takeIf { it.isNotBlank() }
+                val platformType = couponInfo.platformType?.takeIf { it.isNotBlank() }
+                val rating = couponInfo.rating?.takeIf { it.isNotBlank() }
+
                 return@withContext Coupon(
                     id = 0,
                     storeName = couponInfo.storeName.ifBlank { "Unknown Store" },
                     description = couponInfo.description.ifBlank { "No description" },
                     expiryDate = normalizedExpiry,
-                    cashbackAmount = couponInfo.cashbackAmount ?: 0.0,
+                    cashbackAmount = cashbackValueNum ?: 0.0,
                     redeemCode = couponInfo.redeemCode,
                     imageUri = null, // We'll set this later in the ViewModel
-                    category = couponInfo.category,
-                    status = couponInfo.status ?: "Active",
+                    category = category,
+                    status = status ?: "Active",
+                    cashbackType = normalizedDiscountType,
+                    cashbackValueNum = cashbackValueNum,
+                    minimumPurchase = couponInfo.minimumPurchase,
+                    maximumDiscount = couponInfo.maximumDiscount,
+                    paymentMethod = paymentMethod,
+                    usageLimit = couponInfo.usageLimit,
+                    platformType = platformType,
+                    rating = rating,
                     createdAt = Date(),
                     updatedAt = Date()
                 )


### PR DESCRIPTION
## Summary
- map all relevant coupon fields into CouponInfo so the form can display category, status, payment method, and discount metadata
- propagate discount typing and purchase requirements from CouponInfo into the Coupon model during OCR processing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcd33c044c832888af2f3e81493217