### PR TITLE
Prevent fallback store names from duplicating codes

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/extraction/HeuristicFieldExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/HeuristicFieldExtractor.kt
@@ -1,6 +1,7 @@
 package com.example.coupontracker.extraction
 
 import com.example.coupontracker.data.model.FieldType
+import com.example.coupontracker.util.GenericFieldHeuristics
 
 /**
  * Heuristic field extraction - Pass 3 of progressive pipeline.
@@ -26,13 +27,22 @@ class HeuristicFieldExtractor {
     ): Map<FieldType, List<FieldCandidate>> {
         
         val results = mutableMapOf<FieldType, MutableList<FieldCandidate>>()
-        
+        val detectedCode = context.metadata["code"]?.takeIf { it.isNotBlank() }
+            ?: context.attempts.asReversed().asSequence()
+                .mapNotNull { attempt ->
+                    attempt.fieldsExtracted[FieldType.COUPON_CODE]?.value?.takeIf { it.isNotBlank() }
+                }
+                .firstOrNull()
+
         // Store: ANY capitalized word (not in common words)
         if (FieldType.STORE_NAME in missingFields) {
             val capitalPattern = Regex("""\b([A-Z][A-Za-z0-9]{2,})\b""")
             capitalPattern.findAll(context.ocrText).forEach { match ->
                 val word = match.value
-                if (word.lowercase() !in COMMON_WORDS) {
+                if (word.lowercase() !in COMMON_WORDS &&
+                    !GenericFieldHeuristics.isGenericOrMissing(word) &&
+                    (detectedCode == null || !GenericFieldHeuristics.areDuplicateFields(word, detectedCode))
+                ) {
                     results.getOrPut(FieldType.STORE_NAME) { mutableListOf() }.add(
                         FieldCandidate(
                             value = word,

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -1206,7 +1206,10 @@ class ScannerViewModel @Inject constructor(
         }
     }
 
-    private fun mergeValidatedFields(primary: MutableMap<String, String>, fallback: Map<String, String>) {
+    @VisibleForTesting
+    internal fun mergeValidatedFields(primary: MutableMap<String, String>, fallback: Map<String, String>) {
+        val fallbackCode = fallback["code"]?.trim()?.takeIf { it.isNotEmpty() }
+
         fallback.forEach { (key, value) ->
             val sanitized = value.trim()
             if (sanitized.isEmpty()) {
@@ -1214,15 +1217,31 @@ class ScannerViewModel @Inject constructor(
             }
 
             val existing = primary[key]
-            if (shouldReplaceExisting(existing, sanitized, key)) {
+            val extractedCode = primary["code"]
+            if (shouldReplaceExisting(existing, sanitized, key, extractedCode, fallbackCode)) {
                 primary[key] = sanitized
             }
         }
     }
 
-    private fun shouldReplaceExisting(existing: String?, candidate: String, key: String): Boolean {
+    @VisibleForTesting
+    internal fun shouldReplaceExisting(
+        existing: String?,
+        candidate: String,
+        key: String,
+        extractedCode: String?,
+        fallbackCode: String?
+    ): Boolean {
         if (candidate.isBlank()) {
             return false
+        }
+
+        if (key == "storeName") {
+            if (fieldHeuristics.areDuplicateFields(candidate, extractedCode) ||
+                fieldHeuristics.areDuplicateFields(candidate, fallbackCode)
+            ) {
+                return false
+            }
         }
 
         if (existing.isNullOrBlank()) {

--- a/app/src/test/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModelTest.kt
@@ -1,0 +1,94 @@
+package com.example.coupontracker.ui.viewmodel
+
+import android.app.Application
+import android.content.Context
+import android.util.Log
+import com.example.coupontracker.data.repository.CouponRepository
+import com.example.coupontracker.ml.TwoStageDetector
+import com.example.coupontracker.universal.UniversalExtractionService
+import com.example.coupontracker.util.BitmapManager
+import com.example.coupontracker.util.ExtractionPerformanceMonitor
+import com.example.coupontracker.util.ExtractionTelemetryService
+import com.example.coupontracker.util.LocalLlmOcrService
+import com.example.coupontracker.util.MultiEngineOCR
+import io.mockk.anyConstructed
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import io.mockk.unmockkStatic
+import io.mockk.mockkStatic
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class ScannerViewModelTest {
+
+    private lateinit var viewModel: ScannerViewModel
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.d(any(), any()) } returns 0
+        every { Log.d(any(), any(), any()) } returns 0
+        every { Log.e(any(), any()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+        every { Log.w(any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
+        every { Log.v(any(), any()) } returns 0
+
+        mockkConstructor(TwoStageDetector::class)
+        every { anyConstructed<TwoStageDetector>().getModelInfo() } returns "mock"
+
+        mockkConstructor(MultiEngineOCR::class)
+        justRun { anyConstructed<MultiEngineOCR>().setNetworkAvailability(any()) }
+
+        val application: Application = mockk(relaxed = true)
+        val context: Context = mockk(relaxed = true)
+        val couponRepository: CouponRepository = mockk(relaxed = true)
+        val ocrEngine: com.example.coupontracker.ocr.OcrEngine = mockk(relaxed = true)
+        val localLlmOcrService: LocalLlmOcrService = mockk(relaxed = true)
+        val telemetryService: ExtractionTelemetryService = mockk(relaxed = true)
+        val universalExtractionService: UniversalExtractionService = mockk(relaxed = true)
+        val performanceMonitor: ExtractionPerformanceMonitor = mockk(relaxed = true)
+        val bitmapManager: BitmapManager = mockk(relaxed = true)
+
+        viewModel = ScannerViewModel(
+            application,
+            context,
+            couponRepository,
+            ocrEngine,
+            localLlmOcrService,
+            telemetryService,
+            universalExtractionService,
+            performanceMonitor,
+            bitmapManager
+        )
+    }
+
+    @After
+    fun tearDown() {
+        unmockkConstructor(TwoStageDetector::class)
+        unmockkConstructor(MultiEngineOCR::class)
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `fallback merge ignores store names that duplicate detected code`() {
+        val extractedInfo = mutableMapOf(
+            "code" to "SAVE2025",
+            "description" to "Sample description"
+        )
+        val fallbackFields = mapOf(
+            "storeName" to "SAVE2025",
+            "code" to "SAVE2025"
+        )
+
+        viewModel.mergeValidatedFields(extractedInfo, fallbackFields)
+
+        val persistedStore = extractedInfo["storeName"] ?: extractedInfo["app"] ?: "Unknown Store"
+        assertEquals("Unknown Store", persistedStore)
+    }
+}


### PR DESCRIPTION
## Summary
- guard ScannerViewModel's fallback merge so storeName candidates matching the detected coupon code are skipped
- filter heuristic store-name guesses that are generic or duplicate the known code
- add a ScannerViewModel unit test covering the duplicate store/code fallback scenario

## Testing
- `./gradlew test` *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0aa75d8d083288e49ec97e00acbbd