### PR TITLE
Add OCR-backed region extraction for universal detector

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/di/UniversalExtractionModule.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/di/UniversalExtractionModule.kt
@@ -1,6 +1,7 @@
 package com.example.coupontracker.di
 
 import com.example.coupontracker.data.local.LearnedPatternDao
+import com.example.coupontracker.ocr.OcrEngine
 import com.example.coupontracker.universal.AdaptiveConfidenceScorer
 import com.example.coupontracker.universal.PatternLearningEngine
 import com.example.coupontracker.universal.UniversalExtractionService
@@ -43,9 +44,10 @@ object UniversalExtractionModule {
     fun provideUniversalFieldDetector(
         patternLearner: PatternLearningEngine,
         layoutAnalyzer: UniversalLayoutAnalyzer,
-        confidenceScorer: AdaptiveConfidenceScorer
+        confidenceScorer: AdaptiveConfidenceScorer,
+        ocrEngine: OcrEngine
     ): UniversalFieldDetector {
-        return UniversalFieldDetector(patternLearner, layoutAnalyzer, confidenceScorer)
+        return UniversalFieldDetector(patternLearner, layoutAnalyzer, confidenceScorer, ocrEngine)
     }
 
     @Provides

--- a/app/src/main/kotlin/com/example/coupontracker/universal/UniversalFieldDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/universal/UniversalFieldDetector.kt
@@ -3,11 +3,15 @@ package com.example.coupontracker.universal
 import android.graphics.Bitmap
 import android.util.Log
 import com.example.coupontracker.data.model.FieldType
+import com.example.coupontracker.ocr.OcrEngine
 import com.example.coupontracker.util.IndianDateParser
 import com.example.coupontracker.util.IndianCurrencyParser
 import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
 
 /**
  * Universal field detector that uses visual, textual, and learned patterns
@@ -17,7 +21,8 @@ import javax.inject.Singleton
 class UniversalFieldDetector @Inject constructor(
     private val patternLearner: PatternLearningEngine,
     private val layoutAnalyzer: UniversalLayoutAnalyzer,
-    private val confidenceScorer: AdaptiveConfidenceScorer
+    private val confidenceScorer: AdaptiveConfidenceScorer,
+    private val ocrEngine: OcrEngine
 ) {
     companion object {
         private const val TAG = "UniversalFieldDetector"
@@ -51,15 +56,29 @@ class UniversalFieldDetector @Inject constructor(
      */
     private suspend fun detectCouponCodes(
         image: Bitmap,
-        text: String, 
+        text: String,
         layout: CouponLayout,
         context: ExtractionContext
     ): List<ExtractionCandidate> {
-        
+
         val candidates = mutableListOf<ExtractionCandidate>()
-        
+        val seenRegionCodes = mutableSetOf<String>()
+
         // Strategy 1: Visual cues (boxes, highlighting, distinct fonts)
         layout.codeRegion?.let { region ->
+            val regionText = extractTextFromRegion(image, region)
+            val normalized = normalizeCodeText(regionText)
+            if (normalized.isNotEmpty() && seenRegionCodes.add(normalized)) {
+                candidates.add(
+                    ExtractionCandidate(
+                        text = normalized,
+                        confidence = 0.9f,
+                        source = ExtractionSource.VISUAL_REGION,
+                        context = mapOf("region" to "code")
+                    )
+                )
+            }
+
             val visualCandidates = detectVisuallyDistinctCodes(image, region)
             candidates.addAll(visualCandidates)
         }
@@ -205,14 +224,16 @@ class UniversalFieldDetector @Inject constructor(
     ): List<ExtractionCandidate> {
         
         val candidates = mutableListOf<ExtractionCandidate>()
-        
+        val seenRegionStores = mutableSetOf<String>()
+
         // Look for store names in logo region (usually top)
         layout.logoRegion?.let { region ->
             val logoText = extractTextFromRegion(image, region)
-            if (logoText.isNotBlank()) {
+            val normalized = normalizeRegionText(logoText)
+            if (normalized.isNotBlank() && seenRegionStores.add(normalized.lowercase(Locale.ROOT))) {
                 candidates.add(
                     ExtractionCandidate(
-                        text = logoText.trim(),
+                        text = normalized,
                         confidence = 0.8f, // High confidence for logo region
                         source = ExtractionSource.VISUAL_REGION,
                         context = mapOf("region" to "logo")
@@ -376,10 +397,42 @@ class UniversalFieldDetector @Inject constructor(
         return confidence.coerceAtMost(1.0f)
     }
     
-    private fun extractTextFromRegion(image: Bitmap, region: Region): String {
-        // TODO: Implement OCR on specific image region
-        // This would crop the image to the region and run OCR
-        return ""
+    private suspend fun extractTextFromRegion(image: Bitmap, region: Region): String {
+        var croppedBitmap: Bitmap? = null
+        return try {
+            val bounds = region.bounds
+            val left = bounds.left.coerceIn(0f, image.width.toFloat())
+            val top = bounds.top.coerceIn(0f, image.height.toFloat())
+            val right = bounds.right.coerceIn(0f, image.width.toFloat())
+            val bottom = bounds.bottom.coerceIn(0f, image.height.toFloat())
+
+            val x = left.roundToInt().coerceIn(0, image.width - 1)
+            val y = top.roundToInt().coerceIn(0, image.height - 1)
+            val width = max(1, min(image.width - x, max(1, (right - left).roundToInt())))
+            val height = max(1, min(image.height - y, max(1, (bottom - top).roundToInt())))
+
+            if (width <= 0 || height <= 0 || x + width > image.width || y + height > image.height) {
+                return ""
+            }
+
+            croppedBitmap = Bitmap.createBitmap(image, x, y, width, height)
+            ocrEngine.recognize(croppedBitmap!!).trim()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to extract text from region", e)
+            ""
+        } finally {
+            croppedBitmap?.takeIf { !it.isRecycled }?.recycle()
+        }
+    }
+
+    private fun normalizeRegionText(text: String): String {
+        return text.replace("\\s+".toRegex(), " ").trim()
+    }
+
+    private fun normalizeCodeText(text: String): String {
+        return text
+            .replace("[^A-Za-z0-9-_]".toRegex(), "")
+            .uppercase(Locale.ROOT)
     }
 }
 

--- a/app/src/test/kotlin/com/example/coupontracker/universal/UniversalFieldDetectorTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/universal/UniversalFieldDetectorTest.kt
@@ -1,0 +1,73 @@
+package com.example.coupontracker.universal
+
+import android.graphics.Bitmap
+import android.graphics.RectF
+import com.example.coupontracker.data.model.FieldType
+import com.example.coupontracker.ocr.OcrEngine
+import com.example.coupontracker.ocr.OcrTextSpan
+import com.example.coupontracker.universal.ExtractionSource.VISUAL_REGION
+import com.example.coupontracker.universal.RegionType.CODE
+import com.example.coupontracker.universal.RegionType.LOGO
+import io.mockk.any
+import io.mockk.coEvery
+import io.mockk.firstArg
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UniversalFieldDetectorTest {
+
+    @Test
+    fun detectFields_includesRegionOcrResults() = runTest {
+        val patternLearner = mockk<PatternLearningEngine> {
+            coEvery { getRelevantPatterns(any(), any()) } returns emptyList()
+        }
+        val layoutAnalyzer = mockk<UniversalLayoutAnalyzer> {
+            coEvery { analyzeCouponStructure(any()) } returns CouponLayout(
+                logoRegion = Region(RectF(0f, 0f, 40f, 20f), 0.9f, LOGO),
+                codeRegion = Region(RectF(50f, 60f, 90f, 90f), 0.9f, CODE)
+            )
+        }
+        val confidenceScorer = mockk<AdaptiveConfidenceScorer> {
+            coEvery { scoreCandidate(any(), any()) } answers { firstArg<ExtractionCandidate>().confidence }
+        }
+        val ocrEngine = FakeOcrEngine()
+        val detector = UniversalFieldDetector(patternLearner, layoutAnalyzer, confidenceScorer, ocrEngine)
+
+        val bitmap = Bitmap.createBitmap(120, 120, Bitmap.Config.ARGB_8888)
+
+        val results = detector.detectFields(bitmap, "", ExtractionContext())
+
+        val storeCandidates = results[FieldType.STORE_NAME]
+        val codeCandidates = results[FieldType.COUPON_CODE]
+
+        assertTrue(
+            "Expected store candidates to include normalized logo text",
+            storeCandidates?.any { it.text == "Example Store" && it.source == VISUAL_REGION } == true
+        )
+
+        assertTrue(
+            "Expected code candidates to include normalized code text",
+            codeCandidates?.any { it.text == "SAVE20" && it.source == VISUAL_REGION } == true
+        )
+    }
+
+    private class FakeOcrEngine : OcrEngine {
+        override suspend fun recognize(bitmap: Bitmap): String {
+            return when {
+                bitmap.width == 40 && bitmap.height == 20 -> "  Example\nStore  "
+                bitmap.width == 40 && bitmap.height == 30 -> " save20 "
+                else -> ""
+            }
+        }
+
+        override suspend fun recognizeWithBoxes(bitmap: Bitmap): List<OcrTextSpan> = emptyList()
+
+        override fun isReady(): Boolean = true
+
+        override fun release() {
+            // No-op
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- inject the shared OcrEngine into UniversalFieldDetector via Hilt
- crop layout regions, run OCR, and normalize region text before adding candidates
- add a unit test that fakes OCR results to confirm code and store values surface from layout regions

## Testing
- `./gradlew testDebugUnitTest --tests "com.example.coupontracker.universal.UniversalFieldDetectorTest"` *(fails: Android SDK not installed in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf108a6b883289bfec0545a4252be