### PR TITLE
Fix expiry date parsing for comma formatted values

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/extraction/ProgressiveExtractionService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/ProgressiveExtractionService.kt
@@ -11,9 +11,11 @@ import com.example.coupontracker.data.model.FieldType
 import com.example.coupontracker.universal.PatternLearningEngine
 import com.example.coupontracker.util.ImageMetadataExtractor
 import com.example.coupontracker.util.IndianCurrencyParser
+import com.example.coupontracker.util.IndianDateParser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
+import java.time.ZoneId
 import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -397,32 +399,48 @@ class ProgressiveExtractionService @Inject constructor(
     /**
      * Parse date string to Date object
      */
-    private fun parseDate(dateString: String): Date? {
+    internal fun parseDate(dateString: String): Date? {
+        val sanitized = dateString.trim()
+            .replace(Regex("(?i)(\\d{1,2})(st|nd|rd|th)"), "\\1")
+            .replace(",", "")
+            .replace(Regex("\\s+"), " ")
+
         // Try ISO format first (from relative date conversion)
         val isoFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
         try {
-            return isoFormat.parse(dateString)
-        } catch (e: Exception) {
+            return isoFormat.parse(sanitized)
+        } catch (ignored: Exception) {
             // Not ISO format
         }
-        
-        // Try common Indian date formats
+
+        // Try common Indian date formats with both single and double digit days
         val formats = listOf(
             "dd/MM/yyyy",
+            "d/M/yyyy",
             "dd-MM-yyyy",
+            "d-M-yyyy",
             "dd MMM yyyy",
-            "dd MMMM yyyy"
+            "d MMM yyyy",
+            "dd MMMM yyyy",
+            "d MMMM yyyy"
         )
-        
+
         for (formatStr in formats) {
             try {
                 val format = SimpleDateFormat(formatStr, Locale.US)
-                return format.parse(dateString)
-            } catch (e: Exception) {
+                return format.parse(sanitized)
+            } catch (ignored: Exception) {
                 // Try next format
             }
         }
-        
+
+        // Fallback to the shared Indian date parser for harder cases
+        val fallback = IndianDateParser.parseExpiryIST(dateString).date
+        if (fallback != null) {
+            val zone = ZoneId.systemDefault()
+            return Date.from(fallback.atStartOfDay(zone).toInstant())
+        }
+
         Log.w(TAG, "Could not parse date: $dateString")
         return null
     }

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/StructuredFieldExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/StructuredFieldExtractor.kt
@@ -354,7 +354,10 @@ class StructuredFieldExtractor {
         // Pattern 2: Absolute dates (DD/MM/YYYY, DD-MM-YYYY, etc.)
         val absolutePatterns = listOf(
             Regex("""(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})"""),
-            Regex("""(\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{2,4})""", RegexOption.IGNORE_CASE)
+            Regex(
+                """(\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\s*,?\s*\d{2,4})""",
+                RegexOption.IGNORE_CASE
+            )
         )
         
         for (pattern in absolutePatterns) {

--- a/app/src/test/java/com/example/coupontracker/extraction/ProgressiveExtractionServiceTest.kt
+++ b/app/src/test/java/com/example/coupontracker/extraction/ProgressiveExtractionServiceTest.kt
@@ -1,0 +1,32 @@
+package com.example.coupontracker.extraction
+
+import com.example.coupontracker.universal.PatternLearningEngine
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class ProgressiveExtractionServiceTest {
+
+    private val service = ProgressiveExtractionService(
+        structuredExtractor = StructuredFieldExtractor(),
+        semanticExtractor = SemanticFieldExtractor(),
+        heuristicExtractor = HeuristicFieldExtractor(),
+        learnedPatternEngine = mockk(relaxed = true),
+        defaultProvider = DefaultFieldProvider(),
+        llmService = null,
+        extractionLearningIntegration = null
+    )
+
+    @Test
+    fun `parseDate handles comma separated month format`() {
+        val parsed = service.parseDate("31 May, 2025")
+
+        assertNotNull("Expected the date parser to handle comma separated month", parsed)
+
+        val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        assertEquals("2025-05-31", formatter.format(parsed!!))
+    }
+}

--- a/app/src/test/java/com/example/coupontracker/extraction/StructuredFieldExtractorTest.kt
+++ b/app/src/test/java/com/example/coupontracker/extraction/StructuredFieldExtractorTest.kt
@@ -1,0 +1,30 @@
+package com.example.coupontracker.extraction
+
+import com.example.coupontracker.data.model.FieldType
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StructuredFieldExtractorTest {
+
+    private val extractor = StructuredFieldExtractor()
+
+    @Test
+    fun `detectFieldsStructured captures expiry date with comma separated month`() = runTest {
+        val context = ExtractionContext(
+            imageUri = "test://coupon",
+            ocrText = "Buy 2 Get 2 Free. Expires on 31 May, 2025. Use code SAVE",
+            ocrBlocks = emptyList(),
+            metadata = emptyMap(),
+            captureTimestamp = null
+        )
+
+        val results = extractor.detectFieldsStructured(context)
+
+        val expiryCandidates = results[FieldType.EXPIRY_DATE].orEmpty()
+        assertTrue(
+            "Expected expiry candidates to include the normalized date",
+            expiryCandidates.any { it.value.contains("31 May") }
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- allow the structured extractor to match expiry dates that include a comma between the month and year
- sanitize and broaden progressive date parsing while falling back to the shared Indian date parser
- add unit tests covering the comma-formatted expiry detection and parsing logic

## Testing
- ./gradlew test *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec9f032b7c8328b49049a69dd08562