### PR TITLE
Fix multi-line offer parsing for 'upto' connectors

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
@@ -307,7 +307,7 @@ class TextExtractor {
                     if (nextLine.startsWith("+")) {
                         // Preserve the "+" as a connector
                         builder.append(' ').append(nextLine.trim())
-                    } else if (Pattern.compile("(?i)(up\\s+to|flat|plus|&)").matcher(nextLine).find()) {
+                    } else if (Pattern.compile("(?i)(\\bup\\s*to\\b|flat|plus|&)").matcher(nextLine).find()) {
                         builder.append(' ').append(nextLine)
                     }
                 }

--- a/app/src/test/java/com/example/coupontracker/util/TextExtractorTest.kt
+++ b/app/src/test/java/com/example/coupontracker/util/TextExtractorTest.kt
@@ -21,4 +21,19 @@ class TextExtractorTest {
             result
         )
     }
+
+    @Test
+    fun `extractDescription preserves upto connector without whitespace`() {
+        val text = """
+            Buy 2 Get 2 FREE* +
+            Upto 5% Foxcoins
+        """.trimIndent()
+
+        val result = extractor.extractDescription(text)
+
+        assertEquals(
+            "Buy 2 Get 2 FREE* + Upto 5% Foxcoins",
+            result
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- allow the multi-line offer description logic to treat "upto" as a continuation connector
- cover the whitespace-free connector case with a TextExtractor unit test

## Testing
- ./gradlew test --tests com.example.coupontracker.util.TextExtractorTest *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ee9d7bac8c832887241499932d6cd8