### PR TITLE
Implement deterministic multi-coupon extraction scaffolding

### DIFF
--- a/PLAN_REVIEW.md
+++ b/PLAN_REVIEW.md
@@ -1,0 +1,71 @@
+# Extraction Plan Review
+
+## Overall Assessment
+The proposed plan is comprehensive and aligns with the problems observed in the provided coupon examples. It introduces a deterministic-first pipeline with clear fallbacks, which should improve repeatability and reduce reliance on the LLM. The emphasis on regionization, validation, and persistence addresses the primary failure modes we encountered: noisy OCR inputs, misidentified stores, and lost multi-coupon cards.
+
+## Key Strengths
+1. **Layered Architecture** – Breaking responsibilities into classifier, regionizer, OCR, deterministic extractor, composer, validator, and persister should make the system easier to test and reason about. Each stage has explicit outputs and failure handling.
+2. **Deterministic-first Extraction** – Prioritizing regex/heuristics before invoking the LLM lowers latency and cost while preserving control over field validation. The LLM fallback is tightly scoped and still flows through validation, preventing hallucinated descriptions.
+3. **Regionization Focus** – The global crop plus mode-specific rules directly target the noise that caused previous misclassification (e.g., map overlays, CTA buttons). This should significantly improve OCR quality.
+4. **Validator & Normalizer** – The plan introduces concrete guardrails for store names, description content, and glyph fixes. The scoring mechanism gives us a quantitative signal for manual review triage.
+5. **Persistence Guarantees** – Enforcing multi-coupon persistence and deduplication protects against the October 15th regression where secondary coupons were dropped.
+6. **Testing Strategy** – A golden dataset derived from real failures, paired with unit tests per layout type, will make regressions much easier to detect.
+
+## Risks & Open Questions
+1. **Classifier Availability** – The plan assumes a reliable layout classifier. We need clarity on whether we already have training data or if heuristic detection will bootstrap this stage.
+2. **Regionizer Robustness** – The fixed percentage crops may not generalize to all screenshot aspect ratios or device resolutions. We should plan for configuration or auto-tuning based on detected DPI/metadata.
+3. **Regex Coverage** – While the regex set covers the sample layouts, we should document a process for iteratively expanding it (e.g., logging unmatched offers) to prevent silent misses.
+4. **Store Canonicalization** – The curated list is essential but requires maintenance. We should couple it with telemetry to surface unknown stores that users frequently correct.
+5. **LLM Dependency** – Even though the fallback is constrained, we should define latency/error budgets and caching strategies if the offline model is unavailable.
+6. **Telemetry Scope** – The counters are well-chosen, but we should also emit stage-level timings to spot performance regressions.
+
+## Recommendations
+1. **Bootstrap Plan for Classifier** – Document whether the classifier starts as a heuristic rule or lightweight CNN, and how we will transition to YOLO in P2.
+2. **Configurable Regionizer Thresholds** – Expose the crop percentages and whitespace thresholds via configuration so we can tune them without a code push.
+3. **Regex Test Harness** – Add unit/property tests that feed OCR strings through the regex set to ensure we don’t introduce overlapping or contradictory matches.
+4. **Store Dictionary Management** – Store canonical names in a centralized JSON with metadata (aliases, normalized forms) to simplify updates and telemetry analysis.
+5. **LLM Fallback Budgeting** – Track LLM invocation counts and durations in telemetry to inform caching or batching decisions.
+6. **Golden Set Automation** – Integrate the golden corpus into CI with automatic diffing so failures surface immediately after merges.
+
+## Conclusion
+The plan is strong and addresses previously identified weaknesses. With clarity on classifier bootstrapping and configurable regionizer parameters, we should move forward. The suggested telemetry and testing additions will help ensure the pipeline remains maintainable as we integrate more layout types and heuristics.
+
+---
+
+## Addendum – Action Plan Review (March follow-up)
+
+The follow-up implementation blueprint adds the missing execution detail from the original proposal. Overall it is well scoped and directly answers the open risks we flagged earlier. Below is a point-by-point readout to help translate it into tickets and call out remaining concerns.
+
+### What Looks Solid
+1. **Explicit Success Criteria** – The golden-set pass conditions and error-rate targets provide a crisp “definition of done.” They align with our October regressions and should plug directly into CI.
+2. **Classifier Path** – The staged approach (heuristics now, YOLO later) removes the model-blocker risk and keeps us shippable during P0. Documenting the hand-off threshold (0.6 confidence) is particularly helpful.
+3. **Config-driven Regionizer** – Shipping `assets/coupon_regionizer.json` plus a Dev Settings tuner addresses the configurability recommendation we raised. This will let QA iterate on crops without APK rebuilds.
+4. **Regex Harness + Store Canon** – The dedicated test suite, `stores.json`, and telemetry hook for unknown stores cover the maintenance gaps we highlighted.
+5. **Golden Corpus + CI** – End-to-end assertions on the six canonical screenshots ensure the success metrics are continuously enforced.
+6. **Telemetry Coverage** – The proposed counters and timers mirror the observability checklist we requested and should surface both accuracy and performance drift.
+
+### Multi-coupon Extraction Coverage
+The tightened plan does call out the full multi-coupon path—from regionizing grid layouts to persisting every distinct (store, code) pair—but it is worth underscoring the expected flow so it remains a release gate:
+
+1. **Regionizer Support** – The `MULTI_GRID` mode combined with configurable `minCardWidthPx`, `minGapPx`, and `maxCols` thresholds should consistently isolate each tile in screenshots like the Times Prime 2×2 grid. QA should validate this against wider aspect ratios to ensure no tiles bleed into neighbors.
+2. **Extractor Iteration** – Once regions are identified, the deterministic extractor must operate per tile. The Regex Harness needs fixtures that assert we return four offers/codes for the Times Prime sample and do not accidentally merge them into a single description block.
+3. **Persistence Contract** – Updating `handleMultiCouponResult()` to emit and persist a `List<Coupon>` (with deduplication by canonical store + code) directly addresses the “second coupon lost” regression. This change should ship with an instrumentation test that confirms all four grid coupons make it into storage and the success toast enumerates the stores.
+4. **Golden Corpus Guardrail** – The golden CI check for the grid image is the backstop; keep it mandatory for release so any future regression in segmentation or persistence is caught immediately.
+
+If any of these steps slip, we risk repeating the October 15th discard. Keeping them explicitly tracked in the multi-coupon epic will ensure the feature lands end-to-end rather than piecemeal.
+
+### Items to Clarify or Adjust
+1. **Regionizer Dev UI Scope** – Confirm whether the preview tool can ingest local gallery images and export updated configs. Without export, tuning still requires manual edits.
+2. **Regex Negative Cases** – The harness list mentions 40+ cases. Let’s ensure we include examples for hyphenated codes, mixed-case stores, and offers containing slash pricing (e.g., “2 for ₹199”).
+3. **Store Canon Telemetry Volume** – `unknown_store_detected` should include screenshot hash or session id so we can correlate to user corrections later.
+4. **Description Fallback Text** – The default strings (“Exclusive offer…”, “Special discount…”) could surface in production if both store and offer fail. We should tag these with NEEDS_REVIEW automatically to avoid silent bland entries.
+5. **LLM Timeout Handling** – The 900 ms ceiling is reasonable, but we still need a retry/backoff policy when the on-device model is unavailable or warm-up exceeds the limit.
+6. **Multi-coupon Review Screen** – If we add the optional review table, specify whether edits sync back to the dedup hash to prevent discrepancies between the UI and persisted values.
+
+### Ready-to-Track TODOs
+The checklist in section 13 is comprehensive. When importing into Jira/Linear, consider grouping under epics by stage (Regionizer, Extraction, Persistence) to clarify ownership. Additionally:
+- Add a task for tagging NEEDS_REVIEW on composer fallbacks.
+- Include QA-owned tasks for curating and updating the golden set as new failure cases emerge.
+
+### Final Assessment
+Nothing in the tightened plan blocks execution. Once the clarifications above are acknowledged (or translated into follow-up tasks), the team can proceed with implementation. This addendum, coupled with the original review, should give engineering, QA, and ML clear marching orders through P2.

