### PR TITLE
Align Qwen2.5 GGUF filename with HuggingFace artifact

### DIFF
--- a/QWEN25_MIGRATION_COMPLETE.md
+++ b/QWEN25_MIGRATION_COMPLETE.md
@@ -27,7 +27,7 @@ Migrated to **Qwen2.5-1.5B-Instruct** (Q4_K_M, 1.12 GB) for **significantly impr
 ```kotlin
 // Added Qwen2.5 support
 const val MODEL_ID_QWEN25 = "qwen25_1.5b_instruct_q4"
-const val QWEN25_MODEL_FILE = "qwen2.5-1.5b-instruct-q4_k_m.gguf"
+const val QWEN25_MODEL_FILE = "Qwen2.5-1.5B-Instruct-Q4_K_M.gguf"
 const val QWEN25_MODEL_SIZE_BYTES = 1_203_081_216L  // 1.12 GB
 const val DEFAULT_MODEL_ID = MODEL_ID_QWEN25  // NEW DEFAULT
 ```
@@ -120,7 +120,7 @@ Text("Download Qwen2.5 Model (1.12 GB)")
 ## 📦 Model Package Details
 
 ### **Model File**
-- **Filename**: `qwen2.5-1.5b-instruct-q4_k_m.gguf`
+- **Filename**: `Qwen2.5-1.5B-Instruct-Q4_K_M.gguf`
 - **Size**: 1.12 GB (1,203,081,216 bytes)
 - **Quantization**: Q4_K_M
 - **Source**: https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF
@@ -132,7 +132,7 @@ Text("Download Qwen2.5 Model (1.12 GB)")
 - **Size**: 1.0 GB (compressed)
 - **SHA256**: `3b49192eecbbdcb914c6dbe6bb4f19a19383f52b428b8f9e5c25e2fe04c5aafa`
 - **Contents**:
-  - `qwen25_1.5b_instruct_q4/qwen2.5-1.5b-instruct-q4_k_m.gguf`
+  - `qwen25_1.5b_instruct_q4/Qwen2.5-1.5B-Instruct-Q4_K_M.gguf`
   - `qwen25_1.5b_instruct_q4/README.txt`
 
 ---
@@ -254,7 +254,7 @@ MiniCPM (legacy, vision model)
    ```bash
    adb shell ls -lh /data/data/com.example.coupontracker/files/models/qwen25_1.5b_instruct_q4/
    ```
-   Should show `qwen2.5-1.5b-instruct-q4_k_m.gguf` (1.12 GB)
+   Should show `Qwen2.5-1.5B-Instruct-Q4_K_M.gguf` (1.12 GB)
 
 ### **Rollback to Qwen2**:
 If Qwen2.5 doesn't work:

--- a/QWEN25_MIGRATION_PLAN.md
+++ b/QWEN25_MIGRATION_PLAN.md
@@ -73,7 +73,7 @@ curl -I <URL> | grep "HTTP/2 200"
 // Qwen2.5-1.5B-Instruct (Primary - Better JSON)
 const val QWEN25_MODEL_ID = "qwen25_1.5b_instruct_q4"
 const val QWEN25_MODEL_DIR = "qwen25_1.5b_instruct_q4"
-const val QWEN25_MODEL_FILE = "qwen25-1_5b-instruct-q4_k_m.gguf"
+const val QWEN25_MODEL_FILE = "Qwen2.5-1.5B-Instruct-Q4_K_M.gguf"
 const val QWEN25_MODEL_SIZE_MB = 950L  // Adjust based on actual file
 const val QWEN25_MODEL_CHECKSUM = "TBD_AFTER_DOWNLOAD"  // Fill after downloading
 ```
@@ -247,19 +247,19 @@ Text(
 1. **Download from HuggingFace** (using URL from Step 1.1):
 ```bash
 cd ~/Downloads
-wget <HUGGINGFACE_URL> -O qwen25-1_5b-instruct-q4_k_m.gguf
+wget <HUGGINGFACE_URL> -O Qwen2.5-1.5B-Instruct-Q4_K_M.gguf
 
 # OR using curl
-curl -L <HUGGINGFACE_URL> -o qwen25-1_5b-instruct-q4_k_m.gguf
+curl -L <HUGGINGFACE_URL> -o Qwen2.5-1.5B-Instruct-Q4_K_M.gguf
 ```
 
 2. **Verify download**:
 ```bash
