### PR TITLE
Fix secure backup restore flow

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDao.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDao.kt
@@ -29,6 +29,9 @@ interface CouponDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertCoupon(coupon: Coupon): Long
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCoupons(coupons: List<Coupon>): List<Long>
+
     @Update
     suspend fun updateCoupon(coupon: Coupon)
 
@@ -37,6 +40,15 @@ interface CouponDao {
 
     @Query("DELETE FROM coupons")
     suspend fun deleteAllCoupons()
+
+    @Transaction
+    suspend fun replaceAllCoupons(coupons: List<Coupon>): List<Long> {
+        deleteAllCoupons()
+        if (coupons.isEmpty()) {
+            return emptyList()
+        }
+        return insertCoupons(coupons)
+    }
 
     // New queries
     @Query("SELECT * FROM coupons WHERE isPriority = 1 ORDER BY (expiryDate IS NULL), expiryDate ASC")

--- a/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepository.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepository.kt
@@ -16,6 +16,7 @@ interface CouponRepository {
     suspend fun updateCoupon(coupon: Coupon)
     suspend fun deleteCoupon(coupon: Coupon)
     suspend fun deleteAllCoupons()
+    suspend fun replaceAllCoupons(coupons: List<Coupon>): Int
 
     // New methods
     fun getPriorityCoupons(): Flow<List<Coupon>>

--- a/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/repository/CouponRepositoryImpl.kt
@@ -33,6 +33,14 @@ class CouponRepositoryImpl @Inject constructor(
 
     override suspend fun deleteAllCoupons() = couponDao.deleteAllCoupons()
 
+    override suspend fun replaceAllCoupons(coupons: List<Coupon>): Int {
+        val sanitizedCoupons = coupons.map { coupon ->
+            // Force Room to generate fresh IDs so we do not rely on the source database
+            coupon.copy(id = 0)
+        }
+        return couponDao.replaceAllCoupons(sanitizedCoupons).size
+    }
+
     // New methods
     override fun getPriorityCoupons(): Flow<List<Coupon>> = couponDao.getPriorityCoupons()
 

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/SettingsViewModel.kt
@@ -127,20 +127,12 @@ class SettingsViewModel @Inject constructor(
                     return@launch
                 }
                 
-                // Import coupons (replace existing data)
-                var successCount = 0
-                coupons.forEach { coupon ->
-                    try {
-                        couponRepository.insertCoupon(coupon)
-                        successCount++
-                    } catch (e: Exception) {
-                        // Continue with other coupons even if one fails
-                    }
-                }
-                
+                // Import coupons atomically (replace existing data)
+                val insertedCount = couponRepository.replaceAllCoupons(coupons)
+
                 _backupState.value = BackupState.Success(
                     "Imported successfully",
-                    successCount
+                    insertedCount
                 )
             } catch (e: Exception) {
                 _backupState.value = BackupState.Error("Import failed: ${e.message}")

--- a/app/src/main/kotlin/com/example/coupontracker/util/SecureBackupManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/SecureBackupManager.kt
@@ -16,6 +16,7 @@ import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 import java.security.KeyStore
 import java.util.Date
+import javax.crypto.AEADBadTagException
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
@@ -183,19 +184,19 @@ class SecureBackupManager @Inject constructor(
                 val encryptedDataWithIv = context.contentResolver.openInputStream(uri)?.use { inputStream ->
                     inputStream.readBytes()
                 } ?: throw Exception("Failed to read backup file")
-                
+
                 if (encryptedDataWithIv.size < IV_SIZE) {
                     throw Exception("Invalid backup file format (too small)")
                 }
-                
+
                 // Extract IV and encrypted data
                 val iv = encryptedDataWithIv.copyOfRange(0, IV_SIZE)
                 val encryptedData = encryptedDataWithIv.copyOfRange(IV_SIZE, encryptedDataWithIv.size)
-                
+
                 // Decrypt the data
                 val plaintext = decrypt(encryptedData, iv)
                 val json = String(plaintext, Charsets.UTF_8)
-                
+
                 // Deserialize backup data
                 val backupData: BackupData = try {
                     gson.fromJson(json, BackupData::class.java)
@@ -210,12 +211,17 @@ class SecureBackupManager @Inject constructor(
                         coupons = coupons
                     )
                 }
-                
+
                 backupData.coupons
-                
+            } catch (e: AEADBadTagException) {
+                Log.e(TAG, "Failed to decrypt backup - incorrect key", e)
+                throw IllegalStateException(
+                    "Unable to decrypt backup. Please ensure you created it on this device.",
+                    e
+                )
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to read coupons from backup", e)
-                emptyList()
+                throw e
             }
         }
     }


### PR DESCRIPTION
## Summary
- add bulk DAO/repository helpers so restores replace the entire coupon table atomically
- update the settings view model to use the new repository method and report how many coupons were imported
- surface secure backup decryption failures instead of silently swallowing them

## Testing
- ./gradlew app:testDebugUnitTest *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebfa82701083288ef969b0e7fe3c2b