### PR TITLE
Persist coupon form image URI state

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/CouponFormScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/CouponFormScreen.kt
@@ -47,6 +47,12 @@ fun CouponFormScreen(
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
 
+    val persistedImageUri = uiState.persistedImageUri
+    val previewImageUriString = persistedImageUri ?: imageUri
+    val previewImageUri = previewImageUriString
+        ?.takeIf { it.isNotBlank() }
+        ?.let { Uri.parse(it) }
+
     // Form fields
     var storeName by remember { mutableStateOf(uiState.couponInfo?.storeName ?: "") }
     var description by remember { mutableStateOf(uiState.couponInfo?.description ?: "") }
@@ -130,7 +136,7 @@ fun CouponFormScreen(
             onExpiryDateStringChange = { expiryDateString = it },
             category = category,
             onCategoryChange = { category = it },
-            imageUri = imageUri?.let { Uri.parse(it) },
+            imageUri = previewImageUri,
             onSave = {
                 val amountValue = amount.toDoubleOrNull() ?: 0.0
                 val expiryDate = try {
@@ -151,7 +157,7 @@ fun CouponFormScreen(
                     code = code,
                     expiryDate = expiryDate,
                     category = category,
-                    imageUri = imageUri
+                    imageUri = previewImageUriString?.takeIf { it.isNotBlank() }
                 )
             },
             isSaving = uiState.isSaving,

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/CouponFormViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/CouponFormViewModel.kt
@@ -69,7 +69,13 @@ class CouponFormViewModel @Inject constructor(
                 // Convert to coupon info
                 val couponInfo = mapCouponToCouponInfo(coupon)
 
-                updateState { it.copy(isProcessing = false, couponInfo = couponInfo) }
+                updateState {
+                    it.copy(
+                        isProcessing = false,
+                        couponInfo = couponInfo,
+                        persistedImageUri = coupon.imageUri
+                    )
+                }
             } catch (e: Exception) {
                 handleError(e, "Error processing image")
             }
@@ -113,9 +119,11 @@ class CouponFormViewModel @Inject constructor(
                 }
 
                 // Create and save coupon object
+                val persistedImageUri = _uiState.value.persistedImageUri ?: imageUri
+
                 val coupon = createCoupon(
                     storeName, description, amount, code,
-                    expiryDate, category, imageUri
+                    expiryDate, category, persistedImageUri
                 )
                 val normalizedDescription = CouponDedupUtils.normalizeDescription(coupon.description)
                 val savedCouponId = couponRepository.saveOrMergeCoupon(
@@ -240,7 +248,8 @@ data class CouponFormUiState(
     val couponInfo: CouponInfo? = null,
     val error: String? = null,
     val saveResult: CouponSaveResult? = null,
-    val savedCoupon: Coupon? = null
+    val savedCoupon: Coupon? = null,
+    val persistedImageUri: String? = null
 )
 
 enum class CouponSaveResult {


### PR DESCRIPTION
## Summary
- add a persisted image URI to the coupon form state populated after image processing
- show the persisted image in the form preview and use it when saving, falling back to the navigation URI only if needed
- prefer the persisted URI when constructing coupons so saved records store the long-lived reference

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcd66921f483288b7a875f94aed0d3