--- a/app/src/main/assets/coupon_regionizer.json
+++ b/app/src/main/assets/coupon_regionizer.json
@@ -1,0 +1,7 @@
+{
+  "globalCrop": { "topPct": 0.14, "bottomPct": 0.14 },
+  "poster": { "focusTopPct": 0.35, "focusHeightPct": 0.55 },
+  "reward": { "dropPhrases": ["you won", "jackpot", "congratulations", "spin again", "scratch"] },
+  "grid": { "minCardWidthPx": 280, "minGapPx": 16, "maxCols": 3 },
+  "mapOverlay": { "brightnessThresh": 0.88, "overlayMinAreaPct": 0.18 }
+}

--- a/app/src/main/assets/stores.json
+++ b/app/src/main/assets/stores.json
@@ -1,0 +1,13 @@
+{
+  "entries": [
+    { "canonical": "The Man Company", "aliases": ["man company", "tmc", "themancompany"] },
+    { "canonical": "boAt", "aliases": ["boat"] },
+    { "canonical": "Myntra", "aliases": ["myntra"] },
+    { "canonical": "Times Prime", "aliases": ["timesprime", "times prime"] },
+    { "canonical": "Giva", "aliases": ["giva"] },
+    { "canonical": "Skullcandy", "aliases": ["skull candy", "skullcandy"] },
+    { "canonical": "Cellecor Gadgets Limited", "aliases": ["cellecor", "cellecor gadgets"] },
+    { "canonical": "Leaf", "aliases": ["leaf"] }
+  ],
+  "badWords": ["now", "shop", "join", "claim", "redeem", "offer", "deal", "coupon"]
+}

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/MultiCouponExtractionService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/MultiCouponExtractionService.kt
@@ -4,6 +4,12 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.util.Log
 import com.example.coupontracker.data.model.Coupon
+import com.example.coupontracker.extraction.deterministic.DescriptionComposer
+import com.example.coupontracker.extraction.deterministic.DeterministicCouponExtractor
+import com.example.coupontracker.extraction.deterministic.SmartCouponSanitizer
+import com.example.coupontracker.extraction.deterministic.StoreCanon
+import com.example.coupontracker.extraction.region.CouponRegionizer
+import com.example.coupontracker.extraction.region.CouponRegionizerConfig
 import com.example.coupontracker.ml.HybridCouponDetector
 import com.example.coupontracker.ml.ScreenshotClassifier
 import com.example.coupontracker.ocr.OcrEngine
