### PR TITLE
Add Android bulk upload handling and batch scanner improvements

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/BatchScannerScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/BatchScannerScreen.kt
@@ -2,6 +2,7 @@ package com.example.coupontracker.ui.screen
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import android.util.Log
 import android.widget.Toast
@@ -14,6 +15,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -24,7 +26,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
@@ -35,10 +36,11 @@ import coil.compose.rememberAsyncImagePainter
 import com.example.coupontracker.data.model.Coupon
 import com.example.coupontracker.ui.navigation.Screen
 import com.example.coupontracker.ui.viewmodel.BatchScannerViewModel
+import com.example.coupontracker.ui.viewmodel.ImageProcessingStatus
+import com.example.coupontracker.ui.viewmodel.SelectedImage
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
-import kotlinx.coroutines.launch
 
 /**
  * Screen for batch scanning of multiple coupons
@@ -58,9 +60,19 @@ fun BatchScannerScreen(
 
     // Image picker launcher for multiple images
     val multipleImagePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetMultipleContents()
+        contract = ActivityResultContracts.OpenMultipleDocuments()
     ) { uris ->
         if (uris.isNotEmpty()) {
+            uris.forEach { uri ->
+                try {
+                    context.contentResolver.takePersistableUriPermission(
+                        uri,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION
+                    )
+                } catch (e: SecurityException) {
+                    Log.w("BatchScannerScreen", "Unable to persist permission for uri=$uri", e)
+                }
+            }
             viewModel.addImages(uris)
         }
     }
@@ -168,9 +180,17 @@ fun BatchScannerScreen(
                         ) {
                             CircularProgressIndicator()
                             Spacer(modifier = Modifier.height(16.dp))
+                            val currentLabel = uiState.currentlyProcessingImage?.displayName
                             Text(
-                                text = "Processing ${uiState.processedCount}/${uiState.selectedImages.size} images...",
-                                style = MaterialTheme.typography.bodyLarge
+                                text = buildString {
+                                    append("Processing ${uiState.processedCount}/${uiState.selectedImages.size} images")
+                                    if (!currentLabel.isNullOrBlank()) {
+                                        append("\n")
+                                        append(currentLabel)
+                                    }
+                                },
+                                style = MaterialTheme.typography.bodyLarge,
+                                textAlign = TextAlign.Center
                             )
                         }
                     }
@@ -179,6 +199,7 @@ fun BatchScannerScreen(
                     // Show processed coupons
                     ProcessedCouponsView(
                         coupons = uiState.processedCoupons,
+                        imageStatuses = uiState.imageProcessingStatuses,
                         onSaveAll = {
                             viewModel.saveAllCoupons()
                             Toast.makeText(context, "All coupons saved", Toast.LENGTH_SHORT).show()
@@ -208,7 +229,7 @@ fun BatchScannerScreen(
                     // Show empty state with options to add images
                     EmptyBatchScannerView(
                         onAddFromGallery = {
-                            multipleImagePickerLauncher.launch("image/*")
+                            multipleImagePickerLauncher.launch(arrayOf("image/*"))
                         },
                         onAddFromCamera = {
                             if (cameraPermissionState.status.isGranted) {
@@ -230,7 +251,7 @@ fun BatchScannerScreen(
                             viewModel.removeImage(index)
                         },
                         onAddMore = {
-                            multipleImagePickerLauncher.launch("image/*")
+                            multipleImagePickerLauncher.launch(arrayOf("image/*"))
                         }
                     )
                 }
@@ -406,7 +427,7 @@ fun EmptyBatchScannerView(
 
 @Composable
 fun SelectedImagesView(
-    images: List<Uri>,
+    images: List<SelectedImage>,
     onRemoveImage: (Int) -> Unit,
     onAddMore: () -> Unit
 ) {
@@ -421,7 +442,7 @@ fun SelectedImagesView(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "${images.size} Images Selected",
+                text = "${images.size} Files Selected",
                 style = MaterialTheme.typography.titleMedium
             )
 
@@ -444,9 +465,12 @@ fun SelectedImagesView(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            items(images.size) { index ->
+            itemsIndexed(
+                items = images,
+                key = { _, image -> image.uri.toString() }
+            ) { index, image ->
                 ImageItem(
-                    uri = images[index],
+                    image = image,
                     onRemove = { onRemoveImage(index) }
                 )
             }
@@ -456,7 +480,7 @@ fun SelectedImagesView(
 
 @Composable
 fun ImageItem(
-    uri: Uri,
+    image: SelectedImage,
     onRemove: () -> Unit
 ) {
     Card(
@@ -468,12 +492,34 @@ fun ImageItem(
         Box(
             modifier = Modifier.fillMaxSize()
         ) {
-            Image(
-                painter = rememberAsyncImagePainter(uri),
-                contentDescription = "Selected Image",
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
-            )
+            if (image.isImage()) {
+                Image(
+                    painter = rememberAsyncImagePainter(image.uri),
+                    contentDescription = "Selected Image",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.PictureAsPdf,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = image.displayName,
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
 
             // Remove button
             IconButton(
@@ -494,6 +540,23 @@ fun ImageItem(
                     modifier = Modifier.size(16.dp)
                 )
             }
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .background(
+                        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
+                        shape = RoundedCornerShape(topEnd = 8.dp)
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp)
+            ) {
+                Text(
+                    text = image.displayName,
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
         }
     }
 }
@@ -501,6 +564,7 @@ fun ImageItem(
 @Composable
 fun ProcessedCouponsView(
     coupons: List<Coupon>,
+    imageStatuses: List<ImageProcessingStatus>,
     onSaveAll: () -> Unit,
     onEditCoupon: (Int) -> Unit,
     onRemoveCoupon: (Int) -> Unit,
@@ -535,6 +599,11 @@ fun ProcessedCouponsView(
         }
 
         Spacer(modifier = Modifier.height(16.dp))
+
+        if (imageStatuses.isNotEmpty()) {
+            ProcessingSummary(statuses = imageStatuses)
+            Spacer(modifier = Modifier.height(12.dp))
+        }
 
         LazyColumn(
             modifier = Modifier
@@ -576,73 +645,181 @@ fun CouponItem(
             .padding(vertical = 4.dp),
         shape = RoundedCornerShape(8.dp)
     ) {
-        Column(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp)
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
             ) {
+                coupon.imageUri?.let { imageUri ->
+                    Image(
+                        painter = rememberAsyncImagePainter(imageUri),
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                } ?: run {
+                    Icon(
+                        imageVector = Icons.Default.LocalOffer,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .size(32.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = coupon.storeName,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+
+                    Row {
+                        IconButton(
+                            onClick = onEdit,
+                            modifier = Modifier.size(32.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Edit,
+                                contentDescription = "Edit",
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+
+                        IconButton(
+                            onClick = onRemove,
+                            modifier = Modifier.size(32.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "Remove",
+                                tint = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+
                 Text(
-                    text = coupon.storeName,
-                    style = MaterialTheme.typography.titleMedium
+                    text = coupon.description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
 
-                Row {
-                    IconButton(
-                        onClick = onEdit,
-                        modifier = Modifier.size(32.dp)
+                Spacer(modifier = Modifier.height(8.dp))
+
+                val expiryText = remember(coupon.expiryDate) {
+                    coupon.expiryDate?.let {
+                        java.text.DateFormat.getDateInstance().format(it)
+                    }
+                }
+
+                Column {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
                     ) {
-                        Icon(
-                            imageVector = Icons.Default.Edit,
-                            contentDescription = "Edit",
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(20.dp)
+                        Text(
+                            text = "Amount: ₹${coupon.cashbackAmount}",
+                            style = MaterialTheme.typography.bodySmall
                         )
+
+                        coupon.redeemCode?.let {
+                            Text(
+                                text = "Code: $it",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
                     }
 
-                    IconButton(
-                        onClick = onRemove,
-                        modifier = Modifier.size(32.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Delete,
-                            contentDescription = "Remove",
-                            tint = MaterialTheme.colorScheme.error,
-                            modifier = Modifier.size(20.dp)
+                    expiryText?.let { formattedDate ->
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = "Expiry: $formattedDate",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }
             }
+        }
+    }
+}
 
-            Spacer(modifier = Modifier.height(4.dp))
-
+@Composable
+fun ProcessingSummary(statuses: List<ImageProcessingStatus>) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
             Text(
-                text = coupon.description,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                text = "Processing Summary",
+                style = MaterialTheme.typography.titleSmall
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
+            statuses.forEach { status ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    val icon = if (status.success) Icons.Default.Check else Icons.Default.Error
+                    val iconTint = if (status.success) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    }
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    text = "Amount: ₹${coupon.cashbackAmount}",
-                    style = MaterialTheme.typography.bodySmall
-                )
-
-                coupon.redeemCode?.let {
-                    Text(
-                        text = "Code: $it",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.primary
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = iconTint
                     )
+
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = status.image.displayName,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+
+                        Text(
+                            text = if (status.success) {
+                                "${status.couponsFound} coupon(s) extracted"
+                            } else {
+                                status.message ?: "Extraction failed"
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/UnifiedUploadScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/UnifiedUploadScreen.kt
@@ -1,5 +1,6 @@
 package com.example.coupontracker.ui.screen
 
+import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -65,9 +66,19 @@ fun UnifiedUploadScreen(
     
     // Multiple image picker launcher
     val multipleImagePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetMultipleContents()
+        contract = ActivityResultContracts.OpenMultipleDocuments()
     ) { uris ->
         if (uris.isNotEmpty()) {
+            uris.forEach { uri ->
+                try {
+                    context.contentResolver.takePersistableUriPermission(
+                        uri,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION
+                    )
+                } catch (e: SecurityException) {
+                    // Ignore if permission cannot be persisted (e.g., legacy providers)
+                }
+            }
             viewModel.addMultipleImages(uris)
         }
     }
@@ -162,7 +173,7 @@ fun UnifiedUploadScreen(
             
             // Multiple images upload button
             Button(
-                onClick = { multipleImagePickerLauncher.launch("image/*") },
+                onClick = { multipleImagePickerLauncher.launch(arrayOf("image/*")) },
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Icon(Icons.Default.PhotoLibrary, contentDescription = null)

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
@@ -3,6 +3,7 @@ package com.example.coupontracker.ui.viewmodel
 import android.app.Application
 import android.content.Context
 import android.net.Uri
+import android.provider.OpenableColumns
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -86,9 +87,33 @@ class BatchScannerViewModel @Inject constructor(
      * @param uris List of image URIs to add
      */
     fun addImages(uris: List<Uri>) {
+        if (uris.isEmpty()) return
+
         val currentImages = _uiState.value.selectedImages.toMutableList()
-        currentImages.addAll(uris)
-        _uiState.value = _uiState.value.copy(selectedImages = currentImages)
+        val existingUris = currentImages.map { it.uri.toString() }.toMutableSet()
+        val newImages = mutableListOf<SelectedImage>()
+
+        for (uri in uris) {
+            val uriKey = uri.toString()
+            if (existingUris.contains(uriKey) || newImages.any { it.uri.toString() == uriKey }) {
+                Log.d(TAG, "Skipping duplicate image uri=$uriKey")
+                continue
+            }
+
+            val selectionOrder = currentImages.size + newImages.size + 1
+            val selectedImage = createSelectedImage(
+                uri = uri,
+                selectionOrder = selectionOrder,
+                explicitMimeType = null
+            )
+
+            newImages.add(selectedImage)
+        }
+
+        if (newImages.isNotEmpty()) {
+            currentImages.addAll(newImages)
+            _uiState.value = _uiState.value.copy(selectedImages = currentImages)
+        }
     }
 
     /**
@@ -97,7 +122,20 @@ class BatchScannerViewModel @Inject constructor(
      */
     fun addPdf(uri: Uri) {
         val currentImages = _uiState.value.selectedImages.toMutableList()
-        currentImages.add(uri)
+        val uriKey = uri.toString()
+        if (currentImages.any { it.uri.toString() == uriKey }) {
+            Log.d(TAG, "Skipping duplicate PDF uri=$uriKey")
+            return
+        }
+
+        val selectionOrder = currentImages.size + 1
+        val selectedImage = createSelectedImage(
+            uri = uri,
+            selectionOrder = selectionOrder,
+            explicitMimeType = "application/pdf"
+        )
+
+        currentImages.add(selectedImage)
         _uiState.value = _uiState.value.copy(selectedImages = currentImages)
     }
 
