### PR TITLE
refactor: remove offerText and tighten extraction contract

### DIFF
--- a/app/schemas/com.example.coupontracker.data.local.CouponDatabase/8.json
+++ b/app/schemas/com.example.coupontracker.data.local.CouponDatabase/8.json
@@ -1,0 +1,407 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "105e75d1b866fc823bd0a33c7b49d932",
+    "entities": [
+      {
+        "tableName": "coupons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `storeName` TEXT NOT NULL, `description` TEXT NOT NULL, `normalizedDescription` TEXT, `expiryDate` INTEGER, `cashbackAmount` REAL NOT NULL, `redeemCode` TEXT, `cashbackType` TEXT, `cashbackValueNum` REAL, `cashbackCurrency` TEXT, `imageUri` TEXT, `imagePhash` TEXT, `imageSignature` TEXT, `category` TEXT, `status` TEXT, `minimumPurchase` REAL, `maximumDiscount` REAL, `isPriority` INTEGER NOT NULL, `paymentMethod` TEXT, `usageLimit` INTEGER, `usageCount` INTEGER NOT NULL, `reminderDate` INTEGER, `platformType` TEXT, `rating` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedDescription",
+            "columnName": "normalizedDescription",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "expiryDate",
+            "columnName": "expiryDate",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cashbackAmount",
+            "columnName": "cashbackAmount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "redeemCode",
+            "columnName": "redeemCode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cashbackType",
+            "columnName": "cashbackType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cashbackValueNum",
+            "columnName": "cashbackValueNum",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cashbackCurrency",
+            "columnName": "cashbackCurrency",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUri",
+            "columnName": "imageUri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imagePhash",
+            "columnName": "imagePhash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageSignature",
+            "columnName": "imageSignature",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "minimumPurchase",
+            "columnName": "minimumPurchase",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maximumDiscount",
+            "columnName": "maximumDiscount",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isPriority",
+            "columnName": "isPriority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentMethod",
+            "columnName": "paymentMethod",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "usageLimit",
+            "columnName": "usageLimit",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "usageCount",
+            "columnName": "usageCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reminderDate",
+            "columnName": "reminderDate",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "platformType",
+            "columnName": "platformType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "learned_patterns_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `brand` TEXT, `fieldType` TEXT NOT NULL, `regex` TEXT NOT NULL, `weight` REAL NOT NULL, `source` TEXT NOT NULL, `sampleValue` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `successCount` INTEGER NOT NULL, `attemptCount` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brand",
+            "columnName": "brand",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fieldType",
+            "columnName": "fieldType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regex",
+            "columnName": "regex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleValue",
+            "columnName": "sampleValue",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "successCount",
+            "columnName": "successCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_learned_patterns_v1_fieldType",
+            "unique": false,
+            "columnNames": [
+              "fieldType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_learned_patterns_v1_fieldType` ON `${TABLE_NAME}` (`fieldType`)"
+          },
+          {
+            "name": "index_learned_patterns_v1_brand",
+            "unique": false,
+            "columnNames": [
+              "brand"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_learned_patterns_v1_brand` ON `${TABLE_NAME}` (`brand`)"
+          },
+          {
+            "name": "index_learned_patterns_v1_weight",
+            "unique": false,
+            "columnNames": [
+              "weight"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_learned_patterns_v1_weight` ON `${TABLE_NAME}` (`weight` DESC)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "extraction_feedback_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `couponId` INTEGER, `extractionStrategy` TEXT NOT NULL, `feedbackType` TEXT NOT NULL, `originalValues` TEXT NOT NULL, `correctedValues` TEXT, `signalsJson` TEXT NOT NULL, `runPathJson` TEXT NOT NULL, `deviceInfo` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `consentGiven` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "couponId",
+            "columnName": "couponId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "extractionStrategy",
+            "columnName": "extractionStrategy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedbackType",
+            "columnName": "feedbackType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalValues",
+            "columnName": "originalValues",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctedValues",
+            "columnName": "correctedValues",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "signalsJson",
+            "columnName": "signalsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runPathJson",
+            "columnName": "runPathJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceInfo",
+            "columnName": "deviceInfo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "consentGiven",
+            "columnName": "consentGiven",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_extraction_feedback_v1_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_extraction_feedback_v1_timestamp` ON `${TABLE_NAME}` (`timestamp` DESC)"
+          },
+          {
+            "name": "index_extraction_feedback_v1_extractionStrategy",
+            "unique": false,
+            "columnNames": [
+              "extractionStrategy"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_extraction_feedback_v1_extractionStrategy` ON `${TABLE_NAME}` (`extractionStrategy`)"
+          },
+          {
+            "name": "index_extraction_feedback_v1_feedbackType",
+            "unique": false,
+            "columnNames": [
+              "feedbackType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_extraction_feedback_v1_feedbackType` ON `${TABLE_NAME}` (`feedbackType`)"
+          },
+          {
+            "name": "index_extraction_feedback_v1_couponId",
+            "unique": false,
+            "columnNames": [
+              "couponId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_extraction_feedback_v1_couponId` ON `${TABLE_NAME}` (`couponId`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '105e75d1b866fc823bd0a33c7b49d932')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDatabase.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDatabase.kt
@@ -14,7 +14,7 @@ import com.example.coupontracker.data.util.CouponDedupUtils
         LearnedPattern::class,          // V2: Pattern storage
         ExtractionFeedback::class       // V2: Feedback & telemetry
     ],
-    version = 7,
+    version = 8,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -221,6 +221,63 @@ abstract class CouponDatabase : RoomDatabase() {
                 database.execSQL("CREATE INDEX IF NOT EXISTS `index_extraction_feedback_v1_couponId` ON `extraction_feedback_v1` (`couponId`)")
                 
                 android.util.Log.d("CouponDatabase", "✅ V2 Migration 6→7 complete: Pattern learning and feedback tables created")
+            }
+        }
+
+        val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("""
+                    CREATE TABLE IF NOT EXISTS `coupons_new` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `storeName` TEXT NOT NULL,
+                        `description` TEXT NOT NULL,
+                        `normalizedDescription` TEXT,
+                        `expiryDate` INTEGER,
+                        `cashbackAmount` REAL NOT NULL,
+                        `redeemCode` TEXT,
+                        `cashbackType` TEXT,
+                        `cashbackValueNum` REAL,
+                        `cashbackCurrency` TEXT,
+                        `imageUri` TEXT,
+                        `imagePhash` TEXT,
+                        `imageSignature` TEXT,
+                        `category` TEXT,
+                        `status` TEXT,
+                        `minimumPurchase` REAL,
+                        `maximumDiscount` REAL,
+                        `isPriority` INTEGER NOT NULL DEFAULT 0,
+                        `paymentMethod` TEXT,
+                        `usageLimit` INTEGER,
+                        `usageCount` INTEGER NOT NULL DEFAULT 0,
+                        `reminderDate` INTEGER,
+                        `platformType` TEXT,
+                        `rating` TEXT,
+                        `createdAt` INTEGER NOT NULL,
+                        `updatedAt` INTEGER NOT NULL
+                    )
+                """.trimIndent())
+
+                database.execSQL("""
+                    INSERT INTO `coupons_new` (
+                        `id`, `storeName`, `description`, `normalizedDescription`, `expiryDate`,
+                        `cashbackAmount`, `redeemCode`, `cashbackType`, `cashbackValueNum`, `cashbackCurrency`,
+                        `imageUri`, `imagePhash`, `imageSignature`, `category`, `status`,
+                        `minimumPurchase`, `maximumDiscount`, `isPriority`, `paymentMethod`, `usageLimit`,
+                        `usageCount`, `reminderDate`, `platformType`, `rating`, `createdAt`, `updatedAt`
+                    )
+                    SELECT
+                        `id`, `storeName`, `description`, `normalizedDescription`, `expiryDate`,
+                        `cashbackAmount`, `redeemCode`, `cashbackType`, `cashbackValueNum`, `cashbackCurrency`,
+                        `imageUri`, `imagePhash`, `imageSignature`, `category`, `status`,
+                        `minimumPurchase`, `maximumDiscount`, `isPriority`, `paymentMethod`, `usageLimit`,
+                        `usageCount`, `reminderDate`, `platformType`, `rating`, `createdAt`, `updatedAt`
+                    FROM `coupons`
+                """.trimIndent())
+
+                database.execSQL("DROP TABLE `coupons`")
+                database.execSQL("ALTER TABLE `coupons_new` RENAME TO `coupons`")
+
+                android.util.Log.d("CouponDatabase", "✅ Migration 7→8 complete: offerText column removed")
             }
         }
     }

--- a/app/src/main/kotlin/com/example/coupontracker/data/model/Coupon.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/model/Coupon.kt
@@ -19,7 +19,6 @@ data class Coupon(
     val cashbackType: String? = null, // "percent", "amount", "text"
     val cashbackValueNum: Double? = null, // Numeric value only
     val cashbackCurrency: String? = "INR", // Currency for amounts
-    val offerText: String? = null, // Deprecated: kept for migrations; UI should use description instead
     val imageUri: String?,
     val imagePhash: String? = null,
     val imageSignature: String? = null,
@@ -61,7 +60,7 @@ data class Coupon(
     }
 
     /**
-     * Gets the display text for cashback, preferring offerText if available.
+     * Gets the display text for cashback, relying exclusively on the canonical description when available.
      */
     fun getCashbackDisplayText(): String {
         return description.takeIf { it.isNotBlank() } ?: getCashbackInfo().getDisplayText()

--- a/app/src/main/kotlin/com/example/coupontracker/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/di/DatabaseModule.kt
@@ -31,7 +31,8 @@ object DatabaseModule {
                 CouponDatabase.MIGRATION_3_4,
                 CouponDatabase.MIGRATION_4_5,
                 CouponDatabase.MIGRATION_5_6,
-                CouponDatabase.MIGRATION_6_7  // V2: Pattern learning and feedback tables
+                CouponDatabase.MIGRATION_6_7,  // V2: Pattern learning and feedback tables
+                CouponDatabase.MIGRATION_7_8   // Drop deprecated offerText column
             )
             .fallbackToDestructiveMigration()
             .build()

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/ProgressiveExtractionService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/ProgressiveExtractionService.kt
@@ -397,7 +397,6 @@ class ProgressiveExtractionService @Inject constructor(
             cashbackType = cashbackInfo.type.name.lowercase(),
             cashbackValueNum = cashbackInfo.valueNum,
             cashbackCurrency = cashbackInfo.currency,
-            offerText = null,
             category = null,
             rating = null,
             status = "ACTIVE",

--- a/app/src/main/kotlin/com/example/coupontracker/schema/CouponSchema.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/schema/CouponSchema.kt
@@ -2,14 +2,14 @@ package com.example.coupontracker.schema
 
 /**
  * Schema definition for coupon extraction.
- * Defines the 7 core fields extracted from coupon images.
+ * Defines the canonical minimal fields extracted from coupon images.
  */
 object CouponSchema {
     
     /**
      * Schema version - increment when making breaking changes
      */
-    const val VERSION = "1.0.0"
+    const val VERSION = "2.0.0"
     
     /**
      * The complete coupon extraction schema
@@ -18,26 +18,17 @@ object CouponSchema {
         name = "Coupon",
         version = VERSION,
         fields = listOf(
-            // Field 1: Store Name
             SchemaField(
                 name = "storeName",
                 type = FieldType.StringType,
                 required = true,
                 metadata = FieldMetadata(
                     description = "Brand or store name that issued the coupon",
-                    examples = listOf(
-                        "Amazon",
-                        "Flipkart",
-                        "AJIO",
-                        "Myntra",
-                        "Swiggy",
-                        "Zomato",
-                        "Tata CLiQ"
-                    ),
+                    examples = listOf("Amazon", "Flipkart", "AJIO", "Myntra"),
                     hints = listOf(
                         "Extract brand name only, not full company name",
-                        "Use title case (e.g., 'Amazon' not 'AMAZON')",
-                        "If multiple brands mentioned, use the issuing brand"
+                        "Prefer the issuing brand over partner or watermark text",
+                        "Use title case (e.g., 'Amazon' not 'AMAZON')"
                     ),
                     extractionHints = "Usually appears at the top or as a logo. May be in large text or header.",
                     validationRules = listOf(
@@ -47,202 +38,78 @@ object CouponSchema {
                     )
                 )
             ),
-            
-            // Field 2: Description
             SchemaField(
                 name = "description",
                 type = FieldType.StringType,
-                required = false,  // FIXED: Allow null when LLM can't extract description
+                required = false,
                 metadata = FieldMetadata(
-                    description = "Brief summary of the coupon offer",
+                    description = "Verbatim offer text exactly as printed on the coupon",
                     examples = listOf(
+                        "Flat ₹200 cashback on first order",
                         "Get 50% off on electronics",
-                        "Free delivery on orders above ₹499",
-                        "Flat ₹200 off on fashion items",
                         "Buy 1 Get 1 free on select items"
                     ),
                     hints = listOf(
-                        "Keep it concise (under 100 characters)",
-                        "Focus on the main benefit",
-                        "Exclude terms & conditions",
-                        "Clean up OCR noise (timestamps, single letters)"
+                        "Use the offer sentence as-is without adding math or commentary",
+                        "Preserve currency symbols, plus signs, and formatting",
+                        "Exclude generic UI chrome or timestamps",
+                        "If multiple offer lines exist, choose the primary benefit"
                     ),
-                    extractionHints = "Main offer text, usually prominent. Filter out timestamps, navigation elements.",
+                    extractionHints = "Main offer text, usually prominent. Filter out status bar noise.",
                     validationRules = listOf(
-                        "Must not be empty or generic placeholder",
-                        "Must not contain timestamps (e.g., '10:23')",
-                        "Must not be single letters or noise",
-                        "Should be under 100 characters"
+                        "Must not invent combined totals (e.g., do not add ₹100 + ₹70)",
+                        "Must not rewrite or paraphrase the coupon text",
+                        "May be null when no readable description exists"
                     )
                 )
             ),
-            
-            // Field 3: Cashback (structured object)
-            SchemaField(
-                name = "cashback",
-                type = FieldType.ObjectType(
-                    properties = mapOf(
-                        "type" to SchemaField(
-                            name = "type",
-                            type = FieldType.EnumType(listOf("percent", "amount", "text")),
-                            required = true,
-                            metadata = FieldMetadata(
-                                description = "Type of cashback/discount",
-                                examples = listOf("percent", "amount", "text"),
-                                hints = listOf(
-                                    "Use 'percent' for percentage discounts (e.g., 50% off)",
-                                    "Use 'amount' for fixed rupee discounts (e.g., ₹200 off)",
-                                    "Use 'text' only as fallback for complex offers"
-                                )
-                            )
-                        ),
-                        "valueNum" to SchemaField(
-                            name = "valueNum",
-                            type = FieldType.NumberType,
-                            required = true,
-                            metadata = FieldMetadata(
-                                description = "Numeric value of the discount",
-                                examples = listOf("50", "200", "11", "75"),
-                                hints = listOf(
-                                    "For 'percent': just the number (e.g., 50 for '50% off')",
-                                    "For 'amount': just the number (e.g., 200 for '₹200 off')",
-                                    "Do not include currency symbols or percent signs"
-                                )
-                            )
-                        ),
-                        "currency" to SchemaField(
-                            name = "currency",
-                            type = FieldType.StringType,
-                            required = false,
-                            metadata = FieldMetadata(
-                                description = "Currency code (only for amount type)",
-                                examples = listOf("INR", "USD"),
-                                hints = listOf(
-                                    "Use 'INR' for Indian rupees (₹)",
-                                    "Use null for percent type",
-                                    "Default to 'INR' if currency is unclear"
-                                )
-                            )
-                        )
-                    )
-                ),
-                required = false,
-                metadata = FieldMetadata(
-                    description = "Structured cashback/discount information",
-                    examples = listOf(
-                        """{"type":"percent","valueNum":50,"currency":null}""",
-                        """{"type":"amount","valueNum":200,"currency":"INR"}""",
-                        """{"type":"percent","valueNum":11,"currency":null}"""
-                    ),
-                    hints = listOf(
-                        "Parse discount amount and type separately",
-                        "Distinguish between percentage and fixed amount",
-                        "Handle variations: 'Flat 75% Off', '₹500 cashback', '50% discount'"
-                    ),
-                    extractionHints = "Look for '%', '₹', 'Rs', 'off', 'discount', 'cashback' keywords.",
-                    validationRules = listOf(
-                        "If type is 'percent', valueNum should be 0-100",
-                        "If type is 'amount', valueNum should be > 0",
-                        "Currency should be null for percent type",
-                        "Currency should be 'INR' for amount type (default)"
-                    )
-                )
-            ),
-            
-            // Field 4: Redeem Code
             SchemaField(
                 name = "redeemCode",
                 type = FieldType.StringType,
                 required = false,
                 metadata = FieldMetadata(
-                    description = "Coupon code to be entered at checkout",
-                    examples = listOf(
-                        "SAVE50",
-                        "TBNEIZNOL5FSUZY",
-                        "NEWUSER100",
-                        "FLASH75"
-                    ),
+                    description = "Coupon or promo code to be entered at checkout",
+                    examples = listOf("SAVE50", "FLASH75", "NEWUSER100"),
                     hints = listOf(
-                        "Extract ONLY the code itself",
-                        "Strip ALL extra text and spaces",
-                        "Example: 'Code: SAVE50' → extract 'SAVE50'",
-                        "Do NOT include labels like 'Code:', 'Promo:', 'Use code'",
-                        "Do NOT include expiry information"
+                        "Extract only the code characters (no labels like 'Code:' or 'Use')",
+                        "Treat 'couponCode' as an alias for this field",
+                        "Strip whitespace and ensure uppercase alphanumerics with optional - or _"
                     ),
-                    extractionHints = "Often in a box, dashed border, or labeled 'Code:', 'Promo Code:', 'Coupon Code:'.",
+                    extractionHints = "Often appears in boxes, near 'Use code', or beside redemption instructions.",
                     validationRules = listOf(
                         "Must be alphanumeric (may include hyphens/underscores)",
-                        "Must not contain spaces",
-                        "Must not include prefix text (Code:, Use:, etc.)",
-                        "Typically 4-20 characters"
+                        "Must not include spaces or descriptive words",
+                        "Return null when no explicit code is present"
                     )
                 )
             ),
-            
-            // Field 5: Expiry Date
             SchemaField(
                 name = "expiryDate",
-                type = FieldType.StringType, // Keep as string to preserve original format
+                type = FieldType.StringType,
                 required = false,
                 metadata = FieldMetadata(
                     description = "Expiration date of the coupon",
-                    examples = listOf(
-                        "31 May, 2025",
-                        "2025-12-31",
-                        "Dec 15, 2025",
-                        "15/12/2025"
-                    ),
+                    examples = listOf("31 May, 2025", "2025-12-31", "15/12/2025"),
                     hints = listOf(
-                        "Extract date EXACTLY as shown",
-                        "Do NOT reformat or change the date",
-                        "Do NOT hallucinate dates",
-                        "Example: 'Expires on 31 May, 2025, 11:59 PM' → extract '31 May, 2025'",
-                        "Example: 'Valid till 2025-12-31' → extract '2025-12-31'"
+                        "Copy the displayed date exactly when present",
+                        "If only a relative phrase like 'Expires in 5 days' exists, emit ISO date computed from screenshot timestamp",
+                        "Do not hallucinate dates or infer months without evidence"
                     ),
-                    extractionHints = "Look for keywords: 'expires', 'valid till', 'valid until', 'expiry'.",
+                    extractionHints = "Look for keywords: 'expires', 'valid till', 'expiring in'.",
                     validationRules = listOf(
-                        "Must preserve original format from coupon",
-                        "Must not include time component (11:59 PM, etc.)",
-                        "Must not be hallucinated or fabricated"
-                    )
-                )
-            ),
-            
-            // Field 6: Minimum Order Amount
-            SchemaField(
-                name = "minOrderAmount",
-                type = FieldType.StringType, // String to preserve formatting like "₹999"
-                required = false,
-                metadata = FieldMetadata(
-                    description = "Minimum purchase amount required to use the coupon",
-                    examples = listOf(
-                        "₹999",
-                        "₹500",
-                        "₹1,499",
-                        "Rs 299"
-                    ),
-                    hints = listOf(
-                        "Include currency symbol if present",
-                        "Preserve original formatting",
-                        "Look for keywords: 'minimum', 'min', 'above', 'orders over'"
-                    ),
-                    extractionHints = "Often in conditions section: 'Valid on orders above', 'Minimum purchase'.",
-                    validationRules = listOf(
-                        "Should include currency indicator",
-                        "Numeric value should be > 0"
+                        "Preserve original formatting when absolute date is present",
+                        "Emit yyyy-MM-dd when converting relative day counts",
+                        "Return null if no reliable expiry information is available"
                     )
                 )
             )
         ),
-        
         globalRules = listOf(
-            "All keys are required in JSON output, use null if data is missing",
-            "Output ONLY valid JSON, no explanatory text before or after",
-            "Start with '{' and end with '}'",
-            "Do not hallucinate data not present in the OCR text",
-            "If a field cannot be extracted, use null",
-            "Preserve original formatting where specified (dates, amounts)",
-            "Filter out OCR noise (timestamps, single letters, navigation elements)"
+            "Output ONLY the keys: storeName, redeemCode, expiryDate, description",
+            "Use null for any field that cannot be confidently extracted",
+            "Preserve the offer description verbatim without arithmetic or rephrasing",
+            "If the coupon only states it expires in N days and a capture timestamp is provided, convert it to an ISO date using that timestamp",
+            "Do not hallucinate additional structured fields or metadata"
         )
     )
     

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
@@ -464,8 +464,7 @@ class BatchScannerViewModel @Inject constructor(
             updatedAt = java.util.Date(),
             cashbackType = com.example.coupontracker.data.model.CashbackType.TEXT.name.lowercase(),
             cashbackValueNum = 0.0,
-            cashbackCurrency = null,
-            offerText = null
+            cashbackCurrency = null
         )
     }
     
@@ -651,14 +650,11 @@ class BatchScannerViewModel @Inject constructor(
                 Tuple4(0.0, 0.0, com.example.coupontracker.data.model.CashbackType.TEXT.name.lowercase(), null)
             }
         
-        // Description: combine both sources
-        val description = when {
-            llmInfo.description.isNotBlank() && ocrCoupon.description.isNotBlank() -> 
-                "${llmInfo.description} (Hybrid: LLM + OCR)"
-            llmInfo.description.isNotBlank() -> llmInfo.description
-            ocrCoupon.description.isNotBlank() -> ocrCoupon.description
-            else -> "Extracted via Hybrid method"
-        }
+        // Description: prefer LLM verbatim text, fall back to OCR text
+        val description = listOf(llmInfo.description, ocrCoupon.description)
+            .map { it.trim() }
+            .firstOrNull { it.isNotBlank() }
+            ?: "Coupon offer"
         
         return Coupon(
             id = 0,
@@ -674,8 +670,7 @@ class BatchScannerViewModel @Inject constructor(
             updatedAt = java.util.Date(),
             cashbackType = cashbackType,
             cashbackValueNum = cashbackValueNum,
-            cashbackCurrency = cashbackCurrency,
-            offerText = null
+            cashbackCurrency = cashbackCurrency
         )
     }
     
@@ -928,8 +923,7 @@ class BatchScannerViewModel @Inject constructor(
             // V2: Typed cashback fields
             cashbackType = cashbackType,
             cashbackValueNum = cashbackValueNum,
-            cashbackCurrency = cashbackCurrency,
-            offerText = null
+            cashbackCurrency = cashbackCurrency
         )
     }
     
@@ -963,8 +957,7 @@ class BatchScannerViewModel @Inject constructor(
             // V2: Typed cashback fields (CRITICAL - was missing!)
             cashbackType = cashbackType,
             cashbackValueNum = cashbackValueNum,
-            cashbackCurrency = cashbackCurrency,
-            offerText = null
+            cashbackCurrency = cashbackCurrency
         )
     }
 

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -466,8 +466,7 @@ class ScannerViewModel @Inject constructor(
             updatedAt = Date(),
             cashbackType = cashbackInfo.type.name.lowercase(),
             cashbackValueNum = cashbackInfo.valueNum,
-            cashbackCurrency = cashbackInfo.currency,
-            offerText = null
+            cashbackCurrency = cashbackInfo.currency
         )
     }
     
@@ -783,14 +782,11 @@ class ScannerViewModel @Inject constructor(
             Pair(0.0, CashbackInfo(com.example.coupontracker.data.model.CashbackType.TEXT, 0.0))
         }
         
-        // Description: combine both sources
-        val description = when {
-            llmInfo.description.isNotBlank() && ocrCoupon.description.isNotBlank() -> 
-                "${llmInfo.description} (Hybrid: LLM + OCR)"
-            llmInfo.description.isNotBlank() -> llmInfo.description
-            ocrCoupon.description.isNotBlank() -> ocrCoupon.description
-            else -> "Extracted via Hybrid method"
-        }
+        // Description: prefer raw LLM text, otherwise fall back to OCR text
+        val description = listOf(llmInfo.description, ocrCoupon.description)
+            .map { it.trim() }
+            .firstOrNull { it.isNotBlank() }
+            ?: "Coupon offer"
         
         return Coupon(
             id = 0,
@@ -806,8 +802,7 @@ class ScannerViewModel @Inject constructor(
             updatedAt = Date(),
             cashbackType = cashbackInfo.type.name.lowercase(),
             cashbackValueNum = cashbackInfo.valueNum,
-            cashbackCurrency = cashbackInfo.currency,
-            offerText = null
+            cashbackCurrency = cashbackInfo.currency
         )
     }
 
@@ -1429,7 +1424,6 @@ class ScannerViewModel @Inject constructor(
             cashbackType = cashbackInfo.type.name.lowercase(),
             cashbackValueNum = cashbackInfo.valueNum,
             cashbackCurrency = cashbackInfo.currency,
-            offerText = null,
             category = determineCategory(extractedInfo),
             rating = null,
             status = when (couponInstance.status) {
@@ -1773,7 +1767,6 @@ class ScannerViewModel @Inject constructor(
             cashbackType = cashbackInfo.type.name.lowercase(),
             cashbackValueNum = cashbackInfo.valueNum,
             cashbackCurrency = cashbackInfo.currency,
-            offerText = null,
             category = determineCategory(extractedInfo),
             rating = null,
             status = "ACTIVE",

--- a/app/src/main/kotlin/com/example/coupontracker/universal/UniversalExtractionService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/universal/UniversalExtractionService.kt
@@ -302,7 +302,6 @@ class UniversalExtractionService @Inject constructor(
             cashbackType = cashbackInfo.type.name.lowercase(),
             cashbackValueNum = cashbackInfo.valueNum,
             cashbackCurrency = cashbackInfo.currency,
-            offerText = null,
             
             category = null,
             rating = null,

--- a/app/src/main/kotlin/com/example/coupontracker/util/CouponJsonValidator.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/CouponJsonValidator.kt
@@ -21,14 +21,13 @@ object CouponJsonValidator {
     // Set to true to enable schema-driven validation, false to use manual validation
     private const val USE_SCHEMA_VALIDATION = true
     
-    // Allowed keys in the JSON schema (updated for Qwen2.5 typed cashback format)
+    // Allowed keys in the JSON schema (canonical minimal contract)
     private val ALLOWED_KEYS = setOf(
         "storeName",
-        "description", 
-        "cashback",  // Changed from cashbackAmount to support typed object
+        "description",
         "redeemCode",
-        "expiryDate",
-        "minOrderAmount"
+        "couponCode",
+        "expiryDate"
     )
     
     /**
@@ -114,35 +113,12 @@ object CouponJsonValidator {
         }
         
         // Validate redeemCode format if present
-        val redeemCode = json.optString("redeemCode")
+        val redeemCode = when {
+            json.has("redeemCode") -> json.optString("redeemCode")
+            else -> json.optString("couponCode")
+        }
         if (redeemCode.isNotBlank() && !isValidCouponCode(redeemCode)) {
             issues.add("Invalid coupon code format: $redeemCode")
-        }
-        
-        // Validate typed cashback object if present (replaces legacy cashbackAmount)
-        if (json.has("cashback") && !json.isNull("cashback")) {
-            val cashback = json.optJSONObject("cashback")
-            if (cashback != null) {
-                // Validate cashback.type (required)
-                val type = cashback.optString("type")
-                if (type.isBlank() || type !in setOf("percent", "amount", "text")) {
-                    issues.add("Invalid cashback.type: must be 'percent', 'amount', or 'text'")
-                }
-                
-                // Validate cashback.valueNum (required numeric)
-                if (!cashback.has("valueNum") || cashback.isNull("valueNum")) {
-                    issues.add("Missing cashback.valueNum (required numeric field)")
-                } else {
-                    val valueNum = cashback.optDouble("valueNum", -1.0)
-                    if (valueNum < 0) {
-                        issues.add("Invalid cashback.valueNum: must be non-negative number")
-                    }
-                }
-                
-                // currency is optional, can be null or string
-            } else {
-                issues.add("cashback must be object or null, not other type")
-            }
         }
         
         // Validate expiryDate format if present
@@ -150,7 +126,7 @@ object CouponJsonValidator {
         if (expiryDate.isNotBlank() && !isValidDateFormat(expiryDate)) {
             issues.add("Invalid expiry date format: $expiryDate")
         }
-        
+
         return if (issues.isEmpty()) {
             JsonValidationResult.Valid
         } else {
@@ -176,20 +152,6 @@ object CouponJsonValidator {
         
         return basePattern.matches(normalizedCode) && 
                rejectPatterns.none { it.matches(normalizedCode) }
-    }
-    
-    /**
-     * Basic cashback amount validation
-     */
-    private fun isValidCashbackAmount(amount: String): Boolean {
-        // Should contain currency symbol or percentage
-        val validPatterns = listOf(
-            Regex(".*[₹$£€].*\\d+.*"), // Currency symbols
-            Regex(".*\\d+.*%.*"), // Percentage
-            Regex(".*\\d+.*(?:off|back|cashback).*", RegexOption.IGNORE_CASE) // Text indicators
-        )
-        
-        return validPatterns.any { it.matches(amount) }
     }
     
     /**

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONException
 import org.json.JSONObject
+import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 
@@ -671,7 +672,7 @@ class LocalLlmOcrService(
                     Log.e(TAG, "LLM response did not start with '{': ${trimmedResponse.take(200)}")
                     throw IllegalStateException("LLM response not JSON (missing opening brace)")
                 }
-                val couponInfo = parseLlmResponseToCouponInfo(llmResponse, rawOcrText)
+                val couponInfo = parseLlmResponseToCouponInfo(llmResponse, rawOcrText, captureTimestamp)
                 
                 // CRITICAL: Detect mock responses and reject them
                 if (MockLlmResponseDetector.isMockResponse(couponInfo)) {
@@ -789,7 +790,7 @@ class LocalLlmOcrService(
             // Step 6: Parse and validate response
             val couponInfo = if (llmResponse != null) {
                 // We already have OCR text from Step 3, no need to extract again
-                val parsedInfo = parseLlmResponseToCouponInfo(llmResponse, ocrText)
+                val parsedInfo = parseLlmResponseToCouponInfo(llmResponse, ocrText, captureTimestamp)
                 
                 // CRITICAL: Detect mock responses and fall back to OCR
                 if (MockLlmResponseDetector.isMockResponse(parsedInfo)) {
@@ -866,10 +867,8 @@ class LocalLlmOcrService(
         var count = 0
         if (couponInfo.storeName != "Unknown Store") count++
         if (!couponInfo.redeemCode.isNullOrBlank()) count++
-        if (couponInfo.cashbackAmount != null && couponInfo.cashbackAmount > 0) count++
         if (couponInfo.expiryDate != null) count++
         if (couponInfo.description != "Coupon offer") count++
-        if (couponInfo.minimumPurchase != null && couponInfo.minimumPurchase > 0) count++
         return count
     }
     
@@ -911,124 +910,54 @@ class LocalLlmOcrService(
      * NOTE: This is the manual/legacy prompt. When USE_SCHEMA_PROMPTS=true,
      * the prompt is generated from CouponSchema instead.
      */
-    private fun buildQwenPromptManual(sanitizedOcr: String): String = """<|im_start|>system
+    private fun buildQwenPromptManual(sanitizedOcr: String): String = """
+<|im_start|>system
 You are a JSON extractor. Extract coupon data and output ONLY valid JSON.
 
-🚨 MANDATORY FIELDS (MUST ALWAYS INCLUDE):
-1. "redeemCode" - THE coupon code (search for "Code:" in OCR)
-2. "expiryDate" - THE expiry date (search for "Expires on" in OCR)
-3. "storeName" - Store/brand name
-4. "description" - Offer description
-
-⚠️ CRITICAL: All 7 JSON keys MUST be present! Never skip redeemCode or expiryDate!
+🚨 REQUIRED JSON KEYS (always include these four keys):
+1. "storeName" - Store/brand name exactly from the coupon
+2. "redeemCode" - Coupon/promo code. Use null if no code is present
+3. "expiryDate" - Expiry date text exactly as written (no reformatting)
+4. "description" - Offer description verbatim, no extra math or commentary
 
 CRITICAL RULES:
-1. ONLY extract data that EXISTS in the OCR text
-2. DO NOT invent, generate, or hallucinate ANY data
-3. COPY dates EXACTLY as written - do NOT change format or create timestamps
-4. If data is missing, use null (NOT -1, NOT 0, NOT empty object)
-5. NEVER use negative numbers or placeholder values like -1
-6. Output ONLY the JSON object, NO explanations, NO extra text after JSON
+1. Output ONLY these four keys. No additional fields are allowed.
+2. If data is missing, output null (never invent values or placeholders).
+3. Preserve the coupon wording: do NOT add numbers together or rewrite text.
+4. Do not change date formats. Copy the characters exactly as seen.
+5. Output ONLY the JSON object. No explanations before or after the JSON.
 
-Schema (all 6 keys MUST be present):
-{"storeName":str|null,"description":str|null,"cashback":obj|null,"redeemCode":str|null,"expiryDate":str|null,"minOrderAmount":str|null}
+Schema:
+{"storeName":str|null,"redeemCode":str|null,"expiryDate":str|null,"description":str|null}
 
 EXTRACTION GUIDE:
 
 storeName:
-- Brand name ONLY (e.g., "PUMA", "Amazon", "Flipkart")
-- Must appear in OCR text
+- Brand name only (e.g., "PUMA", "Amazon", "Flipkart")
+- Ignore partner logos or watermarks.
 
 redeemCode:
-🚨 CRITICAL - MUST ALWAYS INCLUDE THIS KEY!
-- Search for: "Code:", "Coupon:", or standalone alphanumeric codes
-- Strip prefixes: "Code: KAPW1M3LAfAhSe" → "KAPW1M3LAfAhSe"
-- Examples: "SAVE50", "BTXS5T13LI9V5", "KAPW1M3LAfAhSe"
-- If NO code in OCR, use null (BUT key must be present!)
-- DO NOT invent codes
-- NEVER output "NULL" as a string - use null instead
+- Search for "Code:", "Coupon:", or standalone alphanumeric codes.
+- Strip prefixes and whitespace. Example: "Code: SAVE50" → "SAVE50".
+- Use null when no code is visible.
 
 expiryDate:
-🚨 CRITICAL - MOST IMPORTANT FOR APP REMINDERS! MUST ALWAYS INCLUDE THIS KEY!
-⚠️ Extract EXACTLY what you see in OCR. DO NOT change the date!
-
-STEP 1: Find expiry text in OCR
-- Look for: "Expires on", "Valid till", "Expires:", "Expiry:", "EXPIRES IN"
-
-STEP 2: Extract ONLY day, month, year (remove time)
-- Input: "Expires on 31 May, 2025, 11:59 PM"
-- Output: "31 May 2025"
-  
-- Input: "Expires on 05 May, 2025, 11:59 PM"
-- Output: "05 May 2025"
-
-- Input: "Valid till 15 Dec 2025"
-- Output: "15 Dec 2025"
-
-STEP 3: Remove ALL extra text
-- ❌ WRONG: "May,25|31" (mangled format!)
-- ❌ WRONG: "May/16th @ 11.59 PM IST / End of the OFFER."
-- ❌ WRONG: "May-31-2025T23:59Z"
-- ❌ WRONG: Put it in the WRONG field
-- ✅ CORRECT: "31 May 2025" in "expiryDate" field
-- ✅ CORRECT: "05 May 2025" in "expiryDate" field
-
-🚨 CRITICAL RULES:
-1. MUST include "expiryDate" key (even if null)!
-2. DO NOT change the date numbers (31 May → May,25|31 is WRONG!)
-3. DO NOT add "@", "PM", "IST", "|", weird symbols
-4. DO NOT put expiry in other fields - it goes in "expiryDate"!
-5. ONLY output: day month year (e.g., "31 May 2025")
-
-If NO date in OCR → use null (BUT key must be present!)
-
-cashback:
-⚠️ IMPORTANT: If you cannot CLEARLY identify the discount amount, set cashback to null
-- Only extract if discount is EXPLICIT: "50% off", "₹200 off", "Flat 11% Off"
-- If amount is unclear, misprinted, or ambiguous → use null
-- If multiple amounts are confusing → use null
-- The description field is more important than getting amount wrong
-
-- Convert clear discounts to object:
-  * Percentage: {"type":"percent","valueNum":50,"currency":null}
-  * Amount: {"type":"amount","valueNum":200,"currency":"INR"}
-- CRITICAL: valueNum must be a POSITIVE number (1 or greater)
-- NEVER use: -1, 0, negative numbers, or placeholder values
-- If NO discount exists in OCR → cashback must be null (NOT an object)
-
-⚠️ SKIP CASHBACK IF:
-- OCR text is garbled/unclear around numbers
-- Multiple discount amounts are present (confusing)
-- Numbers don't have clear "off"/"discount" keywords nearby
-- Small numbers (< 5) near "Details", "Redeem Now" = APP RATINGS
-- Numbers with stars (⭐) or near store names = RATINGS
+- Copy the date text exactly (e.g., "31 May 2025", "2025-12-31").
+- If the coupon only says "Expires in 5 days", return null (the app will compute it).
+- Never invent months or days.
 
 description:
-⭐ MOST IMPORTANT FIELD - Focus on getting this right!
-- ❗ NEVER leave this empty if any offer text exists in OCR.
-- ❗ Include the main discount sentence even if extra details exist.
-- DO NOT return an empty string. If no offer text exists, use null (NOT "").
-- Extract the FULL offer text from the coupon
-- Combine multi-line text to form complete sentences
-- Examples:
-  * "Flat 50% off\non orders" → "Flat 50% off on orders"
-  * "you won flat ₹100 off + ₹50 cashback\non your next order" → "Flat ₹100 Off + ₹50 Cashback on your next order"
-  * "Flat 75% Off on Radiance Kit from beminimalist.co" → "Flat 75% Off on Radiance Kit from beminimalist.co"
-- Include ALL key details: discount, product, conditions
-- Clean up OCR noise but keep the offer intact
-- DO NOT leave empty - if there's ANY offer text, extract it
-- Only use null if absolutely no offer information exists
+- Use the main offer sentence exactly as printed.
+- Keep symbols like "₹", "+", "%".
+- Do NOT append helper text like "(Hybrid)" or perform arithmetic.
 
-minOrderAmount:
-- Minimum order value (e.g., "₹999", "₹500")
-- If missing, use null
-
-REMEMBER: ONLY extract data that you can SEE in the OCR text. DO NOT make up data.<|im_end|>
+Provide the JSON object now.
+<|im_end|>
 <|im_start|>user
-Extract coupon from OCR:
-$sanitizedOcr<|im_end|>
-<|im_start|>assistant
-{""".trimIndent()
+OCR_TEXT:
+$sanitizedOcr
+<|im_end|>
+""".trimIndent()
 
     private suspend fun captureRawOcrText(bitmap: Bitmap): String? {
         customOcrTextProvider?.let { provider ->
@@ -1074,16 +1003,39 @@ $sanitizedOcr<|im_end|>
         return if (start >= 0 && end > start) text.substring(start, end + 1) else null
     }
 
-    private fun removeDeprecatedKeys(jsonString: String): String {
+    private fun enforceCanonicalFields(jsonString: String): String {
         return try {
             val jsonObject = JSONObject(jsonString)
-            jsonObject.remove("offerText")
+            val allowedKeys = setOf("storeName", "description", "redeemCode", "couponCode", "expiryDate")
+            val keysToRemove = jsonObject.keys().asSequence()
+                .filter { it !in allowedKeys }
+                .toList()
+            keysToRemove.forEach { jsonObject.remove(it) }
+
+            if (jsonObject.has("couponCode") && !jsonObject.has("redeemCode")) {
+                jsonObject.put("redeemCode", jsonObject.get("couponCode"))
+            }
+            jsonObject.remove("couponCode")
+
             jsonObject.toString()
         } catch (parseError: JSONException) {
-            var sanitized = jsonString.replace(Regex("\"offerText\"\\s*:\\s*\".*?\"\\s*,?"), "")
-            sanitized = sanitized.replace(Regex(",\\s*,"), ",")
+            var sanitized = jsonString
+            val removalPatterns = listOf(
+                "\"offerText\"\\s*:\\s*\".*?\"\\s*,?",
+                "\"cashback\"\\s*:\\s*\{.*?}\\s*,?",
+                "\"cashbackAmount\"\\s*:\\s*[^,{}]+,?",
+                "\"minOrderAmount\"\\s*:\\s*[^,{}]+,?",
+                "\"minimumPurchase\"\\s*:\\s*[^,{}]+,?",
+                "\"maximumDiscount\"\\s*:\\s*[^,{}]+,?"
+            )
+            removalPatterns.forEach { pattern ->
+                sanitized = sanitized.replace(Regex(pattern, RegexOption.DOT_MATCHES_ALL), "")
+            }
+
+            sanitized = sanitized.replace(Regex(",\\s*,+"), ",")
             sanitized = sanitized.replace(Regex("\\{\\s*,"), "{")
             sanitized = sanitized.replace(Regex(",\\s*\\}"), "}")
+            sanitized = sanitized.replace(Regex("\"couponCode\""), "\"redeemCode\"")
             sanitized
         }
     }
@@ -1091,7 +1043,11 @@ $sanitizedOcr<|im_end|>
     /**
      * Parse LLM JSON response to CouponInfo object with strict validation
      */
-    private fun parseLlmResponseToCouponInfo(response: String, rawOcrText: String?): CouponInfo {
+    private fun parseLlmResponseToCouponInfo(
+        response: String,
+        rawOcrText: String?,
+        captureTimestamp: Date?
+    ): CouponInfo {
         return try {
             // Clean response (remove any markdown formatting)
             var cleanResponse = response.trim()
@@ -1131,7 +1087,7 @@ $sanitizedOcr<|im_end|>
             
             val jsonCandidate = extractJsonSlice(cleanResponse)
                 ?: throw IllegalStateException("No JSON object found in LLM output")
-            val sanitizedJsonCandidate = removeDeprecatedKeys(jsonCandidate)
+            val sanitizedJsonCandidate = enforceCanonicalFields(jsonCandidate)
             
             // JSON validation: use schema-driven or legacy validator
             val json = if (USE_SCHEMA_VALIDATION) {
@@ -1200,25 +1156,6 @@ $sanitizedOcr<|im_end|>
                 if (it.isBlank() || it == "Unknown") null else it
             }
             
-        val cashbackData = json.optJSONObject("cashback")
-        val cashbackTriple = cashbackData?.let {
-            val type = it.optString("type", "text")
-            val valueNum = it.optDouble("valueNum", 0.0)
-            val currency = it.optString("currency", "").takeIf { c -> c.isNotBlank() }
-            Triple(type, valueNum, currency)
-        }
-        val validatedCashback = cashbackTriple?.takeIf { (type, valueNum, _) ->
-            when (type) {
-                "percent" -> valueNum > 0 && hasSupportingDigits("${valueNum}", rawOcrText, cleanedDescription)
-                "amount" -> valueNum > 0 && hasSupportingDigits("${valueNum}", rawOcrText, cleanedDescription)
-                else -> true
-            }
-        }
-            
-            val minOrderAmount = json.optString("minOrderAmount").let {
-                if (it.isBlank() || it == "Unknown") null else it
-            }
-            
             // Check for duplicate values between fields (common LLM issue)
             val finalStoreName = if (GenericFieldHeuristics.areDuplicateFields(storeName, code)) {
                 Log.w(TAG, "Detected duplicate store name and redeem code: '$storeName' - downgrading store name")
@@ -1271,89 +1208,47 @@ $sanitizedOcr<|im_end|>
                     null
                 }
             }
-            
-            val (cashbackType, cashbackValue, _) = validatedCashback ?: Triple("text", 0.0, null)
-            val normalizedCashback = when (cashbackType) {
-                "percent" -> cashbackValue
-                "amount" -> cashbackValue
-                else -> null
-            }
+
+            val resolvedExpiry = parsedExpiryDate
+                ?: resolveRelativeExpiry(rawOcrText, description, captureTimestamp)
 
             return CouponInfo(
                 storeName = finalStoreName,
                 description = description,
-                expiryDate = parsedExpiryDate,
-                cashbackAmount = normalizedCashback,
+                expiryDate = resolvedExpiry,
+                cashbackAmount = null,
                 redeemCode = finalCode,
-                minimumPurchase = parseNumericValue(minOrderAmount),
-                discountType = when (cashbackType) {
-                    "percent" -> "PERCENTAGE"
-                    "amount" -> "AMOUNT"
-                    else -> null
-                }
+                minimumPurchase = null,
+                discountType = null
             )
-            
+
         } catch (e: JSONException) {
             Log.e(TAG, "Failed to parse LLM JSON response: $response", e)
             throw IllegalStateException("Invalid JSON response from LLM: ${e.message}")
         }
     }
 
-    private fun hasSupportingDigits(amountText: String, rawOcrText: String?, cleanedDescription: String): Boolean {
-        val numericTokens = Regex("""\d[\d,]*(?:\.\d+)?""").findAll(amountText)
-            .map { it.value }
-            .filter { it.isNotBlank() }
-            .toList()
+    private fun resolveRelativeExpiry(
+        rawOcrText: String?,
+        description: String,
+        captureTimestamp: Date?
+    ): Date? {
+        if (captureTimestamp == null) return null
 
-        if (numericTokens.isEmpty()) {
-            Log.w(TAG, "No digit sequences found in cashback amount '$amountText'")
-            return false
+        val combinedText = listOfNotNull(rawOcrText, description)
+            .joinToString("\n")
+        if (combinedText.isBlank()) return null
+
+        val relativePattern = Regex("(?i)(?:expire|expiring|valid)\\s+(?:in|within)\\s+(\\d+)\\s+days?")
+        val match = relativePattern.find(combinedText) ?: return null
+        val dayCount = match.groupValues.getOrNull(1)?.toIntOrNull() ?: return null
+
+        return Calendar.getInstance().apply {
+            time = captureTimestamp
+            add(Calendar.DAY_OF_YEAR, dayCount)
+        }.time.also {
+            Log.d(TAG, "Resolved relative expiry using capture timestamp +$dayCount days → $it")
         }
-
-        val searchSpaces = mutableListOf<String>()
-        rawOcrText?.let { searchSpaces.add(it) }
-        if (cleanedDescription.isNotBlank()) {
-            searchSpaces.add(cleanedDescription)
-        }
-
-        if (searchSpaces.isEmpty()) {
-            Log.w(TAG, "No OCR text available to validate cashback amount '$amountText'")
-            return false
-        }
-
-        val missingTokens = numericTokens.filterNot { token ->
-            searchSpaces.any { text -> containsDigitSequence(text, token) }
-        }
-
-        if (missingTokens.isNotEmpty()) {
-            Log.w(TAG, "Missing numeric support for tokens $missingTokens in amount '$amountText'")
-            return false
-        }
-
-        return true
-    }
-
-    private fun containsDigitSequence(text: String?, token: String): Boolean {
-        if (text.isNullOrBlank() || token.isBlank()) {
-            return false
-        }
-
-        if (text.contains(token)) {
-            return true
-        }
-
-        val normalizedToken = token.replace(Regex("[^0-9]"), "")
-        if (normalizedToken.isBlank()) {
-            return false
-        }
-
-        val normalizedText = text.replace(Regex("[^0-9]"), "")
-        if (normalizedText.contains(normalizedToken)) {
-            return true
-        }
-
-        val trimmedToken = normalizedToken.trimStart('0')
-        return trimmedToken.isNotBlank() && normalizedText.contains(trimmedToken)
     }
 
     /**
@@ -1396,34 +1291,6 @@ $sanitizedOcr<|im_end|>
         return true
     }
 
-    /**
-     * Parse numeric value from currency/percentage strings
-     * Handles formats like: ₹150, $25, 25%, 150.50, etc.
-     */
-     private fun parseNumericValue(value: String?): Double? {
-        if (value.isNullOrBlank() || value == "Unknown") return null
-        
-        return try {
-            // Remove currency symbols and extract numeric value
-            val numericString = value
-                .replace(Regex("[₹$£€¥%,\\s]"), "") // Remove common currency symbols, %, commas, spaces
-                .replace(Regex("[^0-9.]"), "") // Keep only digits and decimal points
-                .trim()
-            
-            if (numericString.isBlank()) {
-                Log.w(TAG, "No numeric value found in: '$value'")
-                null
-            } else {
-                val parsed = numericString.toDoubleOrNull()
-                Log.d(TAG, "Parsed '$value' → $parsed")
-                parsed
-            }
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to parse numeric value: '$value'", e)
-            null
-        }
-    }
-    
     /**
      * Preprocess bitmap specifically for MiniCPM-Llama3-V2.5 vision model
      * Ensures optimal input format: 768px long side, RGB format, proper aspect ratio

--- a/docs/OFFER_TEXT_DEPRECATION_PLAN.md
+++ b/docs/OFFER_TEXT_DEPRECATION_PLAN.md
@@ -1,0 +1,59 @@
+# OfferText Deprecation Plan
+
+## Objective
+Fully eliminate the deprecated `offerText` field from the codebase, data layer, machine learning pipeline, and documentation so that coupon descriptions rely exclusively on the canonical `description` field.
+
+## Current Usage Inventory
+- **Data model**: `Coupon` data class still exposes an `offerText` property marked as deprecated for migrations.【F:app/src/main/kotlin/com/example/coupontracker/data/model/Coupon.kt†L22-L66】
+- **Database schema**: Room migrations create and persist the `offerText` column and related SQL transitions.【F:app/src/main/kotlin/com/example/coupontracker/data/local/CouponDatabase.kt†L137-L153】【F:app/schemas/com.example.coupontracker.data.local.CouponDatabase/7.json†L9-L79】
+- **ViewModels**: `ScannerViewModel` and `BatchScannerViewModel` null out the field but still include it when mapping coupon results.【F:app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt†L470-L1778】【F:app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt†L468-L967】
+- **Extraction services**: Progressive and Universal extraction stages explicitly set `offerText = null`, and `LocalLlmOcrService` strips the key from LLM responses.【F:app/src/main/kotlin/com/example/coupontracker/extraction/ProgressiveExtractionService.kt†L400-L420】【F:app/src/main/kotlin/com/example/coupontracker/universal/UniversalExtractionService.kt†L305-L324】【F:app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt†L1080-L1086】
+- **Documentation & tests**: Several markdown reports and tests mention `offerText` scenarios, perpetuating legacy expectations.【F:PROGRESSIVE_EXTRACTION_COMPLETE.md†L220-L235】【F:FIX_REQUIRED_FIELDS_KAPIVA_2025-10-11.md†L29-L352】【F:app/src/test/java/com/example/coupontracker/extraction/StructuredFieldExtractorTest.kt†L1-L120】
+
+## Decommission Strategy
+
+### 1. Data Model & Serialization
+1. Remove the `offerText` property from `Coupon` and any DTO/mapper classes.
+2. Update companion convenience methods (e.g., cashback display helpers) to rely solely on `description` and other canonical fields.
+3. Adjust serialization/deserialization logic so JSON payloads ignore unknown `offerText` keys rather than expecting them.
+
+### 2. Database Layer
+1. Introduce a new Room migration that drops the `offerText` column from the `coupons` table.
+2. Update DAO queries and entity definitions to remove the column and regenerate Room schema snapshots.
+3. Provide a one-time data backfill step (if necessary) to copy non-null `offerText` values into `description` before dropping the column.
+4. Validate migrations by running the existing instrumentation/unit tests that exercise Room migrations.
+
+### 3. ViewModels & Business Logic
+1. Remove references to `offerText` when constructing or normalizing coupon objects in `ScannerViewModel`, `BatchScannerViewModel`, and related use cases.
+2. Confirm downstream UI uses `description` for display, ensuring no regressions in coupon preview or detail screens.
+3. Add regression tests verifying that offers displaying stacked amounts (e.g., ₹100 + ₹70 cashback) use the correct canonical fields and no longer infer values from the deprecated key.
+
+### 4. Extraction & ML Pipeline
+1. Update extraction services (`ProgressiveExtractionService`, `UniversalExtractionService`, `LocalLlmOcrService`) to stop mutating or sanitizing `offerText` keys and instead reinforce `description` normalization.
+2. Adjust schema expectations in the ML/LLM prompts so generated JSON excludes the `offerText` field entirely.
+3. Enforce the canonical extraction contract: only `storeName`, `couponCode`, and `expiryDate` are emitted as structured fields, with all remaining coupon text passed through verbatim as the `description`. When only an "expiring in X days" string is present, compute `expiryDate` from the screenshot metadata timestamp plus `X` days.
+4. Re-run affected pipeline tests and validation suites to confirm accurate extraction without concatenating cashback components.
+
+### 5. API & Integration Contracts
+1. Communicate the removal to any external consumers (mobile, backend services) and provide a migration window.
+2. Update API contracts, OpenAPI specs, or protobuf definitions to remove `offerText` references.
+3. Ensure incoming payloads containing `offerText` are either rejected with clear errors or automatically mapped to `description` during the transition period.
+
+### 6. Documentation & Training Data
+1. Purge `offerText` mentions from markdown documentation, developer guides, and troubleshooting logs.
+2. Update training data, prompt templates, and synthetic datasets to rely on `description` and `cashback` fields instead.
+3. Add explicit guidance in contributor docs clarifying the canonical fields for offer messaging.
+
+### 7. Verification & Monitoring
+1. Implement automated tests that fail if `offerText` appears in models, schemas, or serialized JSON.
+2. Instrument runtime logging/analytics to detect legacy payloads still sending `offerText` so teams can remediate sources.
+3. After deployment, monitor user-reported discrepancies (like ₹100 + ₹70 stacking) to confirm the issue no longer reproduces, and add automated alerting if the extraction layer outputs structured fields beyond the approved set or mutates the raw description text.
+
+### 8. Deployment Checklist
+1. Roll out the database migration with proper backups and fallbacks.
+2. Deploy application updates (mobile/web/backend) that no longer reference the field.
+3. Coordinate feature flag or version gating if older clients must remain compatible during rollout.
+4. Post-deployment, validate with regression tests and sample screenshots that coupons render a single, correct description string.
+
+## Expected Outcome
+Once all steps are completed, the `offerText` field will no longer exist in storage, code, or documentation. Offer descriptions will rely on the normalized `description` field, preventing accidental concatenation of cashback components and ensuring consistent display across the application.


### PR DESCRIPTION
## Summary
- drop the deprecated offerText column via a Room v8 schema migration and updated entity/model wiring
- simplify the coupon extraction schema, prompts, and validators so only storeName, redeemCode, expiryDate, and the raw description remain
- update LLM pipelines and view models to rely on canonical description text, convert relative expiries with capture timestamps, and stop emitting structured cashback data

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ef2f531068832889fdebf62354d770