### PR TITLE
Prevent duplicate coupon form image processing logs

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/CouponFormScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/CouponFormScreen.kt
@@ -78,11 +78,14 @@ fun CouponFormScreen(
     var category by remember { mutableStateOf(uiState.couponInfo?.category ?: "") }
 
     // Initialize with image URI
-    LaunchedEffect(imageUri) {
-        imageUri?.let { uri ->
-            if (uri.isNotEmpty()) {
-                viewModel.processImageUri(Uri.parse(uri))
-            }
+    LaunchedEffect(imageUri, uiState.isProcessing, uiState.couponInfo) {
+        val uriString = imageUri?.takeIf { it.isNotEmpty() } ?: return@LaunchedEffect
+
+        val hasExtractedInfo = uiState.couponInfo != null
+        val isCurrentlyProcessing = uiState.isProcessing
+
+        if (!hasExtractedInfo && !isCurrentlyProcessing) {
+            viewModel.processImageUri(Uri.parse(uriString))
         }
     }
 

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/CouponFormViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/CouponFormViewModel.kt
@@ -50,14 +50,35 @@ class CouponFormViewModel @Inject constructor(
     }
 
     /**
+     * Track the currently running image processing request to avoid duplicate work.
+     */
+    private var currentlyProcessingImageUri: String? = null
+
+    /**
      * Process an image URI to extract coupon information
      * @param uri URI of the image to process
+     * @param force When true, bypasses duplicate detection and re-processes the URI
      */
-    fun processImageUri(uri: Uri) {
+    fun processImageUri(uri: Uri, force: Boolean = false) {
+        val uriString = uri.toString()
+
+        if (!force && uriString == currentlyProcessingImageUri) {
+            Log.d(TAG, "Skipping duplicate processing request for URI already in progress: $uriString")
+            return
+        }
+
+        currentlyProcessingImageUri = uriString
+
+        updateState {
+            it.copy(
+                isProcessing = true,
+                error = null,
+                saveResult = null
+            )
+        }
+
         viewModelScope.launch {
             try {
-                updateState { it.copy(isProcessing = true, error = null, saveResult = null) }
-
                 val coupon = couponInputManager.processCouponFromImageUriWithPersistence(uri)
 
                 val couponInfo = mapCouponToCouponInfo(coupon)
@@ -70,6 +91,10 @@ class CouponFormViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 handleError(e, "Error processing image")
+            } finally {
+                if (currentlyProcessingImageUri == uriString) {
+                    currentlyProcessingImageUri = null
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- gate the coupon form screen's image processing effect so it only fires when nothing is already processing or extracted
- mark the view model state as processing before launching extraction to avoid a second duplicate request

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68edccac4b0883289524d89a453b64a0