@@ -108,8 +146,14 @@ class BatchScannerViewModel @Inject constructor(
     fun removeImage(index: Int) {
         val currentImages = _uiState.value.selectedImages.toMutableList()
         if (index in currentImages.indices) {
-            currentImages.removeAt(index)
-            _uiState.value = _uiState.value.copy(selectedImages = currentImages)
+            val removed = currentImages.removeAt(index)
+            val updatedStatuses = _uiState.value.imageProcessingStatuses.filterNot {
+                it.image.uri.toString() == removed.uri.toString()
+            }
+            _uiState.value = _uiState.value.copy(
+                selectedImages = currentImages,
+                imageProcessingStatuses = updatedStatuses
+            )
         }
     }
 
@@ -117,7 +161,14 @@ class BatchScannerViewModel @Inject constructor(
      * Clear all selected images
      */
     fun clearImages() {
-        _uiState.value = _uiState.value.copy(selectedImages = emptyList())
+        _uiState.value = _uiState.value.copy(
+            selectedImages = emptyList(),
+            processedCoupons = emptyList(),
+            imageProcessingStatuses = emptyList(),
+            processedCount = 0,
+            currentlyProcessingImage = null,
+            error = null
+        )
     }
     
     /**
@@ -151,23 +202,54 @@ class BatchScannerViewModel @Inject constructor(
                     return@launch
                 }
 
-                updateState { it.copy(isProcessing = true, processedCount = 0, error = null) }
+                updateState {
+                    it.copy(
+                        isProcessing = true,
+                        processedCount = 0,
+                        error = null,
+                        imageProcessingStatuses = emptyList(),
+                        currentlyProcessingImage = null
+                    )
+                }
 
                 val images = _uiState.value.selectedImages
                 val processedCoupons = mutableListOf<Coupon>()
                 var failedCount = 0
+                val imageStatuses = mutableListOf<ImageProcessingStatus>()
 
-                for ((index, uri) in images.withIndex()) {
+                for ((index, selectedImage) in images.withIndex()) {
+                    val uri = selectedImage.uri
+                    updateState { it.copy(currentlyProcessingImage = selectedImage) }
                     var bitmap: android.graphics.Bitmap? = null
                     try {
+                        if (!selectedImage.isImage()) {
+                            Log.w(TAG, "Batch: Unsupported file type ${selectedImage.mimeType} for uri=$uri")
+                            failedCount++
+                            imageStatuses.add(
+                                ImageProcessingStatus(
+                                    image = selectedImage,
+                                    success = false,
+                                    message = "Unsupported file type"
+                                )
+                            )
+                            continue
+                        }
+
                         // Load and track bitmap
                         bitmap = android.graphics.BitmapFactory.decodeStream(
                             context.contentResolver.openInputStream(uri)
                         )
-                        
+
                         if (bitmap == null) {
                             Log.e(TAG, "Batch: Failed to decode bitmap ${index + 1}")
                             failedCount++
+                            imageStatuses.add(
+                                ImageProcessingStatus(
+                                    image = selectedImage,
+                                    success = false,
+                                    message = "Unable to open image"
+                                )
+                            )
                             continue
                         }
                         
@@ -179,36 +261,70 @@ class BatchScannerViewModel @Inject constructor(
                         if (imageCoupons.isNotEmpty()) {
                             processedCoupons.addAll(imageCoupons)
                             Log.d(TAG, "Batch: Extracted ${imageCoupons.size} coupon(s) from image ${index + 1}/${images.size}")
+                            imageStatuses.add(
+                                ImageProcessingStatus(
+                                    image = selectedImage,
+                                    success = true,
+                                    message = null,
+                                    couponsFound = imageCoupons.size
+                                )
+                            )
                         } else {
                             Log.w(TAG, "Batch: No coupons extracted from image ${index + 1}/${images.size}")
                             failedCount++
+                            imageStatuses.add(
+                                ImageProcessingStatus(
+                                    image = selectedImage,
+                                    success = false,
+                                    message = "No coupons detected"
+                                )
+                            )
                         }
-                        
+
                     } catch (e: Exception) {
                         Log.e(TAG, "Batch: Error processing ${index + 1}/${images.size}", e)
                         failedCount++
+                        imageStatuses.add(
+                            ImageProcessingStatus(
+                                image = selectedImage,
+                                success = false,
+                                message = e.message ?: "Unexpected error"
+                            )
+                        )
                     } finally {
-                        bitmap?.let { 
+                        bitmap?.let {
                             bitmapManager.releaseBitmap(it)
                         }
                     }
 
                     // Update progress
-                    updateState { it.copy(processedCount = index + 1) }
+                    updateState {
+                        it.copy(
+                            processedCount = index + 1,
+                            currentlyProcessingImage = null,
+                            imageProcessingStatuses = imageStatuses.toList()
+                        )
+                    }
                 }
 
                 // Show success or partial success message
+                val failedImages = imageStatuses.filterNot { it.success }
                 val statusMessage = when {
                     failedCount == 0 -> null
-                    failedCount < images.size -> "Processed ${images.size - failedCount} of ${images.size} images. Some images could not be processed."
-                    else -> "Failed to process any images."
+                    failedCount < images.size -> {
+                        val failedNames = failedImages.joinToString { it.image.displayName }
+                        "Processed ${images.size - failedCount} of ${images.size} files. Issues with: $failedNames"
+                    }
+                    else -> "Failed to process any files."
                 }
 
                 updateState {
                     it.copy(
                         isProcessing = false,
                         processedCoupons = processedCoupons,
-                        error = statusMessage
+                        error = statusMessage,
+                        imageProcessingStatuses = imageStatuses.toList(),
+                        currentlyProcessingImage = null
                     )
                 }
             } catch (e: Exception) {
@@ -216,7 +332,8 @@ class BatchScannerViewModel @Inject constructor(
                 updateState {
                     it.copy(
                         isProcessing = false,
-                        error = "Error processing images: ${e.message}"
+                        error = "Error processing images: ${e.message}",
+                        currentlyProcessingImage = null
                     )
                 }
             }
@@ -281,6 +398,9 @@ class BatchScannerViewModel @Inject constructor(
     fun resetProcessedCoupons() {
         _uiState.value = _uiState.value.copy(
             processedCoupons = emptyList(),
+            imageProcessingStatuses = emptyList(),
+            processedCount = 0,
+            currentlyProcessingImage = null,
             error = null
         )
     }
@@ -1042,16 +1162,70 @@ class BatchScannerViewModel @Inject constructor(
             updatedAt = java.util.Date()
         )
     }
+
+    private fun createSelectedImage(
+        uri: Uri,
+        selectionOrder: Int,
+        explicitMimeType: String?
+    ): SelectedImage {
+        val displayName = resolveDisplayName(uri) ?: "Image $selectionOrder"
+        val resolvedMimeType = explicitMimeType ?: context.contentResolver.getType(uri)
+        val guessedMimeType = resolvedMimeType ?: guessMimeType(displayName)
+        return SelectedImage(
+            uri = uri,
+            displayName = displayName,
+            mimeType = guessedMimeType,
+            selectionOrder = selectionOrder
+        )
+    }
+
+    private fun resolveDisplayName(uri: Uri): String? {
+        return runCatching {
+            context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                ?.use { cursor ->
+                    if (!cursor.moveToFirst()) return@use null
+                    val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (index >= 0) cursor.getString(index) else null
+                }
+        }.getOrNull()
+    }
+
+    private fun guessMimeType(displayName: String): String {
+        return when {
+            displayName.endsWith(".pdf", ignoreCase = true) -> "application/pdf"
+            displayName.endsWith(".png", ignoreCase = true) -> "image/png"
+            displayName.endsWith(".jpg", ignoreCase = true) || displayName.endsWith(".jpeg", ignoreCase = true) -> "image/jpeg"
+            else -> "image/*"
+        }
+    }
 }
 
 /**
  * UI state for the batch scanner
  */
 data class BatchScannerUiState(
-    val selectedImages: List<Uri> = emptyList(),
+    val selectedImages: List<SelectedImage> = emptyList(),
     val processedCoupons: List<Coupon> = emptyList(),
     val isProcessing: Boolean = false,
     val isSaving: Boolean = false,
     val processedCount: Int = 0,
-    val error: String? = null
+    val error: String? = null,
+    val imageProcessingStatuses: List<ImageProcessingStatus> = emptyList(),
+    val currentlyProcessingImage: SelectedImage? = null
+)
+
+data class SelectedImage(
+    val uri: Uri,
+    val displayName: String,
+    val mimeType: String,
+    val selectionOrder: Int
+) {
+    fun isImage(): Boolean = mimeType.startsWith("image/") || mimeType == "image/*"
+}
+
+data class ImageProcessingStatus(
+    val image: SelectedImage,
+    val success: Boolean,
+    val message: String?,
+    val couponsFound: Int = 0
 )

--- a/web_ui/app.py
+++ b/web_ui/app.py
@@ -296,42 +296,155 @@ def upload_training_images():
 @app.route('/api/upload/testing', methods=['POST'])
 def upload_testing_images():
     """Handle testing image uploads"""
-    if 'file' not in request.files:
-        return jsonify({'error': 'No file provided'}), 400
+    files = []
 
-    file = request.files['file']
-    if file and allowed_file(file.filename):
-        # Generate a unique filename
+    if 'files[]' in request.files:
+        files = request.files.getlist('files[]')
+    elif 'file' in request.files:
+        files = [request.files['file']]
+
+    if not files:
+        return jsonify({'error': 'No files provided'}), 400
+
+    processed_items = []
+
+    for file in files:
+        if not file or not allowed_file(file.filename):
+            print(f"Invalid file skipped: {getattr(file, 'filename', 'unknown')}")
+            continue
+
         filename = str(uuid.uuid4()) + os.path.splitext(file.filename)[1]
         filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
         file.save(filepath)
 
+        processed_path = filepath
         try:
-            # Process the image
             processed_path = image_processor.preprocess_image(filepath)
-
-            # Check if the processed image exists
             if not os.path.exists(processed_path):
-                print(f"Processed image not found: {processed_path}, using original")
+                print(f"Processed image not found: {processed_path}, falling back to original")
                 processed_path = filepath
+        except Exception as e:
+            print(f"Error preprocessing image {file.filename}: {e}")
 
-            # Run pattern recognition
+        try:
             results = model_manager.test_image(processed_path)
         except Exception as e:
-            print(f"Error processing image: {e}")
-            # If processing fails, try using the original image
-            results = model_manager.test_image(filepath)
+            print(f"Error running model on image {file.filename}: {e}")
+            results = {'error': str(e)}
 
-        return jsonify({
+        coupon_summary = build_coupon_summary(results)
+
+        processed_items.append({
             'file': {
                 'original_name': file.filename,
                 'saved_name': filename,
                 'url': url_for('static', filename=f'uploads/{filename}')
             },
-            'results': results
+            'results': results,
+            'coupon_summary': coupon_summary
         })
 
-    return jsonify({'error': 'Invalid file'}), 400
+    if not processed_items:
+        return jsonify({'error': 'No valid files were processed'}), 400
+
+    aggregated_coupon = aggregate_coupon_summaries([item['coupon_summary'] for item in processed_items])
+
+    response_payload = {
+        'items': processed_items,
+        'count': len(processed_items),
+        'aggregated_coupon': aggregated_coupon
+    }
+
+    # Preserve legacy response shape for single uploads
+    if len(processed_items) == 1:
+        response_payload.update({
+            'file': processed_items[0]['file'],
+            'results': processed_items[0]['results'],
+            'coupon_summary': processed_items[0]['coupon_summary']
+        })
+
+    return jsonify(response_payload)
+
+
+def build_coupon_summary(results):
+    """Normalize coupon data into a consistent summary."""
+    if not isinstance(results, dict):
+        return {}
+
+    summary = {}
+    field_sources = {
+        'store': [('text', 'store'), ('coupon', 'store'), ('store_name', None), ('merchant', None)],
+        'code': [('text', 'code'), ('coupon', 'code'), ('coupon_code', None)],
+        'amount': [('text', 'amount'), ('coupon', 'amount'), ('discount', None), ('value', None)],
+        'description': [('text', 'description'), ('coupon', 'description'), ('details', None)],
+        'expiry': [('text', 'expiry'), ('coupon', 'expiry'), ('expiry_date', None), ('expires_on', None)]
+    }
+
+    for field, sources in field_sources.items():
+        summary[field] = extract_field(results, sources)
+
+    return summary
+
+
+def extract_field(results, sources):
+    for container_key, field_key in sources:
+        container = results.get(container_key) if container_key else results
+        if not isinstance(container, dict):
+            continue
+
+        value = container.get(field_key) if field_key else container
+
+        text, confidence = normalize_value(value)
+        if text:
+            return {
+                'text': text,
+                'confidence': confidence
+            }
+
+    return None
+
+
+def normalize_value(value):
+    if isinstance(value, dict):
+        text = value.get('text') or value.get('value') or value.get('raw') or value.get('label')
+        confidence = value.get('confidence') or value.get('score')
+        if text:
+            return str(text), confidence
+    elif isinstance(value, (str, int, float)):
+        return str(value), None
+
+    return None, None
+
+
+def aggregate_coupon_summaries(summaries):
+    """Merge individual coupon summaries into a single best-effort coupon."""
+    fields = ['store', 'code', 'amount', 'description', 'expiry']
+    aggregated = {}
+
+    for field in fields:
+        best_value = None
+        best_confidence = -1.0
+
+        for summary in summaries:
+            if not summary:
+                continue
+            candidate = summary.get(field)
+            if not candidate or not candidate.get('text'):
+                continue
+
+            confidence = candidate.get('confidence')
+            numeric_confidence = confidence if isinstance(confidence, (int, float)) else None
+
+            if numeric_confidence is not None:
+                if numeric_confidence > best_confidence:
+                    best_value = candidate
+                    best_confidence = numeric_confidence
+            elif best_value is None:
+                best_value = candidate
+
+        aggregated[field] = best_value
+
+    return aggregated
 
 @app.route('/api/annotate', methods=['POST'])
 def save_annotation():

--- a/web_ui/templates/testing.html
+++ b/web_ui/templates/testing.html
@@ -107,14 +107,14 @@
             <div class="col-md-12">
                 <div class="card">
                     <div class="card-header">
-                        <h5>Upload Test Image</h5>
+                        <h5>Upload Test Images</h5>
                     </div>
                     <div class="card-body">
                         <div id="dropArea">
                             <i class="fas fa-cloud-upload-alt fa-3x mb-3"></i>
-                            <h5>Drag & Drop a Coupon Image Here</h5>
+                            <h5>Drag & Drop Coupon Images Here</h5>
                             <p>or</p>
-                            <input type="file" id="fileInput" accept="image/*" style="display: none;">
+                            <input type="file" id="fileInput" accept="image/*" multiple style="display: none;">
                             <button class="btn btn-primary" id="browseBtn">Browse Files</button>
                         </div>
 
@@ -218,7 +218,7 @@
                 const dt = e.dataTransfer;
                 const files = dt.files;
                 if (files.length > 0) {
-                    handleFile(files[0]);
+                    handleFiles(files);
                 }
             }
 
@@ -230,21 +230,24 @@
             // File input change
             $('#fileInput').change(function() {
                 if (this.files.length > 0) {
-                    handleFile(this.files[0]);
+                    handleFiles(this.files);
                 }
             });
         });
 
-        // Handle uploaded file
-        function handleFile(file) {
-            if (!file) return;
+        // Handle uploaded files
+        function handleFiles(fileList) {
+            const files = Array.from(fileList || []).filter(Boolean);
+            if (files.length === 0) return;
 
             // Show progress container
             $('.progress-container').show();
+            $('.progress-bar').css('width', '0%');
+            $('#uploadStatus').text('Uploading...');
 
             // Create FormData
             const formData = new FormData();
-            formData.append('file', file);
+            files.forEach(file => formData.append('files[]', file));
 
             // Upload file
             $.ajax({
@@ -283,283 +286,375 @@
 
         // Display recognition results
         function displayResults(response) {
-            if (!response.file || !response.results) {
-                $('#resultContainer').html('<p class="text-center text-danger">Error: Invalid response</p>');
+            const items = normalizeResponseItems(response);
+
+            if (items.length === 0) {
+                $('#resultContainer').html('<p class="text-center text-danger">Error: No results returned</p>');
+                $('#extractedTextContainer').html('<p class="text-center">No text extracted</p>');
+                $('#detectedElementsContainer').html('<p class="text-center">No elements detected</p>');
+                $('#couponSummaryContainer').html('<p class="text-center">No coupon summary available</p>');
                 return;
             }
 
-            // Display image with highlighted regions
+            renderImageResults(items);
+            renderExtractedText(items);
+            renderDetectedElements(items);
+            renderCouponSummaries(items, response.aggregated_coupon);
+        }
+
+        function normalizeResponseItems(response) {
+            if (!response) {
+                return [];
+            }
+
+            if (Array.isArray(response.items) && response.items.length > 0) {
+                return response.items;
+            }
+
+            if (response.file && response.results) {
+                return [{
+                    file: response.file,
+                    results: response.results,
+                    coupon_summary: response.coupon_summary || null
+                }];
+            }
+
+            return [];
+        }
+
+        function renderImageResults(items) {
             const resultContainer = $('#resultContainer');
             resultContainer.empty();
 
-            const imageContainer = $('<div class="result-image-container"></div>');
-            const image = $('<img class="result-image" src="' + response.file.url + '" alt="' + response.file.original_name + '">');
+            items.forEach(function(item, index) {
+                const section = $('<div class="mb-4"></div>');
+                const title = $('<h6 class="fw-bold"></h6>');
+                const filename = item.file && item.file.original_name ? ' — ' + item.file.original_name : '';
+                title.text('Screenshot ' + (index + 1) + filename);
+                section.append(title);
 
-            imageContainer.append(image);
+                const imageContainer = $('<div class="result-image-container position-relative"></div>');
+                const image = $('<img class="result-image" alt="Coupon screenshot">');
+                if (item.file && item.file.url) {
+                    image.attr('src', item.file.url);
+                }
+                imageContainer.append(image);
+                section.append(imageContainer);
+                resultContainer.append(section);
 
-            // Wait for image to load before adding highlight boxes
-            image.on('load', function() {
-                const imgWidth = this.width;
-                const imgHeight = this.height;
+                image.on('load', function() {
+                    imageContainer.find('.highlight-box, .highlight-label').remove();
 
-                // Add highlight boxes for detected elements
-                if (response.results.elements && response.results.elements.length > 0) {
-                    response.results.elements.forEach(function(element) {
-                        const region = element.region;
-                        const type = element.type;
-                        const confidence = element.confidence;
+                    if (!item.results || !Array.isArray(item.results.elements)) {
+                        return;
+                    }
 
-                        // Determine confidence class
-                        let confidenceClass = '';
-                        if (confidence >= 0.8) {
-                            confidenceClass = 'confidence-high';
-                        } else if (confidence >= 0.5) {
-                            confidenceClass = 'confidence-medium';
-                        } else {
-                            confidenceClass = 'confidence-low';
-                        }
+                    item.results.elements.forEach(function(element) {
+                        const region = element.region || {};
+                        const type = element.type || 'unknown';
+                        const confidence = element.confidence || 0;
 
-                        const box = $('<div class="highlight-box ' + confidenceClass + '"></div>');
+                        const box = $('<div class="highlight-box"></div>');
+                        box.addClass(getConfidenceClass(confidence));
                         box.css({
-                            left: region.left + 'px',
-                            top: region.top + 'px',
-                            width: (region.right - region.left) + 'px',
-                            height: (region.bottom - region.top) + 'px',
+                            left: (region.left || 0) + 'px',
+                            top: (region.top || 0) + 'px',
+                            width: Math.max((region.right || 0) - (region.left || 0), 0) + 'px',
+                            height: Math.max((region.bottom || 0) - (region.top || 0), 0) + 'px',
                             borderColor: getColorForType(type)
                         });
 
-                        // Add tooltip data attributes
                         box.attr('data-bs-toggle', 'tooltip');
                         box.attr('data-bs-placement', 'top');
-                        box.attr('title', type + ': ' + Math.round(confidence * 100) + '% confidence');
+                        box.attr('title', capitalizeFirstLetter(type) + ': ' + Math.round(confidence * 100) + '%');
 
                         const label = $('<div class="highlight-label"></div>');
                         label.text(capitalizeFirstLetter(type) + ' (' + Math.round(confidence * 100) + '%)');
                         label.css({
-                            left: region.left + 'px',
-                            top: (region.top - 25) + 'px',
+                            left: (region.left || 0) + 'px',
+                            top: Math.max((region.top || 0) - 25, 0) + 'px',
                             backgroundColor: getColorForType(type)
                         });
 
                         imageContainer.append(box);
                         imageContainer.append(label);
                     });
-                }
+
+                    const tooltipTriggerList = [].slice.call(imageContainer.find('[data-bs-toggle="tooltip"]'));
+                    tooltipTriggerList.forEach(function(tooltipTriggerEl) {
+                        new bootstrap.Tooltip(tooltipTriggerEl);
+                    });
+                });
             });
+        }
 
-            resultContainer.append(imageContainer);
+        function renderExtractedText(items) {
+            const container = $('#extractedTextContainer');
+            container.empty();
 
-            // Display extracted text
-            const extractedTextContainer = $('#extractedTextContainer');
-            extractedTextContainer.empty();
+            const anyText = items.some(item => item.results && item.results.text && Object.keys(item.results.text).length > 0);
 
-            if (response.results.text && Object.keys(response.results.text).length > 0) {
-                const textList = $('<div class="accordion" id="extractedTextAccordion"></div>');
+            if (!anyText) {
+                container.html('<p class="text-center">No text extracted</p>');
+                return;
+            }
 
-                // Define the order we want to display the fields
+            const accordionId = 'extractedTextAccordion';
+            const accordion = $('<div class="accordion" id="' + accordionId + '"></div>');
+
+            items.forEach(function(item, itemIndex) {
+                const text = item.results && item.results.text ? item.results.text : null;
+                if (!text || Object.keys(text).length === 0) {
+                    return;
+                }
+
+                const itemId = accordionId + 'Item' + itemIndex;
+                const accordionItem = $('<div class="accordion-item"></div>');
+                const header = $('<h2 class="accordion-header" id="' + itemId + 'Header"></h2>');
+                const button = $('<button class="accordion-button' + (itemIndex === 0 ? '' : ' collapsed') + '" type="button" data-bs-toggle="collapse" data-bs-target="#' + itemId + 'Body" aria-expanded="' + (itemIndex === 0) + '" aria-controls="' + itemId + 'Body"></button>');
+                const filename = item.file && item.file.original_name ? item.file.original_name : 'Screenshot ' + (itemIndex + 1);
+                button.html('<i class="fas fa-file-image me-2"></i>' + filename);
+                header.append(button);
+                accordionItem.append(header);
+
+                const collapseDiv = $('<div id="' + itemId + 'Body" class="accordion-collapse collapse' + (itemIndex === 0 ? ' show' : '') + '" aria-labelledby="' + itemId + 'Header" data-bs-parent="#' + accordionId + '"></div>');
+                const body = $('<div class="accordion-body"></div>');
+
                 const fieldOrder = ['store', 'amount', 'code', 'description', 'expiry'];
-
-                // Process fields in the defined order
-                fieldOrder.forEach((type, index) => {
-                    if (response.results.text[type]) {
-                        const text = response.results.text[type];
-                        const headerId = 'heading' + type;
-                        const collapseId = 'collapse' + type;
-                        const isFirst = index === 0;
-
-                        const accordionItem = $('<div class="accordion-item"></div>');
-                        const header = $('<h2 class="accordion-header" id="' + headerId + '"></h2>');
-                        const button = $('<button class="accordion-button ' + (isFirst ? '' : 'collapsed') + '" type="button" data-bs-toggle="collapse" data-bs-target="#' + collapseId + '" aria-expanded="' + (isFirst ? 'true' : 'false') + '" aria-controls="' + collapseId + '"></button>');
-
-                        button.html('<span class="badge bg-' + getBadgeColorForType(type) + ' me-2">' + capitalizeFirstLetter(type) + '</span>');
-
-                        header.append(button);
-                        accordionItem.append(header);
-
-                        const collapseDiv = $('<div id="' + collapseId + '" class="accordion-collapse collapse ' + (isFirst ? 'show' : '') + '" aria-labelledby="' + headerId + '" data-bs-parent="#extractedTextAccordion"></div>');
-                        const body = $('<div class="accordion-body"></div>');
-
-                        body.html('<p class="mb-0">' + text + '</p>');
-
-                        collapseDiv.append(body);
-                        accordionItem.append(collapseDiv);
-
-                        textList.append(accordionItem);
+                fieldOrder.forEach(function(type) {
+                    if (!text[type]) {
+                        return;
                     }
+
+                    const value = text[type];
+                    const fieldRow = $('<div class="mb-2"></div>');
+                    fieldRow.append('<span class="badge bg-' + getBadgeColorForType(type) + ' me-2">' + capitalizeFirstLetter(type) + '</span>');
+                    fieldRow.append('<span>' + value + '</span>');
+                    body.append(fieldRow);
                 });
 
-                extractedTextContainer.append(textList);
-
-                // Add a copy all button
-                const copyAllBtn = $('<button class="btn btn-sm btn-outline-primary mt-3 w-100">Copy All Text</button>');
-                copyAllBtn.click(function() {
-                    const allText = Object.entries(response.results.text)
-                        .map(([type, text]) => capitalizeFirstLetter(type) + ': ' + text)
+                const copyBtn = $('<button class="btn btn-sm btn-outline-primary mt-3">Copy Text</button>');
+                copyBtn.click(function() {
+                    const textBlob = Object.entries(text)
+                        .map(([type, value]) => capitalizeFirstLetter(type) + ': ' + value)
                         .join('\n');
 
-                    navigator.clipboard.writeText(allText).then(function() {
-                        $(this).text('Copied!');
+                    navigator.clipboard.writeText(textBlob).then(function() {
+                        copyBtn.text('Copied!');
                         setTimeout(function() {
-                            copyAllBtn.text('Copy All Text');
+                            copyBtn.text('Copy Text');
                         }, 2000);
-                    }.bind(this));
-                });
-
-                extractedTextContainer.append(copyAllBtn);
-            } else {
-                extractedTextContainer.html('<p class="text-center">No text extracted</p>');
-            }
-
-            // Display detected elements
-            const detectedElementsContainer = $('#detectedElementsContainer');
-            detectedElementsContainer.empty();
-
-            if (response.results.elements && response.results.elements.length > 0) {
-                // Group elements by type
-                const elementsByType = {};
-                response.results.elements.forEach(function(element) {
-                    if (!elementsByType[element.type]) {
-                        elementsByType[element.type] = [];
-                    }
-                    elementsByType[element.type].push(element);
-                });
-
-                // Create a table for better visualization
-                const table = $('<table class="table table-sm table-hover"></table>');
-                const thead = $('<thead class="table-light"></thead>');
-                const headerRow = $('<tr></tr>');
-                headerRow.append('<th>Type</th><th>Confidence</th><th>Position</th>');
-                thead.append(headerRow);
-                table.append(thead);
-
-                const tbody = $('<tbody></tbody>');
-
-                // Process each type in order
-                const fieldOrder = ['store', 'amount', 'code', 'description', 'expiry'];
-                fieldOrder.forEach(type => {
-                    if (elementsByType[type]) {
-                        elementsByType[type].forEach(function(element, index) {
-                            const confidence = element.confidence;
-                            const region = element.region;
-
-                            // Determine confidence class
-                            let confidenceClass = '';
-                            if (confidence >= 0.8) {
-                                confidenceClass = 'table-success';
-                            } else if (confidence >= 0.5) {
-                                confidenceClass = 'table-warning';
-                            } else {
-                                confidenceClass = 'table-danger';
-                            }
-
-                            const row = $('<tr class="' + confidenceClass + '"></tr>');
-
-                            // Only show type name for the first element of each type
-                            if (index === 0) {
-                                row.append('<td><span class="badge bg-' + getBadgeColorForType(type) + '">' +
-                                           capitalizeFirstLetter(type) + '</span></td>');
-                            } else {
-                                row.append('<td></td>');
-                            }
-
-                            // Add confidence with progress bar
-                            const confidencePercent = Math.round(confidence * 100);
-                            const confidenceCell = $('<td></td>');
-                            const progressBar = $('<div class="progress" style="height: 15px;"></div>');
-                            const progressBarInner = $('<div class="progress-bar" role="progressbar"></div>');
-                            progressBarInner.css('width', confidencePercent + '%');
-                            progressBarInner.attr('aria-valuenow', confidencePercent);
-                            progressBarInner.attr('aria-valuemin', '0');
-                            progressBarInner.attr('aria-valuemax', '100');
-                            progressBarInner.text(confidencePercent + '%');
-
-                            // Set color based on confidence
-                            if (confidence >= 0.8) {
-                                progressBarInner.addClass('bg-success');
-                            } else if (confidence >= 0.5) {
-                                progressBarInner.addClass('bg-warning');
-                            } else {
-                                progressBarInner.addClass('bg-danger');
-                            }
-
-                            progressBar.append(progressBarInner);
-                            confidenceCell.append(progressBar);
-                            row.append(confidenceCell);
-
-                            // Add position info
-                            row.append('<td>(' + region.left + ', ' + region.top + ') to (' +
-                                       region.right + ', ' + region.bottom + ')</td>');
-
-                            tbody.append(row);
-                        });
-                    }
-                });
-
-                table.append(tbody);
-                detectedElementsContainer.append(table);
-
-                // Add a note about confidence levels
-                const confidenceNote = $('<div class="mt-2 small text-muted"></div>');
-                confidenceNote.html('<strong>Confidence levels:</strong><br>' +
-                                   '<span class="badge bg-success">High</span> 80-100% | ' +
-                                   '<span class="badge bg-warning">Medium</span> 50-79% | ' +
-                                   '<span class="badge bg-danger">Low</span> 0-49%');
-                detectedElementsContainer.append(confidenceNote);
-            } else {
-                detectedElementsContainer.html('<p class="text-center">No elements detected</p>');
-            }
-
-            // Display coupon summary
-            const couponSummaryContainer = $('#couponSummaryContainer');
-            couponSummaryContainer.empty();
-
-            if (response.results.summary) {
-                // Create a styled summary card
-                const summaryCard = $('<div class="card border-success"></div>');
-                const summaryBody = $('<div class="card-body"></div>');
-
-                // Split the summary into lines and create styled elements
-                const summaryLines = response.results.summary.split('\n');
-
-                summaryLines.forEach(function(line) {
-                    if (line.trim()) {
-                        const parts = line.split(':');
-                        if (parts.length >= 2) {
-                            const label = parts[0].trim();
-                            const value = parts.slice(1).join(':').trim();
-
-                            const row = $('<div class="row mb-2"></div>');
-                            row.append('<div class="col-4 fw-bold">' + label + ':</div>');
-                            row.append('<div class="col-8">' + value + '</div>');
-
-                            summaryBody.append(row);
-                        } else {
-                            summaryBody.append('<p>' + line + '</p>');
-                        }
-                    }
-                });
-
-                // Add a "Copy to Clipboard" button
-                const copyBtn = $('<button class="btn btn-sm btn-outline-success mt-3">Copy to Clipboard</button>');
-                copyBtn.click(function() {
-                    navigator.clipboard.writeText(response.results.summary).then(function() {
-                        $(this).text('Copied!');
-                        setTimeout(function() {
-                            copyBtn.text('Copy to Clipboard');
-                        }, 2000);
-                    }.bind(this)).catch(function(err) {
-                        console.error('Could not copy text: ', err);
                     });
                 });
 
-                summaryBody.append(copyBtn);
-                summaryCard.append(summaryBody);
-                couponSummaryContainer.append(summaryCard);
-            } else if (response.results.error) {
-                couponSummaryContainer.html('<div class="alert alert-danger">' + response.results.error + '</div>');
-            } else {
-                couponSummaryContainer.html('<p class="text-center">No coupon summary available</p>');
+                body.append(copyBtn);
+                collapseDiv.append(body);
+                accordionItem.append(collapseDiv);
+                accordion.append(accordionItem);
+            });
+
+            container.append(accordion);
+        }
+
+        function renderDetectedElements(items) {
+            const container = $('#detectedElementsContainer');
+            container.empty();
+
+            const entries = items.map((item, index) => ({
+                index,
+                file: item.file,
+                elements: item.results && Array.isArray(item.results.elements) ? item.results.elements : []
+            })).filter(entry => entry.elements.length > 0);
+
+            if (entries.length === 0) {
+                container.html('<p class="text-center">No elements detected</p>');
+                return;
             }
+
+            const accordionId = 'detectedElementsAccordion';
+            const accordion = $('<div class="accordion" id="' + accordionId + '"></div>');
+
+            entries.forEach(function(entry, entryIndex) {
+                const itemId = accordionId + 'Item' + entryIndex;
+                const accordionItem = $('<div class="accordion-item"></div>');
+                const header = $('<h2 class="accordion-header" id="' + itemId + 'Header"></h2>');
+                const button = $('<button class="accordion-button' + (entryIndex === 0 ? '' : ' collapsed') + '" type="button" data-bs-toggle="collapse" data-bs-target="#' + itemId + 'Body" aria-expanded="' + (entryIndex === 0) + '" aria-controls="' + itemId + 'Body"></button>');
+                const filename = entry.file && entry.file.original_name ? entry.file.original_name : 'Screenshot ' + (entry.index + 1);
+                button.html('<i class="fas fa-bullseye me-2"></i>' + filename + ' — ' + entry.elements.length + ' elements');
+                header.append(button);
+                accordionItem.append(header);
+
+                const collapseDiv = $('<div id="' + itemId + 'Body" class="accordion-collapse collapse' + (entryIndex === 0 ? ' show' : '') + '" aria-labelledby="' + itemId + 'Header" data-bs-parent="#' + accordionId + '"></div>');
+                const body = $('<div class="accordion-body"></div>');
+
+                const table = $('<table class="table table-sm table-hover"></table>');
+                const thead = $('<thead class="table-light"><tr><th>Type</th><th>Confidence</th><th>Position</th></tr></thead>');
+                table.append(thead);
+                const tbody = $('<tbody></tbody>');
+
+                const fieldOrder = ['store', 'amount', 'code', 'description', 'expiry'];
+                fieldOrder.forEach(function(type) {
+                    entry.elements.filter(element => element.type === type).forEach(function(element, elementIndex) {
+                        const confidence = element.confidence || 0;
+                        const region = element.region || {};
+                        const row = $('<tr></tr>');
+                        row.addClass(getRowConfidenceClass(confidence));
+
+                        if (elementIndex === 0) {
+                            row.append('<td><span class="badge bg-' + getBadgeColorForType(type) + '">' + capitalizeFirstLetter(type) + '</span></td>');
+                        } else {
+                            row.append('<td></td>');
+                        }
+
+                        const confidencePercent = Math.round(confidence * 100);
+                        const confidenceCell = $('<td></td>');
+                        const progressBar = $('<div class="progress" style="height: 15px;"></div>');
+                        const progressBarInner = $('<div class="progress-bar" role="progressbar"></div>');
+                        progressBarInner.css('width', confidencePercent + '%');
+                        progressBarInner.attr({
+                            'aria-valuenow': confidencePercent,
+                            'aria-valuemin': 0,
+                            'aria-valuemax': 100
+                        });
+                        progressBarInner.text(confidencePercent + '%');
+                        progressBarInner.addClass(getProgressBarClass(confidence));
+
+                        progressBar.append(progressBarInner);
+                        confidenceCell.append(progressBar);
+                        row.append(confidenceCell);
+
+                        row.append('<td>(' + (region.left || 0) + ', ' + (region.top || 0) + ') → (' + (region.right || 0) + ', ' + (region.bottom || 0) + ')</td>');
+
+                        tbody.append(row);
+                    });
+                });
+
+                table.append(tbody);
+                body.append(table);
+
+                const confidenceNote = $('<div class="mt-2 small text-muted"></div>');
+                confidenceNote.html('<strong>Confidence levels:</strong><br>' +
+                    '<span class="badge bg-success">High</span> 80-100% | ' +
+                    '<span class="badge bg-warning">Medium</span> 50-79% | ' +
+                    '<span class="badge bg-danger">Low</span> 0-49%');
+                body.append(confidenceNote);
+
+                collapseDiv.append(body);
+                accordionItem.append(collapseDiv);
+                accordion.append(accordionItem);
+            });
+
+            container.append(accordion);
+        }
+
+        function renderCouponSummaries(items, aggregatedCoupon) {
+            const container = $('#couponSummaryContainer');
+            container.empty();
+
+            const summaries = items.map(item => item.coupon_summary).filter(Boolean);
+            const hasSummary = summaries.length > 0 || aggregatedCoupon;
+
+            if (!hasSummary) {
+                container.html('<p class="text-center">No coupon summary available</p>');
+                return;
+            }
+
+            if (aggregatedCoupon) {
+                const aggregatedCard = createSummaryCard('Combined Coupon (Best Fields)', aggregatedCoupon);
+                container.append(aggregatedCard);
+            }
+
+            summaries.forEach(function(summary, index) {
+                const title = 'Screenshot ' + (index + 1);
+                const card = createSummaryCard(title, summary);
+                container.append(card);
+            });
+        }
+
+        function createSummaryCard(title, summary) {
+            const card = $('<div class="card border-success mb-3"></div>');
+            const header = $('<div class="card-header bg-success text-white"></div>').text(title);
+            const body = $('<div class="card-body"></div>');
+
+            const fields = ['store', 'amount', 'code', 'description', 'expiry'];
+            let hasContent = false;
+
+            fields.forEach(function(field) {
+                const data = summary[field];
+                if (!data || !data.text) {
+                    return;
+                }
+                hasContent = true;
+
+                const row = $('<div class="row mb-2"></div>');
+                row.append('<div class="col-4 fw-bold">' + capitalizeFirstLetter(field) + ':</div>');
+
+                let valueHtml = data.text;
+                if (typeof data.confidence === 'number') {
+                    valueHtml += ' <span class="badge bg-secondary ms-2">' + Math.round(data.confidence * 100) + '%</span>';
+                }
+
+                row.append('<div class="col-8">' + valueHtml + '</div>');
+                body.append(row);
+            });
+
+            if (!hasContent) {
+                body.append('<p class="mb-0">No structured data available.</p>');
+            } else {
+                const copyBtn = $('<button class="btn btn-sm btn-outline-success mt-3">Copy Summary</button>');
+                copyBtn.click(function() {
+                    const textBlob = fields
+                        .map(field => ({
+                            key: field,
+                            entry: summary[field]
+                        }))
+                        .filter(item => item.entry && item.entry.text)
+                        .map(item => capitalizeFirstLetter(item.key) + ': ' + item.entry.text)
+                        .join('\n');
+
+                    navigator.clipboard.writeText(textBlob).then(function() {
+                        copyBtn.text('Copied!');
+                        setTimeout(function() {
+                            copyBtn.text('Copy Summary');
+                        }, 2000);
+                    });
+                });
+                body.append(copyBtn);
+            }
+
+            card.append(header);
+            card.append(body);
+            return card;
+        }
+
+        function getConfidenceClass(confidence) {
+            if (confidence >= 0.8) {
+                return 'confidence-high';
+            }
+            if (confidence >= 0.5) {
+                return 'confidence-medium';
+            }
+            return 'confidence-low';
+        }
+
+        function getRowConfidenceClass(confidence) {
+            if (confidence >= 0.8) {
+                return 'table-success';
+            }
+            if (confidence >= 0.5) {
+                return 'table-warning';
+            }
+            return 'table-danger';
+        }
+
+        function getProgressBarClass(confidence) {
+            if (confidence >= 0.8) {
+                return 'bg-success';
+            }
+            if (confidence >= 0.5) {
+                return 'bg-warning';
+            }
+            return 'bg-danger';
         }
 
         // Helper functions


### PR DESCRIPTION
## Summary
- switch the Android upload flows to use the Storage Access Framework so multiple local screenshots are persisted and queued for batch scanning
- extend the batch scanner view model with deduped image metadata, per-image progress tracking, and richer status reporting for each processed file
- refresh the batch scanner UI to surface filenames, thumbnails, processing summaries, and enhanced coupon cards for individual review

## Testing
- ./gradlew :app:lintDebug *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebfd3dffa08328b948731519f457ea