### PR TITLE
Update Qwen2.5 download mirror configuration

### DIFF
--- a/QWEN25_MIGRATION_COMPLETE.md
+++ b/QWEN25_MIGRATION_COMPLETE.md
@@ -123,7 +123,8 @@ Text("Download Qwen2.5 Model (1.12 GB)")
 - **Filename**: `Qwen2.5-1.5B-Instruct-Q4_K_M.gguf`
 - **Size**: 1.12 GB (1,203,081,216 bytes)
 - **Quantization**: Q4_K_M
-- **Source**: https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF
+- **Source**: https://huggingface.co/bartowski/Qwen2.5-1.5B-Instruct-GGUF (verified mirror)
+- **Configurable Mirror**: Override via secure preference `qwen25_model_base_url_override` for staged rollouts
 - **SHA256**: `6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e`
 
 ### **ZIP Package for Android**

--- a/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
@@ -37,7 +37,7 @@ class ModelDownloadManager(
         private const val TAG = "ModelDownloadManager"
         
         // ===== QWEN2.5 MODEL (NEW DEFAULT) =====
-        private const val QWEN25_BASE_URL = "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main"
+        private const val QWEN25_BASE_URL = "https://huggingface.co/bartowski/Qwen2.5-1.5B-Instruct-GGUF/resolve/main"
         private const val QWEN25_MODEL_FILE = "Qwen2.5-1.5B-Instruct-Q4_K_M.gguf"
         private const val QWEN25_MODEL_SIZE = 1_203_081_216L  // 1.12 GB
         private const val QWEN25_VERSION = "2.5-1.5b-q4-instruct"
@@ -161,6 +161,17 @@ class ModelDownloadManager(
             ?.trimEnd('/')
 
         return (override?.takeIf { it.isNotEmpty() } ?: DEFAULT_MODEL_BASE_URL).trimEnd('/')
+    }
+
+    /**
+     * Resolve the Qwen2.5 base URL, allowing remote configuration or staged rollouts to change mirrors.
+     */
+    private fun resolveQwen25BaseUrl(): String {
+        val override = securePrefs.getQwen25ModelBaseUrlOverride()
+            ?.trim()
+            ?.trimEnd('/')
+
+        return (override?.takeIf { it.isNotEmpty() } ?: QWEN25_BASE_URL).trimEnd('/')
     }
     
     /**
@@ -386,7 +397,7 @@ class ModelDownloadManager(
             val modelFile = File(modelDir, QWEN25_MODEL_FILE)
             
             val downloadResult = downloadFile(
-                url = "$QWEN25_BASE_URL/$QWEN25_MODEL_FILE",
+                url = "${resolveQwen25BaseUrl()}/$QWEN25_MODEL_FILE",
                 outputFile = modelFile,
                 progressCallback = { progress ->
                     progressCallback(DownloadProgress(

--- a/app/src/main/kotlin/com/example/coupontracker/util/SecurePreferencesManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/SecurePreferencesManager.kt
@@ -50,6 +50,7 @@ class SecurePreferencesManager @Inject constructor(
         const val KEY_LLM_AUTO_DOWNLOAD_ENABLED = "llm_auto_download_enabled"
         const val KEY_LLM_DOWNLOAD_WIFI_ONLY = "llm_download_wifi_only"
         const val KEY_LLM_MODEL_BASE_URL_OVERRIDE = "llm_model_base_url_override"
+        const val KEY_QWEN25_MODEL_BASE_URL_OVERRIDE = "qwen25_model_base_url_override"
         const val KEY_MINICPM_LICENSE_ACCEPTED = "minicpm_license_accepted"
 
         // Key rotation period in days
@@ -442,6 +443,26 @@ class SecurePreferencesManager @Inject constructor(
                 remove(KEY_LLM_MODEL_BASE_URL_OVERRIDE)
             } else {
                 putString(KEY_LLM_MODEL_BASE_URL_OVERRIDE, baseUrl)
+            }
+        }.apply()
+    }
+
+    /**
+     * Get the preferred mirror for the Qwen2.5 model if one has been configured.
+     */
+    fun getQwen25ModelBaseUrlOverride(): String? {
+        return securePrefs.getString(KEY_QWEN25_MODEL_BASE_URL_OVERRIDE, null)?.takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Persist or clear the preferred Qwen2.5 model mirror.
+     */
+    fun setQwen25ModelBaseUrlOverride(baseUrl: String?) {
+        securePrefs.edit().apply {
+            if (baseUrl.isNullOrBlank()) {
+                remove(KEY_QWEN25_MODEL_BASE_URL_OVERRIDE)
+            } else {
+                putString(KEY_QWEN25_MODEL_BASE_URL_OVERRIDE, baseUrl)
             }
         }.apply()
     }


### PR DESCRIPTION
## Summary
- point the Qwen2.5 GGUF download to the verified bartowski mirror and resolve the URL via a helper
- add secure-preference overrides so future mirror changes can be staged without code changes
- document the new mirror and override knob in the migration notes

## Testing
- `./gradlew :app:testDebugUnitTest --tests "*ModelDownloadManager*"` *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa8c26cf8832882a37f1b870ea1d9