### PR TITLE
Enable OnBackInvokedCallback in AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.CouponTracker"
+        android:enableOnBackInvokedCallback="true"
         android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="31">
 


### PR DESCRIPTION
## Summary
- enable the OnBackInvokedCallback support in the application manifest to satisfy Android 13 back navigation requirements

## Testing
- ./gradlew assembleDebug *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deb8aed22c8328be9bc2bad719642f