### PR TITLE
Enforce strictly positive numbers in coupon grammar

### DIFF
--- a/app/src/main/assets/coupon_schema.gbnf
+++ b/app/src/main/assets/coupon_schema.gbnf
@@ -20,7 +20,7 @@ value ::= string | "null"
 string ::= "\"" string-char* "\""
 string-char ::= [a-zA-Z0-9 .,!?@#$%&*()\-_+=;:'/\[\]{}]
 
-# Positive number only (no negatives for cashback)
+# Positive number only (rejects 0, leading zeros, and negative signs)
 # Note: Must explicitly exclude minus sign at token level
-positive-number ::= [0-9]+ ("." [0-9]+)?
+positive-number ::= ("0." ([0-9]* [1-9] [0-9]*)) | ([1-9][0-9]* ("." [0-9]+)?)
 


### PR DESCRIPTION
## Summary
- tighten the positive-number production to reject zero, leading zeros, and negatives while still allowing decimals and integers greater than zero
- clarify the adjacent comment to reflect the stricter validation

## Testing
- python - <<'PY'
import re
pattern = re.compile(r'^(?:0\.(?:[0-9]*[1-9][0-9]*)|[1-9][0-9]*(?:\.[0-9]+)?)$')
for value in ["0", "00", "-1", "0.0", "0.5", "1", "10", "1.25", "100.00", "01", "2.0", "0.123"]:
    print(value, bool(pattern.fullmatch(value)))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e1591892848328a1b6ec9b61c29d34