### PR TITLE
Detect and block stub LLM responses

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -674,11 +674,12 @@ class LocalLlmOcrService(
                 val couponInfo = parseLlmResponseToCouponInfo(llmResponse, rawOcrText)
                 
                 // CRITICAL: Detect mock responses and reject them
-                if (isMockLlmResponse(couponInfo)) {
+                if (MockLlmResponseDetector.isMockResponse(couponInfo)) {
+                    Log.w(TAG, "Mock response signature: store='${couponInfo.storeName}', code='${couponInfo.redeemCode}', desc='${couponInfo.description}'")
                     Log.w(TAG, "⚠️ MOCK LLM RESPONSE DETECTED - Falling back to OCR")
                     return@coroutineScope ExtractResult.Failed(
                         stage = ExtractionStage.LLM,
-                        error = IllegalStateException("Mock LLM response detected (Example Store / MOCK123)")
+                        error = IllegalStateException("Mock LLM response detected (placeholder runtime output)")
                     )
                 }
                 
@@ -791,9 +792,10 @@ class LocalLlmOcrService(
                 val parsedInfo = parseLlmResponseToCouponInfo(llmResponse, ocrText)
                 
                 // CRITICAL: Detect mock responses and fall back to OCR
-                if (isMockLlmResponse(parsedInfo)) {
+                if (MockLlmResponseDetector.isMockResponse(parsedInfo)) {
+                    Log.w(TAG, "Mock response signature: store='${parsedInfo.storeName}', code='${parsedInfo.redeemCode}', desc='${parsedInfo.description}'")
                     Log.w(TAG, "⚠️ MOCK LLM RESPONSE DETECTED - Falling back to OCR")
-                    throw IllegalStateException("Mock LLM response detected (Example Store / MOCK123)")
+                    throw IllegalStateException("Mock LLM response detected (placeholder runtime output)")
                 }
                 
                 parsedInfo
@@ -875,33 +877,6 @@ class LocalLlmOcrService(
      * Detect mock/placeholder responses from stub JNI
      * Returns true if the response matches known mock patterns
      */
-    private fun isMockLlmResponse(couponInfo: CouponInfo): Boolean {
-        // Check for exact mock patterns from mlc_llm_jni.cpp
-        val isMockStore = couponInfo.storeName.equals("Example Store", ignoreCase = true)
-        val isMockCode = couponInfo.redeemCode?.let {
-            it.equals("MOCK123", ignoreCase = true) ||
-            it.equals("EXAMPLE123", ignoreCase = true) ||
-            it.startsWith("MOCK", ignoreCase = true)
-        } ?: false
-        
-        // Check for generic placeholder patterns
-        val isPlaceholderDescription = couponInfo.description.let {
-            it.equals("Sample coupon offer", ignoreCase = true) ||
-            it.equals("Placeholder offer", ignoreCase = true) ||
-            it.contains("example", ignoreCase = true) && it.contains("offer", ignoreCase = true)
-        }
-        
-        // Detect if it's a mock response (any two indicators match)
-        val mockIndicators = listOf(isMockStore, isMockCode, isPlaceholderDescription).count { it }
-        
-        if (mockIndicators >= 2) {
-            Log.w(TAG, "Mock response detected: store='${couponInfo.storeName}', code='${couponInfo.redeemCode}', desc='${couponInfo.description}'")
-            return true
-        }
-        
-        return false
-    }
-    
     /**
      * Create optimized structured prompt for coupon extraction with strict schema and typed cashback
      */

--- a/app/src/main/kotlin/com/example/coupontracker/util/MockLlmResponseDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/MockLlmResponseDetector.kt
@@ -1,0 +1,74 @@
+package com.example.coupontracker.util
+
+import java.util.Locale
+
+/**
+ * Detects mock or placeholder responses returned by the stubbed LLM runtime.
+ *
+ * The current JNI bridge still returns hard-coded sample values whenever the
+ * real MiniCPM inference pipeline is unavailable. Those placeholder values are
+ * short strings such as "Mock Store"/"Mock coupon offer" with promo codes that
+ * start with "MOCK". When these samples slip through the validation pipeline
+ * the UI displays incorrect information (store name, description, etc.).
+ *
+ * To prevent this we look for a combination of signals that uniquely identify
+ * placeholder payloads without triggering on legitimate coupons.
+ */
+internal object MockLlmResponseDetector {
+
+    private val MOCK_STORE_PATTERNS = listOf(
+        Regex("^mock\\s+store$", RegexOption.IGNORE_CASE),
+        Regex("^example\\s+store$", RegexOption.IGNORE_CASE),
+        Regex("^sample\\s+store$", RegexOption.IGNORE_CASE),
+    )
+
+    private val MOCK_CODE_PATTERNS = listOf(
+        Regex("^MOCK[0-9A-Z_-]*$", RegexOption.IGNORE_CASE),
+        Regex("^EXAMPLE[0-9A-Z_-]*$", RegexOption.IGNORE_CASE)
+    )
+
+    private val MOCK_DESCRIPTION_PATTERNS = listOf(
+        Regex("mock\\s+coupon\\s+offer", RegexOption.IGNORE_CASE),
+        Regex("placeholder\\s+offer", RegexOption.IGNORE_CASE),
+        Regex("sample\\s+coupon", RegexOption.IGNORE_CASE),
+        Regex("example\\s+coupon", RegexOption.IGNORE_CASE)
+    )
+
+    /**
+     * Returns true when the coupon info clearly matches a mock response.
+     *
+     * We require at least two mock indicators to avoid false positives while
+     * still catching the hard coded combinations from the stub runtime.
+     */
+    fun isMockResponse(couponInfo: CouponInfo): Boolean {
+        val store = couponInfo.storeName.ifBlank { "" }
+        val description = couponInfo.description.ifBlank { "" }
+        val code = couponInfo.redeemCode?.trim().orEmpty()
+
+        val isMockStore = MOCK_STORE_PATTERNS.any { it.containsMatchIn(store) }
+
+        val isMockCode = code.isNotEmpty() && (
+            MOCK_CODE_PATTERNS.any { it.matches(code) }
+        )
+
+        val isMockDescription = MOCK_DESCRIPTION_PATTERNS.any {
+            it.containsMatchIn(description)
+        } || description.lowercase(Locale.ROOT).let { lowerDesc ->
+            lowerDesc.startsWith("mock ") || lowerDesc.contains("mock coupon")
+        }
+
+        val stubSignature = store.equals("mock store", ignoreCase = true) &&
+            code.equals("MOCK50", ignoreCase = true) &&
+            description.contains("50%", ignoreCase = true)
+
+        val indicators = listOf(
+            isMockStore,
+            isMockCode,
+            isMockDescription,
+            stubSignature
+        )
+
+        return indicators.count { it } >= 2
+    }
+}
+

--- a/app/src/test/java/com/example/coupontracker/util/MockLlmResponseDetectorTest.kt
+++ b/app/src/test/java/com/example/coupontracker/util/MockLlmResponseDetectorTest.kt
@@ -1,0 +1,35 @@
+package com.example.coupontracker.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MockLlmResponseDetectorTest {
+
+    @Test
+    fun `detects mlc stub placeholder payload`() {
+        val placeholderCoupon = CouponInfo(
+            storeName = "Mock Store",
+            description = "Mock coupon offer - 50% off",
+            cashbackAmount = 100.0,
+            redeemCode = "MOCK50",
+            minimumPurchase = 1000.0
+        )
+
+        assertTrue(MockLlmResponseDetector.isMockResponse(placeholderCoupon))
+    }
+
+    @Test
+    fun `does not flag legitimate coupon data`() {
+        val realCoupon = CouponInfo(
+            storeName = "Amazon",
+            description = "Flat 50% OFF on electronics above ₹999",
+            cashbackAmount = 50.0,
+            redeemCode = "AMZ50",
+            minimumPurchase = 999.0
+        )
+
+        assertFalse(MockLlmResponseDetector.isMockResponse(realCoupon))
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a reusable detector that recognises mock outputs from the stubbed LLM runtime
- update the local OCR service to log and reject placeholder data before it reaches the UI
- add unit coverage to ensure mock detection triggers for stub payloads but not real coupons

## Testing
- ./gradlew test --tests com.example.coupontracker.util.MockLlmResponseDetectorTest *(fails: Android SDK is not available in the CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68ede66660e88328853fd435ccb0b00d