-ls -lh qwen25-1_5b-instruct-q4_k_m.gguf
+ls -lh Qwen2.5-1.5B-Instruct-Q4_K_M.gguf
 # Should show ~950MB file
 
 # Calculate checksum
-shasum -a 256 qwen25-1_5b-instruct-q4_k_m.gguf
+shasum -a 256 Qwen2.5-1.5B-Instruct-Q4_K_M.gguf
 # Save this checksum for ModelPaths.kt
 ```
 
@@ -279,9 +279,9 @@ const val QWEN25_MODEL_SIZE_MB = <ACTUAL_SIZE>L
 ```bash
 cd ~/Downloads
 mkdir -p qwen25_package
-cp qwen25-1_5b-instruct-q4_k_m.gguf qwen25_package/
+cp Qwen2.5-1.5B-Instruct-Q4_K_M.gguf qwen25_package/
 cd qwen25_package
-zip -9 ../qwen25-1_5b-instruct-q4_k_m.zip qwen25-1_5b-instruct-q4_k_m.gguf
+zip -9 ../Qwen2.5-1.5B-Instruct-Q4_K_M.zip Qwen2.5-1.5B-Instruct-Q4_K_M.gguf
 cd ..
 ```
 
@@ -296,16 +296,16 @@ cd ..
      
      - Better JSON output compliance than Qwen2
      - Improved instruction following
-     - File: qwen25-1_5b-instruct-q4_k_m.gguf
+     - File: Qwen2.5-1.5B-Instruct-Q4_K_M.gguf
      - Size: ~950MB
      - Checksum (SHA256): <CHECKSUM>
      ```
-   - Upload file: `qwen25-1_5b-instruct-q4_k_m.zip`
+   - Upload file: `Qwen2.5-1.5B-Instruct-Q4_K_M.zip`
    - Publish release
 
 3. **Verify release URL**:
 ```bash
-curl -I https://github.com/chetank2/coupontracker/releases/download/v1.0-qwen25/qwen25-1_5b-instruct-q4_k_m.zip
+curl -I https://github.com/chetank2/coupontracker/releases/download/v1.0-qwen25/Qwen2.5-1.5B-Instruct-Q4_K_M.zip
 # Should return HTTP 200
 ```
 

--- a/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
@@ -38,7 +38,7 @@ class ModelDownloadManager(
         
         // ===== QWEN2.5 MODEL (NEW DEFAULT) =====
         private const val QWEN25_BASE_URL = "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main"
-        private const val QWEN25_MODEL_FILE = "qwen2.5-1.5b-instruct-q4_k_m.gguf"
+        private const val QWEN25_MODEL_FILE = "Qwen2.5-1.5B-Instruct-Q4_K_M.gguf"
         private const val QWEN25_MODEL_SIZE = 1_203_081_216L  // 1.12 GB
         private const val QWEN25_VERSION = "2.5-1.5b-q4-instruct"
         

--- a/app/src/main/kotlin/com/example/coupontracker/model/ModelPaths.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/model/ModelPaths.kt
@@ -24,7 +24,7 @@ object ModelPaths {
     const val DEFAULT_MODEL_ID = MODEL_ID_QWEN25  // Qwen2.5 is now the default
     
     // ===== MODEL FILES =====
-    const val QWEN25_MODEL_FILE = "qwen2.5-1.5b-instruct-q4_k_m.gguf"
+    const val QWEN25_MODEL_FILE = "Qwen2.5-1.5B-Instruct-Q4_K_M.gguf"
     const val QWEN2_MODEL_FILE = "qwen2-1_5b-instruct-q4_k_m.gguf"
     const val MINICPM_MODEL_FILE = "ggml-model-Q4_K_M.gguf"
     const val MINICPM_MMPROJ_FILE = "mmproj-model-f16.gguf"


### PR DESCRIPTION
## Summary
- update the Qwen2.5 model filename constant to the exact HuggingFace artifact name
- synchronize ModelPaths helpers and migration docs to reference the canonical filename

## Testing
- ./gradlew assembleDebug *(fails: Android SDK not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df6ae80bf4832889012c9c4d8b3e9e