### PR TITLE
Improve Unicode store name detection

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/universal/UniversalFieldDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/universal/UniversalFieldDetector.kt
@@ -244,14 +244,20 @@ class UniversalFieldDetector @Inject constructor(
         
         // Look for explicit store indicators
         val storePatterns = listOf(
-            Regex("""(?:from|at|by|shop|store|brand)\s+([A-Za-z0-9\s&.'-]+)""", RegexOption.IGNORE_CASE),
-            Regex("""^([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)"""), // Capitalized words at start
+            Regex(
+                """(?:from|at|by|shop|store|brand)\s+(([\p{L}\p{M}\p{N}&.'-]+(?:\s+[\p{L}\p{M}\p{N}&.'-]+)*))""",
+                setOf(RegexOption.IGNORE_CASE, RegexOption.UNICODE_CASE)
+            ),
+            Regex(
+                """\b([\p{Lu}][\p{L}\p{M}]+(?:\s+[\p{Lu}][\p{L}\p{M}]+)*)""",
+                RegexOption.UNICODE_CASE
+            ),
         )
         
         for (pattern in storePatterns) {
             pattern.findAll(text).forEach { match ->
-                val storeName = match.groupValues[1].trim()
-                if (storeName.length >= 3 && storeName.length <= 30) {
+                val storeName = cleanStoreCandidate(match.groupValues[1])
+                if (storeName.length in 3..30) {
                     val confidence = calculateStoreNameConfidence(storeName, text)
                     candidates.add(
                         ExtractionCandidate(
@@ -390,11 +396,35 @@ class UniversalFieldDetector @Inject constructor(
         var confidence = 0.4f
         
         // Boost confidence for known patterns
-        if (storeName.matches(Regex("[A-Z][a-z]+"))) confidence += 0.2f // Proper case
+        if (storeName.matches(Regex("""[\p{Lu}][\p{L}\p{M}]+(?:\s+[\p{Lu}][\p{L}\p{M}]+)*""", RegexOption.UNICODE_CASE))) {
+            confidence += 0.2f // Proper case
+        }
         if (storeName.length in 3..15) confidence += 0.1f // Reasonable length
         if (fullText.indexOf(storeName) < 100) confidence += 0.1f // Near beginning
-        
+
         return confidence.coerceAtMost(1.0f)
+    }
+
+    private fun cleanStoreCandidate(raw: String): String {
+        val tokens = raw.trim().split("\\s+".toRegex()).filter { it.isNotBlank() }
+        if (tokens.isEmpty()) {
+            return ""
+        }
+
+        val builder = mutableListOf<String>()
+        for (token in tokens) {
+            val trimmedToken = token.trim().trimEnd(',', '.', ';', ':')
+            if (trimmedToken.isEmpty()) {
+                continue
+            }
+            val leadingLetter = trimmedToken.firstOrNull { it.isLetter() }
+            if (builder.isNotEmpty() && leadingLetter != null && leadingLetter.isLowerCase()) {
+                break
+            }
+            builder.add(trimmedToken)
+        }
+
+        return builder.joinToString(" ").trim()
     }
     
     private suspend fun extractTextFromRegion(image: Bitmap, region: Region): String {

--- a/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
@@ -136,7 +136,7 @@ class TextExtractor {
         }
 
         // Look for "Brand:" pattern
-        val brandPattern = Pattern.compile("(?i)Brand:\\s*([A-Za-z0-9]+)")
+        val brandPattern = Pattern.compile("(?i)Brand:\\s*([\\p{L}\\p{M}\\p{N}]+)", Pattern.UNICODE_CASE)
         val brandMatcher = brandPattern.matcher(text)
         if (brandMatcher.find()) {
             val brand = brandMatcher.group(1)
@@ -144,11 +144,11 @@ class TextExtractor {
             return brand
         }
 
-        val lowerText = text.lowercase(Locale.getDefault())
+        val lowerText = text.lowercase(Locale.ROOT)
         val wordFrequency = mutableMapOf<String, Int>()
-        val wordMatcher = Pattern.compile("\\b([A-Za-z][A-Za-z'\\-]*)\\b").matcher(text)
+        val wordMatcher = Pattern.compile("\\b([\\p{L}][\\p{L}\\p{M}'\\-]*)\\b", Pattern.UNICODE_CASE).matcher(text)
         while (wordMatcher.find()) {
-            val word = wordMatcher.group(1)?.lowercase(Locale.getDefault()) ?: continue
+            val word = wordMatcher.group(1)?.lowercase(Locale.ROOT) ?: continue
             wordFrequency[word] = wordFrequency.getOrDefault(word, 0) + 1
         }
 
@@ -157,8 +157,8 @@ class TextExtractor {
         val lines = text.lines()
 
         fun addCandidate(raw: String?, isTitleCase: Boolean, lineIndex: Int) {
-            val candidate = raw?.trim()?.takeIf { it.length >= 3 } ?: return
-            val normalized = candidate.lowercase(Locale.getDefault())
+            val candidate = cleanCandidate(raw) ?: return
+            val normalized = candidate.lowercase(Locale.ROOT)
             if (COMMON_WORDS.contains(normalized)) {
                 return
             }
@@ -182,14 +182,47 @@ class TextExtractor {
             }
         }
 
-        val titlePattern = Pattern.compile("\\b([A-Z][a-z]{2,})\\b")
-        val allCapsPattern = Pattern.compile("\\b([A-Z]{3,})\\b")
+        data class TitleToken(val text: String, val start: Int, val end: Int)
+
+        fun mergeAdjacentTitleTokens(line: String, tokens: List<TitleToken>): List<String> {
+            if (tokens.isEmpty()) return emptyList()
+
+            val merged = mutableListOf<String>()
+            var currentText = tokens[0].text
+            var currentEnd = tokens[0].end
+
+            for (i in 1 until tokens.size) {
+                val next = tokens[i]
+                val between = line.substring(currentEnd, next.start)
+                if (between.all { it.isWhitespace() }) {
+                    currentText = "$currentText ${next.text}"
+                    currentEnd = next.end
+                } else {
+                    merged.add(currentText)
+                    currentText = next.text
+                    currentEnd = next.end
+                }
+            }
+
+            merged.add(currentText)
+            return merged
+        }
+
+        val titlePattern = Pattern.compile("\\b([\\p{Lu}][\\p{L}\\p{M}]{2,})\\b", Pattern.UNICODE_CASE)
+        val allCapsPattern = Pattern.compile("\\b([\\p{Lu}\\p{N}]{3,})\\b", Pattern.UNICODE_CASE)
 
         lines.forEachIndexed { index, line ->
             val titleMatcher = titlePattern.matcher(line)
+            val titleTokens = mutableListOf<TitleToken>()
             while (titleMatcher.find()) {
-                addCandidate(titleMatcher.group(1), true, index)
+                val token = titleMatcher.group(1) ?: continue
+                titleTokens.add(TitleToken(token, titleMatcher.start(), titleMatcher.end()))
+                addCandidate(token, true, index)
             }
+
+            mergeAdjacentTitleTokens(line, titleTokens)
+                .filter { it.contains(' ') }
+                .forEach { combined -> addCandidate(combined, true, index) }
 
             val capsMatcher = allCapsPattern.matcher(line)
             while (capsMatcher.find()) {
@@ -208,22 +241,46 @@ class TextExtractor {
 
         // Try to find store names by common patterns
         val storePatterns = listOf(
-            Pattern.compile("(?i)from\\s+([A-Za-z0-9]+)"),
-            Pattern.compile("(?i)at\\s+([A-Za-z0-9]+)"),
-            Pattern.compile("(?i)on\\s+([A-Za-z0-9]+)"),
-            Pattern.compile("(?i)via\\s+([A-Za-z0-9]+)\\s+pay")
+            Pattern.compile("(?i)from\\s+(([\\p{L}\\p{M}\\p{N}]+(?:[&.'-]?\\s*[\\p{L}\\p{M}\\p{N}]+)*))", Pattern.UNICODE_CASE),
+            Pattern.compile("(?i)at\\s+(([\\p{L}\\p{M}\\p{N}]+(?:[&.'-]?\\s*[\\p{L}\\p{M}\\p{N}]+)*))", Pattern.UNICODE_CASE),
+            Pattern.compile("(?i)on\\s+(([\\p{L}\\p{M}\\p{N}]+(?:[&.'-]?\\s*[\\p{L}\\p{M}\\p{N}]+)*))", Pattern.UNICODE_CASE),
+            Pattern.compile("(?i)via\\s+(([\\p{L}\\p{M}\\p{N}]+(?:[&.'-]?\\s*[\\p{L}\\p{M}\\p{N}]+)*))\\s+pay", Pattern.UNICODE_CASE)
         )
 
         for (pattern in storePatterns) {
             val storeMatcher = pattern.matcher(text)
             if (storeMatcher.find()) {
-                val name = storeMatcher.group(1)
+                val name = cleanCandidate(storeMatcher.group(1)) ?: continue
                 Log.d(TAG, "Found store name from pattern: $name")
                 return name
             }
         }
 
         return null
+    }
+
+    private fun cleanCandidate(raw: String?): String? {
+        val initial = raw?.trim()?.takeIf { it.length >= 3 } ?: return null
+        val tokens = initial.split("\\s+".toRegex()).filter { it.isNotBlank() }
+        if (tokens.isEmpty()) {
+            return null
+        }
+
+        val builder = mutableListOf<String>()
+        for (token in tokens) {
+            val trimmedToken = token.trim().trimEnd(',', '.', ';', ':')
+            if (trimmedToken.isEmpty()) continue
+
+            val leadingLetter = trimmedToken.firstOrNull { it.isLetter() }
+            if (builder.isNotEmpty() && leadingLetter != null && leadingLetter.isLowerCase()) {
+                break
+            }
+
+            builder.add(trimmedToken)
+        }
+
+        val cleaned = builder.joinToString(" ").trim()
+        return cleaned.takeIf { it.length >= 3 }
     }
 
     /**

--- a/app/src/test/java/com/example/coupontracker/util/TextExtractorTest.kt
+++ b/app/src/test/java/com/example/coupontracker/util/TextExtractorTest.kt
@@ -135,6 +135,15 @@ class TextExtractorTest {
         assertNotNull("Store name should not be null", storeName)
         assertEquals("IXIGO", storeName)
     }
+
+    @Test
+    fun `extractStoreName handles accented mid sentence brand`() {
+        val text = "Enjoy a croissant at the Zepto Café kiosk before noon."
+
+        val storeName = extractor.extractStoreName(text)
+
+        assertEquals("Zepto Café", storeName)
+    }
     
     @Test
     fun `test extractDescription from IXIGO coupon`() {

--- a/app/src/test/kotlin/com/example/coupontracker/universal/UniversalFieldDetectorTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/universal/UniversalFieldDetectorTest.kt
@@ -10,6 +10,7 @@ import com.example.coupontracker.universal.RegionType.CODE
 import com.example.coupontracker.universal.RegionType.LOGO
 import io.mockk.any
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.firstArg
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -50,6 +51,37 @@ class UniversalFieldDetectorTest {
         assertTrue(
             "Expected code candidates to include normalized code text",
             codeCandidates?.any { it.text == "SAVE20" && it.source == VISUAL_REGION } == true
+        )
+    }
+
+    @Test
+    fun detectStoreNames_handlesAccentedSequences() = runTest {
+        val patternLearner = mockk<PatternLearningEngine> {
+            coEvery { getRelevantPatterns(any(), any()) } returns emptyList()
+        }
+        val layoutAnalyzer = mockk<UniversalLayoutAnalyzer> {
+            coEvery { analyzeCouponStructure(any()) } returns CouponLayout()
+        }
+        val confidenceScorer = mockk<AdaptiveConfidenceScorer> {
+            coEvery { scoreCandidate(any(), any()) } answers { firstArg<ExtractionCandidate>().confidence }
+        }
+        val ocrEngine = mockk<OcrEngine> {
+            coEvery { recognize(any()) } returns ""
+            coEvery { recognizeWithBoxes(any()) } returns emptyList()
+            every { isReady() } returns true
+        }
+        val detector = UniversalFieldDetector(patternLearner, layoutAnalyzer, confidenceScorer, ocrEngine)
+
+        val bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888)
+        val text = "Limited-time latte deal! Grab yours at Zepto Café before 5PM."
+
+        val results = detector.detectFields(bitmap, text, ExtractionContext())
+
+        val storeCandidates = results[FieldType.STORE_NAME].orEmpty()
+
+        assertTrue(
+            "Expected store candidates to include the accented store name",
+            storeCandidates.any { it.text == "Zepto Café" }
         )
     }
 


### PR DESCRIPTION
## Summary
- update universal field detector store regexes to scan full text with Unicode support and clean candidates
- adjust the TextExtractor store-name heuristics to tokenize Unicode words and merge adjacent title-case tokens
- add regression tests covering accented, mid-sentence store names for both the detector and fallback extractor

## Testing
- ./gradlew test --tests "com.example.coupontracker.util.TextExtractorTest" --tests "com.example.coupontracker.universal.UniversalFieldDetectorTest" *(fails: requires Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf6bfe4688328b2803ff2ecc7ff68