### PR TITLE
Reset expiry when coupon info lacks date

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/CouponFormScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/CouponFormScreen.kt
@@ -71,11 +71,15 @@ fun CouponFormScreen(
             description = info.description
             amount = info.cashbackAmount?.toString() ?: ""
             code = info.redeemCode ?: ""
+            category = info.category ?: ""
 
             // Format expiry date if available
-            info.expiryDate?.let { date ->
+            val expiryDate = info.expiryDate
+            if (expiryDate != null) {
                 val format = SimpleDateFormat("MM/dd/yyyy", Locale.getDefault())
-                expiryDateString = format.format(date)
+                expiryDateString = format.format(expiryDate)
+            } else {
+                expiryDateString = ""
             }
         }
     }


### PR DESCRIPTION
## Summary
- update the coupon form screen to keep the category field in sync with scanned coupon info
- clear the expiry date field when the scanned coupon has no expiry to prevent stale values

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcd475386c8328b79a2ecbcc47a6b0