@@ -46,6 +52,15 @@ class MultiCouponExtractionService @Inject constructor(
     private val screenshotClassifier = ScreenshotClassifier()
     private val hybridDetector = HybridCouponDetector(context, ocrEngine)
     private val multiEngineOCR = MultiEngineOCR(context, ocrEngine)
+    private val regionizerConfig = CouponRegionizerConfig.load(context)
+    private val regionizer = CouponRegionizer(regionizerConfig)
+    private val storeCanon = StoreCanon(context)
+    private val deterministicExtractor = DeterministicCouponExtractor(
+        storeCanon = storeCanon,
+        rewardDropPhrases = regionizerConfig.reward.dropPhrases
+    )
+    private val descriptionComposer = DescriptionComposer(storeCanon)
+    private val sanitizer = SmartCouponSanitizer(storeCanon, descriptionComposer)
     
     companion object {
         private const val TAG = "MultiCouponExtractionService"
@@ -120,13 +135,20 @@ class MultiCouponExtractionService @Inject constructor(
             Log.d(TAG, "Step 3: Detecting coupon regions...")
             val couponRegions = hybridDetector.detectCoupons(bitmap, ocrResult)
             Log.d(TAG, "Detected ${couponRegions.size} coupon region(s)")
-            
+
+            val regionCandidates = regionizer.regionize(
+                bitmap = bitmap,
+                screenshotType = classification.type,
+                ocrText = fullText,
+                fallbackRegions = couponRegions
+            )
+
             // Limit to MAX_COUPONS_PER_SCREENSHOT
-            val regionsToProcess = couponRegions.take(MAX_COUPONS_PER_SCREENSHOT)
-            if (couponRegions.size > MAX_COUPONS_PER_SCREENSHOT) {
-                Log.w(TAG, "Too many regions detected (${couponRegions.size}), limiting to $MAX_COUPONS_PER_SCREENSHOT")
+            val regionsToProcess = regionCandidates.take(MAX_COUPONS_PER_SCREENSHOT)
+            if (regionCandidates.size > MAX_COUPONS_PER_SCREENSHOT) {
+                Log.w(TAG, "Too many regions detected (${regionCandidates.size}), limiting to $MAX_COUPONS_PER_SCREENSHOT")
             }
-            
+
             // Step 4: Extract each coupon region
             Log.d(TAG, "Step 4: Extracting ${regionsToProcess.size} coupon(s)...")
             val extractedCoupons = mutableListOf<CouponWithConfidence>()
@@ -134,11 +156,11 @@ class MultiCouponExtractionService @Inject constructor(
             
             for ((index, region) in regionsToProcess.withIndex()) {
                 try {
-                    Log.d(TAG, "  Extracting coupon ${index + 1}/${regionsToProcess.size}...")
-                    
+                    Log.d(TAG, "  Extracting coupon ${index + 1}/${regionsToProcess.size} (mode=${region.mode})...")
+
                     val couponWithConfidence = extractSingleRegion(
                         bitmap = bitmap,
-                        region = region,
+                        candidate = region,
                         regionIndex = index,
                         imageUri = imageUri
                     )
@@ -166,7 +188,7 @@ class MultiCouponExtractionService @Inject constructor(
             return@withContext MultiCouponResult(
                 coupons = extractedCoupons,
                 screenshotType = classification.type,
-                totalDetected = couponRegions.size,
+                totalDetected = regionCandidates.size,
                 totalExtracted = extractedCoupons.size,
                 totalFiltered = filteredCount
             )
@@ -188,46 +210,61 @@ class MultiCouponExtractionService @Inject constructor(
      */
     private suspend fun extractSingleRegion(
         bitmap: Bitmap,
-        region: HybridCouponDetector.CouponRegion,
+        candidate: CouponRegionizer.RegionCandidate,
         regionIndex: Int,
         imageUri: String?
     ): CouponWithConfidence {
-        
-        // Crop bitmap to region
-        val regionBitmap = cropBitmapToRegion(bitmap, region.boundingBox)
-            ?: throw IllegalStateException("Failed to crop region $regionIndex")
-        
-        try {
-            // Use progressive extraction service (already has validation integrated)
-        val extractionResult = progressiveExtractionService.extractCoupon(
-                androidContext = context,
-                image = regionBitmap,
-                ocrText = region.ocrText,
-                ocrBlocks = emptyList(),
-                imageUri = imageUri ?: "multi_coupon_region_$regionIndex",
-                captureTimestamp = Date()
-            )
-            
-            // Validate extraction
-            val validationResult = extractionValidator.validate(extractionResult.coupon)
-            
-        val refinedCoupon = CouponPostProcessor.refine(
-            coupon = extractionResult.coupon,
-            context = CouponFixContext(
-                ocrText = region.ocrText,
-                captureTimestamp = Date()
-            )
-        )
 
-        return CouponWithConfidence(
-            coupon = refinedCoupon,
-            confidence = validationResult.validationResult.overallConfidence,
-            extractionQuality = validationResult.extractionQuality,
-            warnings = validationResult.actionableRecommendations
-        )
-            
+        val regionBitmap = cropBitmapToRegion(bitmap, candidate.bounds)
+            ?: throw IllegalStateException("Failed to crop region $regionIndex")
+
+        return try {
+            val existingText = candidate.sourceRegion?.ocrText?.takeIf { it.isNotBlank() }
+            val regionText = existingText ?: when (val ocr = multiEngineOCR.processImage(regionBitmap)) {
+                is MultiEngineOCR.OCRResult.Success -> ocr.text
+                else -> ""
+            }
+
+            val deterministicResult = deterministicExtractor.extract(regionText, candidate.mode)
+
+            val fallbackExtraction = if (deterministicResult.requiresFallback()) {
+                progressiveExtractionService.extractCoupon(
+                    androidContext = context,
+                    image = regionBitmap,
+                    ocrText = regionText,
+                    ocrBlocks = emptyList(),
+                    imageUri = imageUri ?: "multi_coupon_region_$regionIndex",
+                    captureTimestamp = Date()
+                )
+            } else {
+                null
+            }
+
+            val mergedFields = deterministicResult.withFallbackCoupon(fallbackExtraction?.coupon)
+            val sanitized = sanitizer.sanitize(
+                fields = mergedFields,
+                fallbackCoupon = fallbackExtraction?.coupon,
+                imageUri = imageUri,
+                captureTimestamp = Date()
+            )
+
+            val refinedCoupon = CouponPostProcessor.refine(
+                coupon = sanitized.coupon,
+                context = CouponFixContext(
+                    ocrText = regionText,
+                    captureTimestamp = Date()
+                )
+            )
+
+            val validationResult = extractionValidator.validate(refinedCoupon)
+
+            CouponWithConfidence(
+                coupon = refinedCoupon,
+                confidence = maxOf(sanitized.confidence, validationResult.validationResult.overallConfidence),
+                extractionQuality = validationResult.extractionQuality,
+                warnings = (sanitized.issues + validationResult.actionableRecommendations).distinct()
+            )
         } finally {
-            // Clean up cropped bitmap
             if (!regionBitmap.isRecycled) {
                 regionBitmap.recycle()
             }

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/deterministic/DescriptionComposer.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/deterministic/DescriptionComposer.kt
@@ -1,0 +1,30 @@
+package com.example.coupontracker.extraction.deterministic
+
+/**
+ * Produces canonical coupon descriptions with consistent formatting.
+ */
+class DescriptionComposer(
+    private val storeCanon: StoreCanon
+) {
+
+    fun compose(offer: String?, store: String?): String {
+        val cleanedOffer = normalizeOffer(offer)
+        val canonicalStore = store?.let { storeCanon.canonicalize(it) } ?: store
+        return when {
+            !cleanedOffer.isNullOrBlank() && !canonicalStore.isNullOrBlank() ->
+                "$cleanedOffer from $canonicalStore"
+            !cleanedOffer.isNullOrBlank() -> cleanedOffer
+            !canonicalStore.isNullOrBlank() -> "Exclusive offer from $canonicalStore"
+            else -> "Special discount available"
+        }
+    }
+
+    fun normalizeOffer(rawOffer: String?): String? {
+        if (rawOffer.isNullOrBlank()) return null
+        return rawOffer
+            .replace(Regex("\s+"), " ")
+            .replace(Regex("₹\s*(\d)")) { match -> "₹${match.groupValues[1]}" }
+            .replace(Regex("\s*%"), "%")
+            .trim()
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/deterministic/DeterministicCouponExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/deterministic/DeterministicCouponExtractor.kt
@@ -1,0 +1,144 @@
+package com.example.coupontracker.extraction.deterministic
+
+import com.example.coupontracker.extraction.region.CouponRegionizer.RegionMode
+import com.example.coupontracker.util.IndianDateParser
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Locale
+
+/**
+ * Regex-first extractor that produces deterministic coupon fields from OCR text.
+ */
+class DeterministicCouponExtractor(
+    private val storeCanon: StoreCanon,
+    private val rewardDropPhrases: List<String>
+) {
+
+    data class Result(
+        val normalizedText: String,
+        val flatText: String,
+        val offer: String?,
+        val storeCandidate: String?,
+        val code: String?,
+        val expiryText: String?,
+        val expiryDate: LocalDate?,
+        val offerMatched: Boolean,
+        val codeMatched: Boolean
+    ) {
+        val hasCriticalFields: Boolean
+            get() = !offer.isNullOrBlank() && !storeCandidate.isNullOrBlank()
+
+        fun requiresFallback(): Boolean = !hasCriticalFields
+
+        fun withFallbackCoupon(coupon: com.example.coupontracker.data.model.Coupon?): Result {
+            if (coupon == null) return this
+            val fallbackOffer = offer ?: coupon.description.takeIf { it.isNotBlank() }
+            val fallbackStore = storeCandidate ?: coupon.storeName.takeIf { it.isNotBlank() }
+            val fallbackCode = code ?: coupon.redeemCode?.takeIf { it.isNotBlank() }
+            val fallbackExpiryDate = expiryDate ?: coupon.expiryDate?.toInstant()?.atZone(ZoneId.systemDefault())?.toLocalDate()
+            val fallbackExpiryText = expiryText ?: coupon.expiryDate?.let { coupon.expiryDate.toString() }
+            return copy(
+                offer = fallbackOffer,
+                storeCandidate = fallbackStore,
+                code = fallbackCode,
+                expiryDate = fallbackExpiryDate,
+                expiryText = fallbackExpiryText
+            )
+        }
+    }
+
+    private val offerPatterns = listOf(
+        Regex("""(?i)flat\s*₹?\s*\d+(?:[/-])?\s*off"""),
+        Regex("""(?i)upto?\s*₹?\s*\d+%?\s*off"""),
+        Regex("""(?i)buy\s*\d+.*?@\s*₹?\s*\d+"""),
+        Regex("""(?i)you\s*won\s+.*?worth\s*₹?\s*\d+.*?for\s*₹?\s*\d+""")
+    )
+
+    private val codePattern = Regex("""(?=\b[A-Z0-9-]{6,}\b)(?=.*[A-Z])(?=.*\d)[A-Z0-9-]+""")
+    private val expiryPattern = Regex("""(?i)(?:expires|valid\s*(?:till|until|by)|ends\s*on)\s*[:\-]?\s*(\d{1,2}\s*[A-Za-z]{3,9}\s*\d{4})""")
+    private val codeStoplist = setOf("ONTIME", "NOW", "JOIN", "REDEEM")
+
+    fun extract(rawText: String, mode: RegionMode): Result {
+        val normalized = normalizeText(rawText, mode)
+        val flat = normalized.replace("\n", " ")
+        val upperFlat = flat.uppercase(Locale.ROOT)
+
+        val storeCandidate = storeCanon.findInText(flat) ?: storeCanon.findInText(rawText)
+        val offerMatch = offerPatterns.firstOrNull { pattern -> pattern.find(flat) != null }
+        val offerText = offerMatch?.find(flat)?.value
+
+        val codeCandidate = codePattern.findAll(upperFlat)
+            .map { it.value }
+            .firstOrNull { value -> value.uppercase(Locale.ROOT) !in codeStoplist }
+        val expiryMatch = expiryPattern.find(flat)
+        val expiryRaw = expiryMatch?.groupValues?.getOrNull(1)
+        val expiryDate = expiryRaw?.let { raw ->
+            IndianDateParser.parseExpiryIST(raw).date
+        }
+
+        return Result(
+            normalizedText = normalized,
+            flatText = flat,
+            offer = offerText?.let { normalizeOffer(it) },
+            storeCandidate = storeCandidate,
+            code = codeCandidate,
+            expiryText = expiryRaw,
+            expiryDate = expiryDate,
+            offerMatched = offerMatch != null,
+            codeMatched = codeCandidate != null
+        )
+    }
+
+    private fun normalizeText(rawText: String, mode: RegionMode): String {
+        val withoutCarriage = rawText.replace("\r", "\n")
+        val glyphFixed = replaceGlyphs(withoutCarriage)
+        val collapsedWhitespace = glyphFixed.replace(Regex("[\t\u00A0]+"), " ")
+        val lines = collapsedWhitespace.split("\n")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+        val filteredLines = if (mode == RegionMode.REWARD && rewardDropPhrases.isNotEmpty()) {
+            val lowerDrop = rewardDropPhrases.map { it.lowercase(Locale.ROOT) }
+            lines.filter { line ->
+                val lower = line.lowercase(Locale.ROOT)
+                lowerDrop.none { lower.contains(it) }
+            }
+        } else {
+            lines
+        }
+        return filteredLines.joinToString(separator = "\n")
+    }
+
+    private fun replaceGlyphs(text: String): String {
+        val builder = StringBuilder(text.length)
+        var index = 0
+        while (index < text.length) {
+            val char = text[index]
+            when {
+                char == 'T' && looksLikeRupee(text, index) -> builder.append('₹')
+                char == 'O' && isWithinNumber(text, index) -> builder.append('0')
+                else -> builder.append(char)
+            }
+            index++
+        }
+        return builder.toString()
+    }
+
+    private fun looksLikeRupee(text: String, index: Int): Boolean {
+        for (i in index + 1 until text.length) {
+            val c = text[i]
+            if (c.isWhitespace()) continue
+            return c.isDigit()
+        }
+        return false
+    }
+
+    private fun isWithinNumber(text: String, index: Int): Boolean {
+        val prevIsDigit = index > 0 && text[index - 1].isDigit()
+        val nextIsDigit = index + 1 < text.length && text[index + 1].isDigit()
+        return prevIsDigit || nextIsDigit
+    }
+
+    private fun normalizeOffer(rawOffer: String): String {
+        return rawOffer.replace(Regex("\s+"), " ").trim()
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/deterministic/SmartCouponSanitizer.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/deterministic/SmartCouponSanitizer.kt
@@ -1,0 +1,118 @@
+package com.example.coupontracker.extraction.deterministic
+
+import com.example.coupontracker.data.model.Coupon
+import java.time.ZoneId
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Applies guard rails and confidence scoring on deterministic extraction output.
+ */
+class SmartCouponSanitizer(
+    private val storeCanon: StoreCanon,
+    private val composer: DescriptionComposer
+) {
+
+    data class SanitizedResult(
+        val coupon: Coupon,
+        val confidence: Float,
+        val needsReview: Boolean,
+        val issues: List<String>
+    )
+
+    fun sanitize(
+        fields: DeterministicCouponExtractor.Result,
+        fallbackCoupon: Coupon?,
+        imageUri: String?,
+        captureTimestamp: Date?
+    ): SanitizedResult {
+        val issues = mutableListOf<String>()
+        val resolvedStore = storeCanon.resolve(fields.storeCandidate, fields.flatText, fields.offer)
+            ?: fallbackCoupon?.storeName?.takeIf { it.isNotBlank() }
+        val canonicalStore = resolvedStore?.let { storeCanon.canonicalize(it) ?: it }
+
+        val offerText = composer.normalizeOffer(fields.offer)
+            ?: fallbackCoupon?.description?.takeIf { it.isNotBlank() }
+        if (offerText == null) {
+            issues.add("Missing offer text")
+        }
+
+        if (canonicalStore == null) {
+            issues.add("Missing store name")
+        } else if (storeCanon.isBadWord(canonicalStore)) {
+            issues.add("Store matched stopword")
+        }
+
+        val code = fields.code ?: fallbackCoupon?.redeemCode?.takeIf { it.isNotBlank() }
+        val sanitizedCode = code?.uppercase(Locale.ROOT)
+
+        val expiryDate = fields.expiryDate
+            ?: fallbackCoupon?.expiryDate?.toInstant()?.atZone(ZoneId.systemDefault())?.toLocalDate()
+        val expiryDateConverted = expiryDate?.atStartOfDay(ZoneId.systemDefault())?.let { Date.from(it.toInstant()) }
+
+        val description = composer.compose(offerText, canonicalStore)
+
+        val createdAt = fallbackCoupon?.createdAt ?: captureTimestamp ?: Date()
+        val baseCoupon = fallbackCoupon ?: Coupon(
+            id = 0,
+            storeName = canonicalStore ?: "Unknown Store",
+            description = description,
+            cashbackAmount = 0.0,
+            redeemCode = sanitizedCode,
+            expiryDate = expiryDateConverted,
+            imageUri = imageUri,
+            status = "Active",
+            createdAt = createdAt,
+            updatedAt = Date()
+        )
+
+        val finalCoupon = baseCoupon.copy(
+            storeName = canonicalStore ?: baseCoupon.storeName,
+            description = description,
+            normalizedDescription = description.lowercase(Locale.ROOT),
+            redeemCode = sanitizedCode,
+            expiryDate = expiryDateConverted ?: baseCoupon.expiryDate,
+            imageUri = imageUri ?: baseCoupon.imageUri,
+            updatedAt = Date()
+        )
+
+        val confidence = computeConfidence(fields, canonicalStore, offerText, sanitizedCode)
+        val needsReview = confidence < 0.5f || canonicalStore == null || offerText.isNullOrBlank()
+
+        if (needsReview) {
+            issues.add("Needs manual review")
+        }
+
+        return SanitizedResult(
+            coupon = finalCoupon,
+            confidence = confidence,
+            needsReview = needsReview,
+            issues = issues
+        )
+    }
+
+    private fun computeConfidence(
+        fields: DeterministicCouponExtractor.Result,
+        canonicalStore: String?,
+        offerText: String?,
+        code: String?
+    ): Float {
+        var score = 0f
+        if (!canonicalStore.isNullOrBlank() && !storeCanon.isBadWord(canonicalStore)) {
+            score += 0.4f
+        } else if (canonicalStore == null) {
+            score -= 0.5f
+        }
+
+        if (!offerText.isNullOrBlank()) {
+            score += if (fields.offerMatched) 0.3f else 0.15f
+        }
+
+        if (!code.isNullOrBlank()) {
+            val codeMentioned = Regex("""(?i)code[:\s-]*${Regex.escape(code)}""").containsMatchIn(fields.flatText)
+            score += if (codeMentioned) 0.2f else 0.1f
+        }
+
+        return score.coerceIn(0f, 1f)
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/deterministic/StoreCanon.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/deterministic/StoreCanon.kt
@@ -1,0 +1,137 @@
+package com.example.coupontracker.extraction.deterministic
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.Locale
+
+/**
+ * Canonicalizes store names using a curated alias list and stopword guard rails.
+ */
+class StoreCanon private constructor(
+    private val aliasToCanonical: Map<String, String>,
+    private val canonicalToAliases: Map<String, List<String>>, 
+    private val badWords: Set<String>
+) {
+
+    data class StoreEntry(val canonical: String, val aliases: List<String>)
+    data class StoreCanonConfig(val entries: List<StoreEntry>, val badWords: Set<String>)
+
+    constructor(context: Context) : this(loadConfig(context))
+
+    private constructor(config: StoreCanonConfig) : this(
+        aliasToCanonical = buildAliasMap(config.entries),
+        canonicalToAliases = config.entries.associate { entry ->
+            entry.canonical to (entry.aliases + entry.canonical)
+        },
+        badWords = config.badWords.map { normalizeToken(it) }.toSet()
+    )
+
+    fun resolve(storeGuess: String?, ocrText: String, descriptionHint: String?): String? {
+        canonicalize(storeGuess)?.let { canonical ->
+            if (!isBadWord(canonical)) {
+                return canonical
+            }
+        }
+
+        canonicalize(descriptionHint)?.let { canonical ->
+            if (!isBadWord(canonical)) {
+                return canonical
+            }
+        }
+
+        findInText(ocrText)?.let { return it }
+        return null
+    }
+
+    fun findInText(text: String): String? {
+        if (text.isBlank()) return null
+        val normalized = normalizeToken(text)
+        aliasToCanonical.forEach { (alias, canonical) ->
+            if (normalized.contains(alias) && !isBadWord(canonical)) {
+                return canonical
+            }
+        }
+        return null
+    }
+
+    fun canonicalize(store: String?): String? {
+        if (store.isNullOrBlank()) return null
+        val normalized = normalizeToken(store)
+        return aliasToCanonical[normalized]
+    }
+
+    fun isBadWord(token: String?): Boolean {
+        if (token.isNullOrBlank()) return true
+        return badWords.contains(normalizeToken(token))
+    }
+
+    fun aliasesFor(canonical: String): List<String> {
+        return canonicalToAliases[canonical] ?: emptyList()
+    }
+
+    companion object {
+        private const val CONFIG_PATH = "stores.json"
+        private const val TAG = "StoreCanon"
+
+        private fun loadConfig(context: Context): StoreCanonConfig {
+            return runCatching {
+                context.assets.open(CONFIG_PATH).bufferedReader().use { reader ->
+                    parse(JSONObject(reader.readText()))
+                }
+            }.getOrElse { error ->
+                Log.w(TAG, "Failed to load stores.json: ${error.message}")
+                StoreCanonConfig(emptyList(), emptySet())
+            }
+        }
+
+        private fun parse(json: JSONObject): StoreCanonConfig {
+            val entriesArray = json.optJSONArray("entries") ?: JSONArray()
+            val entries = buildList(entriesArray.length()) { index ->
+                val entry = entriesArray.optJSONObject(index) ?: return@buildList
+                val canonical = entry.optString("canonical").takeIf { it.isNotBlank() } ?: return@buildList
+                val aliases = entry.optJSONArray("aliases")?.let { array ->
+                    buildList(array.length()) { aliasIndex ->
+                        array.optString(aliasIndex).takeIf { it.isNotBlank() }?.lowercase()
+                    }.filterNotNull()
+                } ?: emptyList()
+                add(StoreEntry(canonical, aliases))
+            }
+
+            val badWordsArray = json.optJSONArray("badWords") ?: JSONArray()
+            val badWords = buildSet(badWordsArray.length()) { index ->
+                val value = badWordsArray.optString(index)
+                if (!value.isNullOrBlank()) {
+                    add(value)
+                }
+            }
+            return StoreCanonConfig(entries, badWords)
+        }
+
+        fun fromConfig(config: StoreCanonConfig): StoreCanon = StoreCanon(config)
+
+        private fun buildAliasMap(entries: List<StoreEntry>): Map<String, String> {
+            val map = mutableMapOf<String, String>()
+            entries.forEach { entry ->
+                val canonicalNormalized = normalizeToken(entry.canonical)
+                if (canonicalNormalized.isNotBlank()) {
+                    map[canonicalNormalized] = entry.canonical
+                }
+                entry.aliases.forEach { alias ->
+                    val normalized = normalizeToken(alias)
+                    if (normalized.isNotBlank()) {
+                        map[normalized] = entry.canonical
+                    }
+                }
+            }
+            return map
+        }
+
+        private fun normalizeToken(value: String): String {
+            return value.lowercase(Locale.ROOT)
+                .replace("&", "and")
+                .replace(Regex("[^a-z0-9]"), "")
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/region/CouponRegionizer.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/region/CouponRegionizer.kt
@@ -1,0 +1,167 @@
+package com.example.coupontracker.extraction.region
+
+import android.graphics.Bitmap
+import android.graphics.Rect
+import android.util.Log
+import com.example.coupontracker.extraction.region.CouponRegionizerConfig.GridConfig
+import com.example.coupontracker.ml.HybridCouponDetector
+import com.example.coupontracker.ml.ScreenshotClassifier
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * Applies lightweight geometric heuristics to carve the screenshot into coupon-ready regions.
+ */
+class CouponRegionizer(
+    private val config: CouponRegionizerConfig
+) {
+
+    enum class RegionMode { DEFAULT, POSTER, REWARD, MAP_OVERLAY, MULTI_GRID }
+
+    data class RegionCandidate(
+        val bounds: Rect,
+        val mode: RegionMode,
+        val sourceRegion: HybridCouponDetector.CouponRegion?,
+        val index: Int
+    )
+
+    fun regionize(
+        bitmap: Bitmap,
+        screenshotType: ScreenshotClassifier.ScreenshotType,
+        ocrText: String,
+        fallbackRegions: List<HybridCouponDetector.CouponRegion>
+    ): List<RegionCandidate> {
+        val workingRect = applyGlobalCrop(bitmap.width, bitmap.height)
+        val mode = detectMode(screenshotType, ocrText, fallbackRegions.size, workingRect)
+
+        val regions = when (mode) {
+            RegionMode.MULTI_GRID -> buildGridRegions(workingRect, fallbackRegions, config.grid)
+            RegionMode.POSTER -> listOf(buildPosterRegion(workingRect))
+            RegionMode.REWARD -> listOf(RegionCandidate(workingRect, RegionMode.REWARD, fallbackRegions.firstOrNull(), 0))
+            RegionMode.MAP_OVERLAY -> listOf(RegionCandidate(workingRect, RegionMode.MAP_OVERLAY, fallbackRegions.firstOrNull(), 0))
+            RegionMode.DEFAULT -> fallbackRegions.takeIf { it.isNotEmpty() }
+                ?.mapIndexed { index, region ->
+                    RegionCandidate(intersect(region.boundingBox, workingRect) ?: workingRect, RegionMode.DEFAULT, region, index)
+                }
+                ?: listOf(RegionCandidate(workingRect, RegionMode.DEFAULT, null, 0))
+        }
+
+        return regions.sortedWith(compareBy({ it.bounds.top }, { it.bounds.left }))
+    }
+
+    private fun detectMode(
+        screenshotType: ScreenshotClassifier.ScreenshotType,
+        rawText: String,
+        fallbackCount: Int,
+        workingRect: Rect
+    ): RegionMode {
+        val normalized = rawText.lowercase()
+
+        if (config.reward.dropPhrases.any { normalized.contains(it) }) {
+            return RegionMode.REWARD
+        }
+
+        if (fallbackCount >= 2 || screenshotType == ScreenshotClassifier.ScreenshotType.MULTI_COUPON_APP) {
+            return RegionMode.MULTI_GRID
+        }
+
+        val aspectRatio = workingRect.height().toFloat() / workingRect.width().toFloat()
+        if (aspectRatio > 1.3f && containsPosterSignals(normalized)) {
+            return RegionMode.POSTER
+        }
+
+        return RegionMode.DEFAULT
+    }
+
+    private fun containsPosterSignals(text: String): Boolean {
+        val keywords = listOf("flat", "upto", "up to", "% off", "shop now", "limited time")
+        return keywords.any { keyword -> text.contains(keyword) }
+    }
+
+    private fun applyGlobalCrop(width: Int, height: Int): Rect {
+        val topCrop = (height * config.globalCrop.topPct).roundToInt()
+        val bottomCrop = (height * config.globalCrop.bottomPct).roundToInt()
+        val top = topCrop.coerceIn(0, height / 2)
+        val bottom = (height - bottomCrop).coerceAtLeast(top + 1)
+        return Rect(0, top, width, bottom)
+    }
+
+    private fun buildPosterRegion(base: Rect): RegionCandidate {
+        val posterTop = base.top + (base.height() * config.poster.focusTopPct).roundToInt()
+        val posterHeight = (base.height() * config.poster.focusHeightPct).roundToInt()
+        val posterBottom = min(base.bottom, posterTop + posterHeight)
+        val posterRect = Rect(base.left, posterTop, base.right, max(posterTop + 1, posterBottom))
+        return RegionCandidate(posterRect, RegionMode.POSTER, null, 0)
+    }
+
+    private fun buildGridRegions(
+        base: Rect,
+        fallback: List<HybridCouponDetector.CouponRegion>,
+        gridConfig: GridConfig
+    ): List<RegionCandidate> {
+        if (fallback.isNotEmpty()) {
+            return fallback.mapIndexed { index, region ->
+                val clipped = intersect(region.boundingBox, base) ?: base
+                RegionCandidate(clipped, RegionMode.MULTI_GRID, region, index)
+            }
+        }
+
+        val cols = determineColumnCount(base, gridConfig)
+        val rows = determineRowCount(base, cols)
+        val gap = gridConfig.minGapPx
+        val cellWidth = ((base.width() - (gap * (cols - 1))) / cols).coerceAtLeast(gridConfig.minCardWidthPx)
+        val cellHeight = (base.height() - (gap * (rows - 1))) / rows
+
+        val regions = mutableListOf<RegionCandidate>()
+        var index = 0
+        var currentTop = base.top
+        for (row in 0 until rows) {
+            var currentLeft = base.left
+            for (col in 0 until cols) {
+                val right = min(base.right, currentLeft + cellWidth)
+                val bottom = min(base.bottom, currentTop + cellHeight)
+                val rect = Rect(currentLeft, currentTop, right, bottom)
+                regions.add(RegionCandidate(rect, RegionMode.MULTI_GRID, null, index++))
+                currentLeft = right + gap
+                if (currentLeft >= base.right) break
+            }
+            currentTop += cellHeight + gap
+            if (currentTop >= base.bottom) break
+        }
+
+        if (regions.isEmpty()) {
+            Log.w(TAG, "Grid heuristic failed, falling back to single region")
+            regions.add(RegionCandidate(base, RegionMode.MULTI_GRID, null, 0))
+        }
+
+        return regions
+    }
+
+    private fun determineColumnCount(base: Rect, gridConfig: GridConfig): Int {
+        val possibleCols = max(1, base.width() / gridConfig.minCardWidthPx)
+        return possibleCols.coerceIn(1, gridConfig.maxCols)
+    }
+
+    private fun determineRowCount(base: Rect, cols: Int): Int {
+        val aspectRatio = base.height().toFloat() / base.width().toFloat()
+        return when {
+            aspectRatio > 1.4f -> max(2, ceil(cols / 1.5).roundToInt())
+            aspectRatio > 1.0f -> max(1, ceil(cols / 1.2).roundToInt())
+            else -> 1
+        }
+    }
+
+    private fun intersect(original: Rect, clipping: Rect): Rect? {
+        val left = max(original.left, clipping.left)
+        val top = max(original.top, clipping.top)
+        val right = min(original.right, clipping.right)
+        val bottom = min(original.bottom, clipping.bottom)
+        return if (left < right && top < bottom) Rect(left, top, right, bottom) else null
+    }
+
+    companion object {
+        private const val TAG = "CouponRegionizer"
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/region/CouponRegionizerConfig.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/region/CouponRegionizerConfig.kt
@@ -1,0 +1,85 @@
+package com.example.coupontracker.extraction.region
+
+import android.content.Context
+import org.json.JSONObject
+
+/**
+ * Configuration backing the heuristic regionizer.
+ */
+data class CouponRegionizerConfig(
+    val globalCrop: GlobalCrop,
+    val poster: PosterConfig,
+    val reward: RewardConfig,
+    val grid: GridConfig,
+    val mapOverlay: MapOverlayConfig
+) {
+    data class GlobalCrop(val topPct: Float, val bottomPct: Float)
+    data class PosterConfig(val focusTopPct: Float, val focusHeightPct: Float)
+    data class RewardConfig(val dropPhrases: List<String>)
+    data class GridConfig(val minCardWidthPx: Int, val minGapPx: Int, val maxCols: Int)
+    data class MapOverlayConfig(val brightnessThresh: Float, val overlayMinAreaPct: Float)
+
+    companion object {
+        private const val CONFIG_PATH = "coupon_regionizer.json"
+
+        fun load(context: Context): CouponRegionizerConfig {
+            return runCatching {
+                context.assets.open(CONFIG_PATH).bufferedReader().use { reader ->
+                    parse(JSONObject(reader.readText()))
+                }
+            }.getOrElse {
+                default()
+            }
+        }
+
+        private fun parse(json: JSONObject): CouponRegionizerConfig {
+            val global = json.optJSONObject("globalCrop")
+            val poster = json.optJSONObject("poster")
+            val reward = json.optJSONObject("reward")
+            val grid = json.optJSONObject("grid")
+            val mapOverlay = json.optJSONObject("mapOverlay")
+
+            return CouponRegionizerConfig(
+                globalCrop = GlobalCrop(
+                    topPct = global?.optDouble("topPct", 0.12)?.toFloat() ?: 0.12f,
+                    bottomPct = global?.optDouble("bottomPct", 0.12)?.toFloat() ?: 0.12f
+                ),
+                poster = PosterConfig(
+                    focusTopPct = poster?.optDouble("focusTopPct", 0.32)?.toFloat() ?: 0.32f,
+                    focusHeightPct = poster?.optDouble("focusHeightPct", 0.56)?.toFloat() ?: 0.56f
+                ),
+                reward = RewardConfig(
+                    dropPhrases = reward?.optJSONArray("dropPhrases")?.let { array ->
+                        buildList(array.length()) {
+                            for (i in 0 until array.length()) {
+                                val value = array.optString(i)
+                                if (!value.isNullOrBlank()) {
+                                    add(value.lowercase())
+                                }
+                            }
+                        }
+                    } ?: emptyList()
+                ),
+                grid = GridConfig(
+                    minCardWidthPx = grid?.optInt("minCardWidthPx", 260) ?: 260,
+                    minGapPx = grid?.optInt("minGapPx", 12) ?: 12,
+                    maxCols = grid?.optInt("maxCols", 3) ?: 3
+                ),
+                mapOverlay = MapOverlayConfig(
+                    brightnessThresh = mapOverlay?.optDouble("brightnessThresh", 0.85)?.toFloat() ?: 0.85f,
+                    overlayMinAreaPct = mapOverlay?.optDouble("overlayMinAreaPct", 0.2)?.toFloat() ?: 0.2f
+                )
+            )
+        }
+
+        private fun default(): CouponRegionizerConfig {
+            return CouponRegionizerConfig(
+                globalCrop = GlobalCrop(topPct = 0.12f, bottomPct = 0.12f),
+                poster = PosterConfig(focusTopPct = 0.32f, focusHeightPct = 0.56f),
+                reward = RewardConfig(dropPhrases = emptyList()),
+                grid = GridConfig(minCardWidthPx = 260, minGapPx = 12, maxCols = 3),
+                mapOverlay = MapOverlayConfig(brightnessThresh = 0.85f, overlayMinAreaPct = 0.2f)
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/example/coupontracker/extraction/deterministic/DeterministicCouponExtractorTest.kt
+++ b/app/src/test/java/com/example/coupontracker/extraction/deterministic/DeterministicCouponExtractorTest.kt
@@ -1,0 +1,55 @@
+package com.example.coupontracker.extraction.deterministic
+
+import com.example.coupontracker.extraction.region.CouponRegionizer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class DeterministicCouponExtractorTest {
+
+    private val storeCanon = StoreCanon.fromConfig(
+        StoreCanon.StoreCanonConfig(
+            entries = listOf(
+                StoreCanon.StoreEntry("Myntra", listOf("myntra")),
+                StoreCanon.StoreEntry("boAt", listOf("boat")),
+                StoreCanon.StoreEntry("Times Prime", listOf("timesprime", "times prime"))
+            ),
+            badWords = setOf("now", "shop")
+        )
+    )
+
+    private val extractor = DeterministicCouponExtractor(
+        storeCanon = storeCanon,
+        rewardDropPhrases = listOf("you won", "jackpot")
+    )
+
+    @Test
+    fun `extractor finds offer code and store`() {
+        val text = """
+            Flat T300 Off | Use code MISSEDYOU
+            Myntra Exclusive Sale
+        """.trimIndent()
+
+        val result = extractor.extract(text, CouponRegionizer.RegionMode.DEFAULT)
+
+        assertEquals("Flat ₹300 Off", result.offer)
+        assertEquals("MISSEDYOU", result.code)
+        assertEquals("Myntra", result.storeCandidate)
+        assertFalse(result.requiresFallback())
+    }
+
+    @Test
+    fun `reward mode drops celebratory phrases`() {
+        val text = """
+            You won a jackpot!
+            Claim boAt rewards now
+            Up to 80% Off on Earbuds
+        """.trimIndent()
+
+        val result = extractor.extract(text, CouponRegionizer.RegionMode.REWARD)
+
+        assertNotNull(result.offer)
+        assertEquals("Up to 80% Off", result.offer)
+    }
+}


### PR DESCRIPTION
## Summary
- add regionizer configuration assets and heuristic CouponRegionizer to crop screenshots before extraction
- introduce deterministic field extractor, store canonicalization, description composer, and sanitizer utilities for structured multi-coupon output
- update MultiCouponExtractionService to apply the new regionizer and sanitizer pipeline and cover deterministic regexes with unit tests

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68efa9fb2e188328b8003fcf4d4d8d20