### PR TITLE
Restore missing HomeScreen imports

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/HomeScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/HomeScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -60,6 +61,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts


### PR DESCRIPTION
## Summary
- reintroduce the Button and TextAlign imports that were inadvertently removed from HomeScreen

## Testing
- not run (Android SDK not installed in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68ebf7cd171083288dfd402cb9d31470