### PR TITLE
Harden LLM coupon extraction with validator pipeline

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinator.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinator.kt
@@ -1,0 +1,105 @@
+package com.example.coupontracker.extraction.validation
+
+import com.example.coupontracker.data.model.FieldType
+import com.example.coupontracker.extraction.FieldCandidate
+import com.example.coupontracker.util.GenericFieldHeuristics
+import com.example.coupontracker.util.TextExtractor
+import java.util.Date
+
+/**
+ * Summary of field validation containing the normalized fields and any issues raised.
+ */
+data class FieldValidationSummary(
+    val fields: FieldValueBundle,
+    val issues: List<FieldValidationIssue>
+)
+
+/**
+ * Container for the string-based coupon fields that we validate and repair.
+ */
+data class FieldValueBundle(
+    val storeName: String?,
+    val description: String?,
+    val redeemCode: String?,
+    val expiryDateText: String?
+)
+
+/**
+ * Severity of a field validation issue.
+ */
+enum class FieldValidationSeverity {
+    WARNING,
+    ERROR
+}
+
+/**
+ * Details about a validation issue, including which field was affected and how it was repaired.
+ */
+data class FieldValidationIssue(
+    val field: FieldType,
+    val message: String,
+    val severity: FieldValidationSeverity,
+    val replacementSource: String?
+)
+
+/**
+ * Coordinates validation of the core coupon fields returned by the LLM.
+ * Uses deterministic heuristics and structured extraction fallbacks to keep
+ * store, description and expiry decisions isolated from one another.
+ */
+class FieldValidationCoordinator(
+    private val textExtractor: TextExtractor,
+    private val storeNameValidator: StoreNameValidator = StoreNameValidator(),
+    private val descriptionValidator: DescriptionValidator = DescriptionValidator(),
+    private val expiryDateValidator: ExpiryDateValidator = ExpiryDateValidator()
+) {
+    fun refine(
+        initial: FieldValueBundle,
+        rawOcrText: String?,
+        captureTimestamp: Date?,
+        structuredCandidates: Map<FieldType, List<FieldCandidate>>
+    ): FieldValidationSummary {
+        val issues = mutableListOf<FieldValidationIssue>()
+        val structuredStoreCandidates = structuredCandidates[FieldType.STORE_NAME].orEmpty()
+        val structuredExpiryCandidates = structuredCandidates[FieldType.EXPIRY_DATE].orEmpty()
+
+        val fallbackInfo = runCatching {
+            if (rawOcrText.isNullOrBlank()) {
+                null
+            } else {
+                textExtractor.extractCouponInfoSync(rawOcrText, captureTimestamp)
+            }
+        }.getOrNull()
+
+        var bundle = initial
+
+        val storeDecision = storeNameValidator.repair(
+            current = bundle.storeName,
+            description = bundle.description,
+            redeemCode = bundle.redeemCode,
+            structuredCandidates = structuredStoreCandidates,
+            fallbackStore = fallbackInfo?.storeName?.takeUnless { GenericFieldHeuristics.isGenericOrMissing(it) }
+        )
+        bundle = bundle.copy(storeName = storeDecision.value)
+        storeDecision.issue?.let { issues += it }
+
+        val descriptionDecision = descriptionValidator.repair(
+            current = bundle.description,
+            storeName = bundle.storeName,
+            redeemCode = bundle.redeemCode,
+            fallbackDescription = fallbackInfo?.description?.takeUnless { GenericFieldHeuristics.isGenericOrMissing(it) }
+        )
+        bundle = bundle.copy(description = descriptionDecision.value)
+        descriptionDecision.issue?.let { issues += it }
+
+        val expiryDecision = expiryDateValidator.repair(
+            current = bundle.expiryDateText,
+            structuredCandidates = structuredExpiryCandidates,
+            fallbackDate = fallbackInfo?.expiryDate
+        )
+        bundle = bundle.copy(expiryDateText = expiryDecision.value)
+        expiryDecision.issue?.let { issues += it }
+
+        return FieldValidationSummary(bundle, issues)
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidators.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidators.kt
@@ -1,0 +1,192 @@
+package com.example.coupontracker.extraction.validation
+
+import com.example.coupontracker.data.model.FieldType
+import com.example.coupontracker.extraction.FieldCandidate
+import com.example.coupontracker.util.DateParser
+import com.example.coupontracker.util.GenericFieldHeuristics
+import com.example.coupontracker.util.IndianDateParser
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+internal data class FieldRepairDecision(
+    val value: String?,
+    val issue: FieldValidationIssue? = null
+)
+
+internal class StoreNameValidator {
+    fun repair(
+        current: String?,
+        description: String?,
+        redeemCode: String?,
+        structuredCandidates: List<FieldCandidate>,
+        fallbackStore: String?
+    ): FieldRepairDecision {
+        val normalized = current?.trim()
+        if (isValid(normalized, description, redeemCode)) {
+            return FieldRepairDecision(normalized)
+        }
+
+        val structured = structuredCandidates.firstOrNull { candidate ->
+            isValid(candidate.value, description, redeemCode)
+        }
+        if (structured != null) {
+            return FieldRepairDecision(
+                value = structured.value,
+                issue = FieldValidationIssue(
+                    field = FieldType.STORE_NAME,
+                    message = "Replaced invalid store name '${normalized.orEmpty()}' with '${structured.value}'",
+                    severity = FieldValidationSeverity.ERROR,
+                    replacementSource = structured.source
+                )
+            )
+        }
+
+        val fallback = fallbackStore?.trim()
+        if (isValid(fallback, description, redeemCode)) {
+            return FieldRepairDecision(
+                value = fallback,
+                issue = FieldValidationIssue(
+                    field = FieldType.STORE_NAME,
+                    message = "Replaced invalid store name '${normalized.orEmpty()}' with fallback '$fallback'",
+                    severity = FieldValidationSeverity.ERROR,
+                    replacementSource = "text_extractor"
+                )
+            )
+        }
+
+        return FieldRepairDecision(
+            value = normalized,
+            issue = FieldValidationIssue(
+                field = FieldType.STORE_NAME,
+                message = "Store name '${normalized.orEmpty()}' failed validation and no fallback was available",
+                severity = FieldValidationSeverity.ERROR,
+                replacementSource = null
+            )
+        )
+    }
+
+    private fun isValid(value: String?, description: String?, redeemCode: String?): Boolean {
+        if (value.isNullOrBlank()) return false
+        val normalized = value.trim()
+        if (normalized.equals("unknown", ignoreCase = true)) return false
+        if (normalized.equals("unknown store", ignoreCase = true)) return false
+        if (normalized.length < 3) return false
+        if (!normalized.any { it.isLetter() }) return false
+        if (GenericFieldHeuristics.isGenericOrMissing(normalized)) return false
+        if (GenericFieldHeuristics.areDuplicateFields(normalized, redeemCode)) return false
+        if (GenericFieldHeuristics.areDuplicateFields(normalized, description)) return false
+        return true
+    }
+}
+
+internal class DescriptionValidator {
+    fun repair(
+        current: String?,
+        storeName: String?,
+        redeemCode: String?,
+        fallbackDescription: String?
+    ): FieldRepairDecision {
+        val normalized = current?.trim()
+        if (isValid(normalized, storeName, redeemCode)) {
+            return FieldRepairDecision(normalized)
+        }
+
+        val fallback = fallbackDescription?.trim()
+        if (isValid(fallback, storeName, redeemCode)) {
+            return FieldRepairDecision(
+                value = fallback,
+                issue = FieldValidationIssue(
+                    field = FieldType.DESCRIPTION,
+                    message = "Replaced invalid description with fallback text",
+                    severity = FieldValidationSeverity.WARNING,
+                    replacementSource = "text_extractor"
+                )
+            )
+        }
+
+        return FieldRepairDecision(
+            value = normalized,
+            issue = FieldValidationIssue(
+                field = FieldType.DESCRIPTION,
+                message = "Description validation failed and fallback was unavailable",
+                severity = FieldValidationSeverity.WARNING,
+                replacementSource = null
+            )
+        )
+    }
+
+    private fun isValid(value: String?, storeName: String?, redeemCode: String?): Boolean {
+        if (value.isNullOrBlank()) return false
+        val normalized = value.trim()
+        if (normalized.length < 4) return false
+        if (GenericFieldHeuristics.isGenericOrMissing(normalized)) return false
+        if (GenericFieldHeuristics.areDuplicateFields(normalized, storeName)) return false
+        if (GenericFieldHeuristics.areDuplicateFields(normalized, redeemCode)) return false
+        return true
+    }
+}
+
+internal class ExpiryDateValidator {
+    private val isoFormatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    private val relativePattern = Regex("(?i)expires?\\s+in\\s+\\d+\\s+(days?|weeks?|months?|hrs?|hours?)")
+
+    fun repair(
+        current: String?,
+        structuredCandidates: List<FieldCandidate>,
+        fallbackDate: Date?
+    ): FieldRepairDecision {
+        val normalized = current?.trim()
+        if (isValid(normalized)) {
+            return FieldRepairDecision(normalized)
+        }
+
+        val structured = structuredCandidates.firstOrNull { candidate ->
+            isValid(candidate.value)
+        }
+        if (structured != null) {
+            return FieldRepairDecision(
+                value = structured.value,
+                issue = FieldValidationIssue(
+                    field = FieldType.EXPIRY_DATE,
+                    message = "Replaced invalid expiry '${normalized.orEmpty()}' with structured candidate '${structured.value}'",
+                    severity = FieldValidationSeverity.WARNING,
+                    replacementSource = structured.source
+                )
+            )
+        }
+
+        val fallback = fallbackDate?.let { isoFormatter.format(it) }
+        if (isValid(fallback)) {
+            return FieldRepairDecision(
+                value = fallback,
+                issue = FieldValidationIssue(
+                    field = FieldType.EXPIRY_DATE,
+                    message = "Replaced invalid expiry '${normalized.orEmpty()}' with fallback date '$fallback'",
+                    severity = FieldValidationSeverity.WARNING,
+                    replacementSource = "text_extractor"
+                )
+            )
+        }
+
+        return FieldRepairDecision(
+            value = normalized,
+            issue = FieldValidationIssue(
+                field = FieldType.EXPIRY_DATE,
+                message = "Expiry date validation failed and no reliable fallback was available",
+                severity = FieldValidationSeverity.WARNING,
+                replacementSource = null
+            )
+        )
+    }
+
+    private fun isValid(value: String?): Boolean {
+        if (value.isNullOrBlank()) return false
+        val normalized = value.trim()
+        if (relativePattern.containsMatchIn(normalized)) return true
+        if (IndianDateParser.parseExpiryIST(normalized).date != null) return true
+        if (IndianDateParser.extractExpiryFromText(normalized).date != null) return true
+        if (DateParser.parseDate(normalized) != null) return true
+        return false
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -3,6 +3,13 @@ package com.example.coupontracker.util
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.Log
+import com.example.coupontracker.data.model.FieldType
+import com.example.coupontracker.extraction.ExtractionContext
+import com.example.coupontracker.extraction.FieldCandidate
+import com.example.coupontracker.extraction.StructuredFieldExtractor
+import com.example.coupontracker.extraction.validation.FieldValidationCoordinator
+import com.example.coupontracker.extraction.validation.FieldValidationIssue
+import com.example.coupontracker.extraction.validation.FieldValueBundle
 import com.example.coupontracker.llm.LlmRuntimeManager
 import com.example.coupontracker.llm.LlmTelemetryService
 import com.example.coupontracker.ocr.OcrEngine
@@ -11,6 +18,7 @@ import com.example.coupontracker.schema.PromptGenerator
 import com.example.coupontracker.schema.SchemaValidator
 import com.example.coupontracker.schema.ValidationResult
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -92,6 +100,8 @@ class LocalLlmOcrService(
     private val telemetryService = injectedTelemetryService ?: LlmTelemetryService.getInstance(context)
     private val imagePreprocessor = ImagePreprocessor()
     private val textExtractor = TextExtractor() // Fallback
+    private val structuredFieldExtractor = StructuredFieldExtractor()
+    private val fieldValidationCoordinator = FieldValidationCoordinator(textExtractor)
     private var modelPinned = false
     
     init {
@@ -172,6 +182,14 @@ class LocalLlmOcrService(
                     error = IllegalStateException("OCR returned blank text; cannot build prompt")
                 )
             val prompt = createCouponExtractionPrompt(rawOcrText)
+            val extractionContext = ExtractionContext(
+                imageUri = "inline://llm",
+                ocrText = rawOcrText,
+                captureTimestamp = captureTimestamp
+            )
+            val structuredCandidatesDeferred = async(Dispatchers.Default) {
+                structuredFieldExtractor.detectFieldsStructured(extractionContext)
+            }
             
             // Step 4: Run LLM inference with timeout and memory tracking
             memoryUsage = llmRuntime.getMemoryStats().modelLoadedMemoryMB.toLong()
@@ -186,7 +204,17 @@ class LocalLlmOcrService(
                     Log.e(TAG, "LLM response did not start with '{': ${trimmedResponse.take(200)}")
                     throw IllegalStateException("LLM response not JSON (missing opening brace)")
                 }
-                val couponInfo = parseLlmResponseToCouponInfo(llmResponse, rawOcrText, captureTimestamp)
+                val structuredCandidates = runCatching { structuredCandidatesDeferred.await() }
+                    .onFailure { error ->
+                        Log.w(TAG, "Structured extraction failed: ${error.message}", error)
+                    }
+                    .getOrElse { emptyMap() }
+                val couponInfo = parseLlmResponseToCouponInfo(
+                    llmResponse,
+                    rawOcrText,
+                    captureTimestamp,
+                    structuredCandidates
+                )
                 
                 // CRITICAL: Detect mock responses and reject them
                 if (MockLlmResponseDetector.isMockResponse(couponInfo)) {
@@ -285,6 +313,14 @@ class LocalLlmOcrService(
             
             // Step 4: Create structured extraction prompt
             val prompt = createCouponExtractionPrompt(ocrText)
+            val extractionContext = ExtractionContext(
+                imageUri = "inline://llm",
+                ocrText = ocrText,
+                captureTimestamp = captureTimestamp
+            )
+            val structuredCandidatesDeferred = async(Dispatchers.Default) {
+                structuredFieldExtractor.detectFieldsStructured(extractionContext)
+            }
             
             // Step 5: Run TEXT-ONLY LLM inference with OCR text
             Log.d(TAG, "========================================")
@@ -304,7 +340,17 @@ class LocalLlmOcrService(
             // Step 6: Parse and validate response
             val couponInfo = if (llmResponse != null) {
                 // We already have OCR text from Step 3, no need to extract again
-                val parsedInfo = parseLlmResponseToCouponInfo(llmResponse, ocrText, captureTimestamp)
+                val structuredCandidates = runCatching { structuredCandidatesDeferred.await() }
+                    .onFailure { error ->
+                        Log.w(TAG, "Structured extraction failed: ${error.message}", error)
+                    }
+                    .getOrElse { emptyMap() }
+                val parsedInfo = parseLlmResponseToCouponInfo(
+                    llmResponse,
+                    ocrText,
+                    captureTimestamp,
+                    structuredCandidates
+                )
                 
                 // CRITICAL: Detect mock responses and fall back to OCR
                 if (MockLlmResponseDetector.isMockResponse(parsedInfo)) {
@@ -560,7 +606,8 @@ $sanitizedOcr
     private fun parseLlmResponseToCouponInfo(
         response: String,
         rawOcrText: String?,
-        captureTimestamp: Date?
+        captureTimestamp: Date?,
+        structuredCandidates: Map<FieldType, List<FieldCandidate>>
     ): CouponInfo {
         return try {
             // Clean response (remove any markdown formatting)
@@ -633,54 +680,75 @@ $sanitizedOcr
                 parsedJson
             }
             
-            // Extract fields with fallbacks and generic filtering
-            val storeName = json.optString("storeName", "Unknown Store").let {
-                when {
-                    it.isBlank() || it == "Unknown" -> "Unknown Store"
-                    GenericFieldHeuristics.isGenericOrMissing(it) -> "Unknown Store"
-                    else -> it
-                }
-            }
-            
-            val rawDescription = json.optString("description", "")
-            val cleanedDescription = cleanDescription(rawDescription)
-            val description = when {
-                cleanedDescription.isBlank() -> selectDescriptionFallback(rawOcrText)
-                cleanedDescription.equals("Unknown", ignoreCase = true) -> selectDescriptionFallback(rawOcrText)
-                GenericFieldHeuristics.isGenericOrMissing(cleanedDescription) -> selectDescriptionFallback(rawOcrText)
-                else -> cleanedDescription
-            }
-            
-        // Use universal code validation instead of brand-specific patterns
-            val code = (json.optString("redeemCode").takeIf { it.isNotBlank() && it != "Unknown" }
+            sanitizeSentinelValues(json)
+
+            val rawStoreName = json.optString("storeName").takeIf { it.isNotBlank() }
+            val cleanedDescription = cleanDescription(json.optString("description", "")).takeIf { it.isNotBlank() }
+            val codeCandidate = (json.optString("redeemCode").takeIf { it.isNotBlank() && it != "Unknown" }
                 ?: json.optString("code").takeIf { it.isNotBlank() && it != "Unknown" })
                 ?.let { rawCode ->
-                    // Basic sanitization and universal validation
                     val sanitized = RedeemCodeSanitizer.sanitizePreserve(rawCode)
                     val repaired = sanitized ?: RedeemCodeRepair.repair(rawCode)
-                    repaired?.takeIf { isValidUniversalCode(it) }?.also {
-                        Log.d(TAG, "Validated universal code: $it")
-                    }
+                    repaired?.takeIf { isValidUniversalCode(it) }
                 }
-                ?.takeIf { !GenericFieldHeuristics.isGenericOrMissingCode(it) }
-            
-            val expiryDate = json.optString("expiryDate").let {
-                if (it.isBlank() || it == "Unknown") null else it
+            val sanitizedCodeCandidate = codeCandidate?.takeIf { !GenericFieldHeuristics.isGenericOrMissingCode(it) }
+            val expiryCandidate = json.optString("expiryDate").takeIf { it.isNotBlank() && it != "Unknown" }
+
+            val validationSummary = fieldValidationCoordinator.refine(
+                initial = FieldValueBundle(
+                    storeName = rawStoreName,
+                    description = cleanedDescription,
+                    redeemCode = sanitizedCodeCandidate,
+                    expiryDateText = expiryCandidate
+                ),
+                rawOcrText = rawOcrText,
+                captureTimestamp = captureTimestamp,
+                structuredCandidates = structuredCandidates
+            )
+
+            validationSummary.issues.forEach { issue: FieldValidationIssue ->
+                val sourceInfo = issue.replacementSource?.let { source -> " via $source" } ?: ""
+                Log.w(TAG, "Field validation ${issue.severity} for ${issue.field}: ${issue.message}$sourceInfo")
             }
-            
-            // Check for duplicate values between fields (common LLM issue)
-            val finalStoreName = if (GenericFieldHeuristics.areDuplicateFields(storeName, code)) {
-                Log.w(TAG, "Detected duplicate store name and redeem code: '$storeName' - downgrading store name")
-                "Unknown Store"
-            } else storeName
-            
-            val finalCode = if (GenericFieldHeuristics.areDuplicateFields(storeName, code) || GenericFieldHeuristics.isGenericOrMissingCode(code)) {
-                Log.w(TAG, "Detected duplicate store name and redeem code: '$code' - clearing redeem code")
+
+            val candidateStoreName = validationSummary.fields.storeName?.trim()
+            val candidateDescription = validationSummary.fields.description
+            val candidateCode = validationSummary.fields.redeemCode
+            val candidateExpiry = validationSummary.fields.expiryDateText
+
+            val cleanedCandidateDescription = cleanDescription(candidateDescription)
+            val description = when {
+                cleanedCandidateDescription.isBlank() -> selectDescriptionFallback(rawOcrText)
+                cleanedCandidateDescription.equals("Unknown", ignoreCase = true) -> selectDescriptionFallback(rawOcrText)
+                GenericFieldHeuristics.isGenericOrMissing(cleanedCandidateDescription) -> selectDescriptionFallback(rawOcrText)
+                else -> cleanedCandidateDescription
+            }
+
+            val normalizedCode = candidateCode?.takeIf { isValidUniversalCode(it) }?.takeIf {
+                !GenericFieldHeuristics.isGenericOrMissingCode(it)
+            }
+
+            val finalStoreCandidate = if (GenericFieldHeuristics.areDuplicateFields(candidateStoreName, normalizedCode)) {
+                Log.w(TAG, "Detected duplicate store name and redeem code: '${candidateStoreName.orEmpty()}' - downgrading store name")
                 null
-            } else code
-            
+            } else candidateStoreName
+
+            val finalCode = if (
+                GenericFieldHeuristics.areDuplicateFields(candidateStoreName, normalizedCode) ||
+                GenericFieldHeuristics.isGenericOrMissingCode(normalizedCode)
+            ) {
+                if (!normalizedCode.isNullOrBlank()) {
+                    Log.w(TAG, "Detected invalid or duplicate redeem code: '$normalizedCode' - clearing redeem code")
+                }
+                null
+            } else normalizedCode
+
+            val finalStoreName = finalStoreCandidate?.takeIf {
+                it.isNotBlank() && !GenericFieldHeuristics.isGenericOrMissing(it)
+            } ?: "Unknown Store"
+
             // Parse expiry date with enhanced pattern matching
-            val parsedExpiryDate = expiryDate?.let { dateStr ->
+            val parsedExpiryDate = candidateExpiry?.let { dateStr ->
                 try {
                     // First try extracting from the full text (in case LLM gave us a sentence)
                     var parseResult = IndianDateParser.extractExpiryFromText(dateStr)

--- a/app/src/test/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinatorTest.kt
@@ -1,0 +1,83 @@
+package com.example.coupontracker.extraction.validation
+
+import com.example.coupontracker.data.model.FieldType
+import com.example.coupontracker.extraction.FieldCandidate
+import com.example.coupontracker.util.TextExtractor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FieldValidationCoordinatorTest {
+    private val textExtractor = TextExtractor()
+    private val coordinator = FieldValidationCoordinator(textExtractor)
+
+    @Test
+    fun `refine replaces invalid store with structured candidate`() {
+        val bundle = FieldValueBundle(
+            storeName = "Unknown Store",
+            description = "Flat 20% OFF on fashion",
+            redeemCode = "SAVE20",
+            expiryDateText = null
+        )
+        val structured = mapOf(
+            FieldType.STORE_NAME to listOf(FieldCandidate("Myntra", 0.9f, "all_caps", null))
+        )
+
+        val summary = coordinator.refine(
+            bundle,
+            rawOcrText = "MYNTRA\nFlat 20% OFF on fashion\nUse code SAVE20",
+            captureTimestamp = null,
+            structuredCandidates = structured
+        )
+
+        assertEquals("Myntra", summary.fields.storeName)
+        assertTrue(summary.issues.any { it.field == FieldType.STORE_NAME })
+    }
+
+    @Test
+    fun `refine fills missing description from text extractor`() {
+        val bundle = FieldValueBundle(
+            storeName = "Amazon",
+            description = null,
+            redeemCode = "AMZ100",
+            expiryDateText = null
+        )
+
+        val summary = coordinator.refine(
+            bundle,
+            rawOcrText = "AMAZON\nGet Rs 100 cashback on first order\nUse code AMZ100",
+            captureTimestamp = null,
+            structuredCandidates = emptyMap()
+        )
+
+        assertNotNull(summary.fields.description)
+        assertTrue(summary.issues.any { it.field == FieldType.DESCRIPTION })
+    }
+
+    @Test
+    fun `refine supplies expiry from structured fallback`() {
+        val bundle = FieldValueBundle(
+            storeName = "Flipkart",
+            description = "Flat 15% off",
+            redeemCode = "FLIP15",
+            expiryDateText = null
+        )
+        val structured = mapOf(
+            FieldType.EXPIRY_DATE to listOf(FieldCandidate("2025-05-31", 0.85f, "absolute_date", null))
+        )
+
+        val summary = coordinator.refine(
+            bundle,
+            rawOcrText = "Flipkart Summer Sale\nValid till 31 May 2025",
+            captureTimestamp = null,
+            structuredCandidates = structured
+        )
+
+        assertEquals("2025-05-31", summary.fields.expiryDateText)
+        assertTrue(summary.issues.any { it.field == FieldType.EXPIRY_DATE })
+    }
+}

--- a/docs/llm_extraction_plan.md
+++ b/docs/llm_extraction_plan.md
@@ -1,0 +1,88 @@
+# Coupon Extraction Stability Plan
+
+## Objectives
+- Extract expiry date, description, store name, and other coupon fields accurately without regression when prompts or schemas change.
+- Leverage large language models (LLMs) for flexible parsing while insulating downstream systems from prompt variability.
+- Establish a feedback loop so extraction quality improves over time instead of requiring ad-hoc fixes.
+
+## Guiding Principles
+1. **Schema-first contracts** – Define a single canonical JSON schema for coupon data (using strict types for date, currency, etc.). Any model or rule-based extractor must target this schema, keeping downstream integration stable.
+2. **Separation of concerns** – Use isolated modules for prompt construction, LLM inference, post-processing, and validation. Changes to one layer should not affect others.
+3. **Deterministic validation** – Validate LLM output with deterministic rules (regular expressions, business logic). Reject or auto-correct invalid fields before they reach storage.
+4. **Observability and regression testing** – Maintain golden datasets and automated evaluation to detect regressions when prompts or model versions change.
+
+## Target Architecture
+```
+raw text/image -> preprocessing -> prompt builder -> LLM extraction -> structured JSON -> validators -> resolver -> storage/API
+```
+
+### 1. Preprocessing
+- Normalize OCR results (remove duplicates, fix casing, standardize date formats like `MM/DD/YYYY` vs `DD MMM YYYY`).
+- Detect coupon language and route to language-specific prompt templates if necessary.
+
+### 2. Prompt Builder
+- Maintain versioned prompt templates stored as files (e.g., `prompts/coupon_v1.txt`).
+- Compose prompts programmatically: `system` message enforces schema, `user` message supplies coupon text, optional `few-shot` examples for tricky cases.
+- Use template variables for toggling focus (expiry, description, store) without rewriting prompts.
+
+### 3. LLM Extraction
+- Prefer JSON mode or function calling (OpenAI/Anthropic/etc.) to force structured output.
+- Enable `temperature = 0` to reduce randomness.
+- Retry with fallback prompt variants when the model returns invalid JSON.
+
+### 4. Validators
+- Implement validators per field:
+  - **Expiry date** – parse with multiple formats, ensure it is not in the past (unless historical coupons allowed), cross-check with text.
+  - **Description** – require minimum length, reject when identical to store name.
+  - **Store name** – fuzzy match against known list; if unknown, ensure it contains alphabetic words and not dates/prices.
+- Keep validators declarative so they can be unit tested and reused.
+
+### 5. Resolver Layer
+- Combine validator feedback with LLM output:
+  - If one field fails, re-prompt only for that field using a focused prompt (`"Given the coupon text, only return the store_name"`).
+  - Cache intermediate results to avoid reprocessing the entire coupon.
+  - Apply rule-based fallbacks (e.g., regex for expiry date) when LLM is uncertain.
+
+### 6. Storage/API
+- Store version metadata: prompt version, model version, validator version. This enables auditing and rollback when regressions occur.
+
+## Implementation Plan
+1. **Define schema and validation rules**
+   - Create `schemas/coupon.json` with all required fields.
+   - Implement validators in `app/src/main/java/.../validators` with unit tests covering positive/negative cases.
+
+2. **Prompt management**
+   - Introduce a `prompts/` directory with YAML/JSON metadata describing each prompt version.
+   - Build a prompt loader that reads templates and substitutes variables.
+
+3. **Extraction service wrapper**
+   - Wrap LLM API calls in a service that handles retries, temperature, max tokens, and logging.
+   - Expose a function `extractCouponFields(text, fields=None)` that optionally focuses on specific fields.
+
+4. **Feedback loop & evaluation**
+   - Assemble a labeled dataset (start with 100+ coupons) stored in `data/golden_coupons.jsonl`.
+   - Write an evaluation script to compare extracted outputs with ground truth and produce metrics per field.
+   - Run evaluation automatically (CI pipeline) when prompts, validators, or model configs change.
+
+5. **Continuous learning**
+   - Log all production extractions with validator outcomes.
+   - Prioritize failed cases for human review and add to the golden dataset.
+   - Optionally fine-tune or build smaller specialized models using accumulated data.
+
+6. **Operational safeguards**
+   - Add alerting when failure rates exceed thresholds.
+   - Version-control prompt and validator changes; require review plus evaluation results before merging.
+   - Provide a rollback mechanism (keep previous prompt/model versions available).
+
+## Leveraging LLM Potential
+- Use chain-of-thought internally (hidden) when requesting complex reasoning, but ensure final answer remains structured JSON.
+- Explore multi-pass extraction: first pass to identify candidate fields, second pass to resolve conflicts.
+- Consider ensemble approaches (LLM + deterministic regex + small classifier) with a resolver picking the best field.
+- Use embeddings to match against known store names for better accuracy.
+
+## Long-term Enhancements
+- Train a lightweight classifier to predict confidence per field and trigger targeted re-prompts only when confidence is low.
+- Experiment with vision-language models for cases where layout matters.
+- Automate prompt evaluation by simulating coupon variants (synthetic data) to ensure resilience to format changes.
+
+By enforcing modular boundaries, strong validation, and continuous evaluation, changes to one field (expiry date, description, store name) will not cascade into others. The LLM remains central for flexible extraction, but deterministic layers guarantee stability and precise data for downstream consumers.


### PR DESCRIPTION
## Summary
- add a reusable field validation coordinator with store, description, and expiry validators
- run structured extraction in parallel and feed results into the LLM parser for per-field repair
- cover the new validation flow with Robolectric unit tests

## Testing
- not run (Android SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68efea3a32fc83289f009b125227b18c