### PR TITLE
Add debug extraction diagnostics overlay

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/debug/ExtractionDebugModels.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/debug/ExtractionDebugModels.kt
@@ -1,0 +1,377 @@
+package com.example.coupontracker.debug
+
+import com.example.coupontracker.util.ExtractResult
+import com.example.coupontracker.util.RunPath
+import com.example.coupontracker.ui.viewmodel.MiniCpmProgress
+import com.example.coupontracker.ui.viewmodel.FieldExtractionResult
+import com.example.coupontracker.universal.UniversalExtractionResult
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Enum describing high level extraction components we want to surface to developers.
+ */
+enum class ExtractionComponent(val displayName: String) {
+    DETECTOR("Detection"),
+    OCR("OCR"),
+    LLM("LLM"),
+    FUSION("Fusion"),
+    VALIDATION("Validation")
+}
+
+/**
+ * Status of a stage score – helps color the UI.
+ */
+enum class StageStatus {
+    HEALTHY,
+    DEGRADED,
+    FAILED
+}
+
+/**
+ * Score for an individual extraction component.
+ */
+data class ExtractionStageScore(
+    val component: ExtractionComponent,
+    val score: Int,
+    val status: StageStatus,
+    val notes: List<String> = emptyList()
+)
+
+/**
+ * Snapshot representing the full diagnostic view for a single extraction.
+ * This is kept lightweight because the feature is temporary and in-memory only.
+ */
+data class ExtractionDebugSnapshot(
+    val overallScore: Int,
+    val stageScores: List<ExtractionStageScore>,
+    val primaryCause: ExtractionComponent? = null,
+    val notes: List<String> = emptyList(),
+    val source: String = "unknown",
+    val timestampMs: Long = System.currentTimeMillis()
+) {
+    fun scoreFor(component: ExtractionComponent): ExtractionStageScore? =
+        stageScores.firstOrNull { it.component == component }
+}
+
+/**
+ * Central scorer that translates existing telemetry into developer-friendly diagnostics.
+ * Heuristics intentionally err on the side of over-communicating since this is a debug-only feature.
+ */
+object ExtractionDebugScorer {
+
+    private const val HEALTHY_THRESHOLD = 75
+    private const val DEGRADED_THRESHOLD = 45
+
+    private fun statusFor(score: Int): StageStatus = when {
+        score >= HEALTHY_THRESHOLD -> StageStatus.HEALTHY
+        score >= DEGRADED_THRESHOLD -> StageStatus.DEGRADED
+        else -> StageStatus.FAILED
+    }
+
+    fun fromLlmResult(result: ExtractResult, source: String): ExtractionDebugSnapshot {
+        return when (result) {
+            is ExtractResult.Good -> buildSnapshot(
+                overall = result.signals.qualityScore,
+                stageEntries = listOf(
+                    ExtractionStageScore(
+                        component = ExtractionComponent.DETECTOR,
+                        score = 80,
+                        status = StageStatus.HEALTHY,
+                        notes = listOf("Detector not consulted – assumed healthy")
+                    ),
+                    ExtractionStageScore(
+                        component = ExtractionComponent.OCR,
+                        score = (result.signals.fieldConfidences["ocrCoverage"]?.times(100)?.toInt())
+                            ?: 70,
+                        status = statusFor((result.signals.fieldConfidences["ocrCoverage"]?.times(100)?.toInt()) ?: 70),
+                        notes = listOf("Derived from OCR coverage heuristic")
+                    ),
+                    ExtractionStageScore(
+                        component = ExtractionComponent.LLM,
+                        score = result.signals.qualityScore,
+                        status = statusFor(result.signals.qualityScore),
+                        notes = listOf("LLM quality score from signals")
+                    ),
+                    ExtractionStageScore(
+                        component = ExtractionComponent.FUSION,
+                        score = 65,
+                        status = statusFor(65),
+                        notes = listOf("Fusion assumed nominal")
+                    )
+                ),
+                primary = null,
+                notes = listOf(
+                    "LLM succeeded with quality ${result.signals.qualityScore}",
+                    "Stage=${result.signals.stage}"
+                ),
+                source = source
+            )
+            is ExtractResult.LowQuality -> {
+                val culprit = when (result.signals.stage) {
+                    com.example.coupontracker.util.ExtractionStage.LLM -> ExtractionComponent.LLM
+                    com.example.coupontracker.util.ExtractionStage.MLKIT,
+                    com.example.coupontracker.util.ExtractionStage.TFLITE -> ExtractionComponent.OCR
+                    com.example.coupontracker.util.ExtractionStage.TWO_STAGE_DETECTION -> ExtractionComponent.DETECTOR
+                    else -> ExtractionComponent.FUSION
+                }
+                buildSnapshot(
+                    overall = result.signals.qualityScore,
+                    stageEntries = listOf(
+                        ExtractionStageScore(
+                            component = ExtractionComponent.DETECTOR,
+                            score = if (culprit == ExtractionComponent.DETECTOR) 30 else 75,
+                            status = statusFor(if (culprit == ExtractionComponent.DETECTOR) 30 else 75)
+                        ),
+                        ExtractionStageScore(
+                            component = ExtractionComponent.OCR,
+                            score = if (culprit == ExtractionComponent.OCR) 35 else 65,
+                            status = statusFor(if (culprit == ExtractionComponent.OCR) 35 else 65)
+                        ),
+                        ExtractionStageScore(
+                            component = ExtractionComponent.LLM,
+                            score = if (culprit == ExtractionComponent.LLM) 25 else 60,
+                            status = statusFor(if (culprit == ExtractionComponent.LLM) 25 else 60),
+                            notes = listOf("Low quality output: ${result.reason}")
+                        ),
+                        ExtractionStageScore(
+                            component = ExtractionComponent.FUSION,
+                            score = 45,
+                            status = statusFor(45)
+                        )
+                    ),
+                    primary = culprit,
+                    notes = listOf("LLM returned low quality (${result.reason})"),
+                    source = source
+                )
+            }
+            is ExtractResult.Failed -> {
+                val culprit = when (result.stage) {
+                    com.example.coupontracker.util.ExtractionStage.LLM -> ExtractionComponent.LLM
+                    com.example.coupontracker.util.ExtractionStage.MLKIT,
+                    com.example.coupontracker.util.ExtractionStage.TFLITE -> ExtractionComponent.OCR
+                    com.example.coupontracker.util.ExtractionStage.TWO_STAGE_DETECTION -> ExtractionComponent.DETECTOR
+                    com.example.coupontracker.util.ExtractionStage.REGEX -> ExtractionComponent.FUSION
+                }
+                buildSnapshot(
+                    overall = 0,
+                    stageEntries = listOf(
+                        ExtractionStageScore(
+                            component = ExtractionComponent.DETECTOR,
+                            score = if (culprit == ExtractionComponent.DETECTOR) 10 else 70,
+                            status = statusFor(if (culprit == ExtractionComponent.DETECTOR) 10 else 70)
+                        ),
+                        ExtractionStageScore(
+                            component = ExtractionComponent.OCR,
+                            score = if (culprit == ExtractionComponent.OCR) 10 else 60,
+                            status = statusFor(if (culprit == ExtractionComponent.OCR) 10 else 60)
+                        ),
+                        ExtractionStageScore(
+                            component = ExtractionComponent.LLM,
+                            score = if (culprit == ExtractionComponent.LLM) 5 else 55,
+                            status = statusFor(if (culprit == ExtractionComponent.LLM) 5 else 55),
+                            notes = listOf("Failure: ${result.error.message ?: "unknown"}")
+                        ),
+                        ExtractionStageScore(
+                            component = ExtractionComponent.FUSION,
+                            score = 30,
+                            status = statusFor(30)
+                        )
+                    ),
+                    primary = culprit,
+                    notes = listOf("Stage failure propagated from ${result.stage}", result.error.message ?: ""),
+                    source = source
+                )
+            }
+        }
+    }
+
+    fun fromFieldExtraction(result: FieldExtractionResult, runPath: RunPath?): ExtractionDebugSnapshot {
+        val llmScore = when (result.miniCpmStatus) {
+            MiniCpmProgress.SUCCESS -> 80
+            MiniCpmProgress.NEEDS_REVIEW -> 55
+            MiniCpmProgress.FALLBACK -> 35
+        }
+        val ocrFallback = runPath?.final?.uppercase(Locale.getDefault())?.contains("OCR") == true
+        val ocrScore = if (ocrFallback) 50 else 75
+        val detectionScore = if (result.fields.isEmpty()) 30 else 78
+        val fusionScore = ((llmScore + ocrScore + detectionScore) / 3).coerceIn(20, 85)
+
+        val culprit = when {
+            result.miniCpmStatus == MiniCpmProgress.FALLBACK -> ExtractionComponent.LLM
+            ocrScore < DEGRADED_THRESHOLD -> ExtractionComponent.OCR
+            detectionScore < DEGRADED_THRESHOLD -> ExtractionComponent.DETECTOR
+            else -> null
+        }
+
+        val stageEntries = listOf(
+            ExtractionStageScore(
+                component = ExtractionComponent.DETECTOR,
+                score = detectionScore,
+                status = statusFor(detectionScore),
+                notes = listOf("Instances extracted: ${result.fields.size}")
+            ),
+            ExtractionStageScore(
+                component = ExtractionComponent.OCR,
+                score = ocrScore,
+                status = statusFor(ocrScore),
+                notes = listOf(if (ocrFallback) "Fallback OCR used" else "Primary OCR path")
+            ),
+            ExtractionStageScore(
+                component = ExtractionComponent.LLM,
+                score = llmScore,
+                status = statusFor(llmScore),
+                notes = listOf("MiniCPM status: ${result.miniCpmStatus}")
+            ),
+            ExtractionStageScore(
+                component = ExtractionComponent.FUSION,
+                score = fusionScore,
+                status = statusFor(fusionScore),
+                notes = listOf("Run path: ${runPath?.strategy ?: "unknown"} → ${runPath?.final ?: "unknown"}")
+            )
+        )
+
+        val overall = (llmScore + ocrScore + detectionScore + fusionScore) / 4
+
+        return buildSnapshot(
+            overall = overall,
+            stageEntries = stageEntries,
+            primary = culprit,
+            notes = listOf("Processing time: ${runPath?.totalTimeMs ?: 0} ms"),
+            source = "two_stage"
+        )
+    }
+
+    fun fromUniversalResult(result: UniversalExtractionResult, ocrTextEmpty: Boolean): ExtractionDebugSnapshot {
+        val ocrScore = if (ocrTextEmpty) 20 else (result.confidence * 100).toInt().coerceIn(30, 85)
+        val fusionScore = (result.confidence * 100).toInt().coerceIn(30, 90)
+
+        val culprit = when {
+            !result.success -> ExtractionComponent.FUSION
+            ocrScore < DEGRADED_THRESHOLD -> ExtractionComponent.OCR
+            fusionScore < DEGRADED_THRESHOLD -> ExtractionComponent.FUSION
+            else -> null
+        }
+
+        val stageEntries = listOf(
+            ExtractionStageScore(
+                component = ExtractionComponent.DETECTOR,
+                score = 40,
+                status = statusFor(40),
+                notes = listOf("Detector bypassed in universal path")
+            ),
+            ExtractionStageScore(
+                component = ExtractionComponent.OCR,
+                score = ocrScore,
+                status = statusFor(ocrScore),
+                notes = listOf(if (ocrTextEmpty) "OCR text missing" else "OCR text length > 0")
+            ),
+            ExtractionStageScore(
+                component = ExtractionComponent.LLM,
+                score = 55,
+                status = statusFor(55),
+                notes = listOf("Semantic pattern scoring applied")
+            ),
+            ExtractionStageScore(
+                component = ExtractionComponent.FUSION,
+                score = fusionScore,
+                status = statusFor(fusionScore),
+                notes = listOf("Universal extractor confidence ${(result.confidence * 100).toInt()}" )
+            )
+        )
+
+        val overall = (ocrScore + fusionScore + 40 + 55) / 4
+
+        return buildSnapshot(
+            overall = overall,
+            stageEntries = stageEntries,
+            primary = culprit,
+            notes = listOf("Universal pipeline executed"),
+            source = "universal"
+        )
+    }
+
+    fun fromTraditionalOcr(fields: Map<String, String>): ExtractionDebugSnapshot {
+        val detectionScore = 35
+        val ocrScore = if (fields.isEmpty()) 15 else 60 + (fields.size * 4).coerceAtMost(20)
+        val fusionScore = if (fields.isEmpty()) 20 else 45
+        val culprit = if (fields.isEmpty()) ExtractionComponent.OCR else null
+
+        val stageEntries = listOf(
+            ExtractionStageScore(
+                component = ExtractionComponent.DETECTOR,
+                score = detectionScore,
+                status = statusFor(detectionScore),
+                notes = listOf("Pure OCR fallback")
+            ),
+            ExtractionStageScore(
+                component = ExtractionComponent.OCR,
+                score = ocrScore,
+                status = statusFor(ocrScore),
+                notes = listOf("Fields extracted: ${fields.keys}")
+            ),
+            ExtractionStageScore(
+                component = ExtractionComponent.LLM,
+                score = 30,
+                status = statusFor(30),
+                notes = listOf("LLM bypassed")
+            ),
+            ExtractionStageScore(
+                component = ExtractionComponent.FUSION,
+                score = fusionScore,
+                status = statusFor(fusionScore),
+                notes = listOf("Heuristic fusion applied")
+            )
+        )
+
+        val overall = (detectionScore + ocrScore + 30 + fusionScore) / 4
+
+        return buildSnapshot(
+            overall = overall,
+            stageEntries = stageEntries,
+            primary = culprit,
+            notes = listOf("Traditional OCR fallback"),
+            source = "traditional_ocr"
+        )
+    }
+
+    private fun buildSnapshot(
+        overall: Int,
+        stageEntries: List<ExtractionStageScore>,
+        primary: ExtractionComponent?,
+        notes: List<String>,
+        source: String
+    ): ExtractionDebugSnapshot {
+        return ExtractionDebugSnapshot(
+            overallScore = overall.coerceIn(0, 100),
+            stageScores = stageEntries,
+            primaryCause = primary,
+            notes = notes.filter { it.isNotBlank() },
+            source = source
+        )
+    }
+}
+
+/**
+ * Simple in-memory repository storing the most recent debug snapshot per coupon ID.
+ * Designed for rapid removal once diagnostics ship.
+ */
+@Singleton
+class ExtractionDebugRepository @Inject constructor() {
+
+    private val _snapshots = MutableStateFlow<Map<Long, ExtractionDebugSnapshot>>(emptyMap())
+    val snapshots: StateFlow<Map<Long, ExtractionDebugSnapshot>> = _snapshots.asStateFlow()
+
+    fun updateSnapshot(couponId: Long, snapshot: ExtractionDebugSnapshot) {
+        _snapshots.update { current -> current + (couponId to snapshot) }
+    }
+
+    fun removeSnapshot(couponId: Long) {
+        _snapshots.update { current -> current - couponId }
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/ui/components/BrandComponents.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/components/BrandComponents.kt
@@ -43,6 +43,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.example.coupontracker.BuildConfig
+import com.example.coupontracker.debug.ExtractionComponent
+import com.example.coupontracker.debug.ExtractionDebugSnapshot
+import com.example.coupontracker.debug.StageStatus
 import com.example.coupontracker.ui.theme.BrandColors
 import com.example.coupontracker.ui.theme.BrandShapes
 import com.example.coupontracker.ui.theme.BrandSpacing
@@ -582,7 +586,8 @@ fun EnhancedCouponCard(
     onClick: () -> Unit,
     onCopyCode: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier,
-    cashbackDisplayText: String? = null
+    cashbackDisplayText: String? = null,
+    debugSnapshot: ExtractionDebugSnapshot? = null
 ) {
     val expiryStatus = DateFormatter.getExpiryStatus(expiryDate)
     val expiryText = DateFormatter.getExpiryText(expiryDate)
@@ -700,9 +705,91 @@ fun EnhancedCouponCard(
                         }
                     }
                 }
+
+                if (BuildConfig.DEBUG && debugSnapshot != null) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    DebugExtractionPanel(snapshot = debugSnapshot)
+                }
             }
         }
     }
+}
+
+@Composable
+private fun DebugExtractionPanel(snapshot: ExtractionDebugSnapshot) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(10.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 0.dp,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            val overallStatus = statusForScore(snapshot.overallScore)
+            Text(
+                text = "Debug score: ${snapshot.overallScore}",
+                style = MaterialTheme.typography.labelLarge,
+                color = statusColor(overallStatus)
+            )
+
+            snapshot.primaryCause?.let { cause ->
+                Text(
+                    text = "Primary culprit: ${cause.displayName}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = BrandColors.Error,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+
+            snapshot.stageScores.forEach { stage ->
+                Spacer(modifier = Modifier.height(6.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stage.component.displayName,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = stage.score.toString(),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = statusColor(stage.status)
+                    )
+                }
+                if (stage.notes.isNotEmpty()) {
+                    Text(
+                        text = stage.notes.first(),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+            }
+
+            if (snapshot.notes.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = snapshot.notes.joinToString(separator = " • "),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
+}
+
+private fun statusColor(status: StageStatus): Color = when (status) {
+    StageStatus.HEALTHY -> BrandColors.Success
+    StageStatus.DEGRADED -> BrandColors.Warning
+    StageStatus.FAILED -> BrandColors.Error
+}
+
+private fun statusForScore(score: Int): StageStatus = when {
+    score >= 75 -> StageStatus.HEALTHY
+    score >= 45 -> StageStatus.DEGRADED
+    else -> StageStatus.FAILED
 }
 
 /**
@@ -730,6 +817,7 @@ fun EnhancedCouponCard(
         onClick = onClick,
         onCopyCode = onCopyCode,
         modifier = modifier,
-        cashbackDisplayText = null
+        cashbackDisplayText = null,
+        debugSnapshot = null
     )
 }

--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/HomeScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/HomeScreen.kt
@@ -391,6 +391,7 @@ fun HomeScreen(
                     verticalArrangement = Arrangement.spacedBy(BrandSpacing.Small)
                 ) {
                     items(coupons) { coupon ->
+                        val debugSnapshot = homeUiState.extractionDebug[coupon.id]
                         EnhancedCouponCard(
                             storeName = coupon.storeName,
                             description = coupon.description,
@@ -404,7 +405,8 @@ fun HomeScreen(
                             onCopyCode = { code ->
                                 clipboardManager.setText(AnnotatedString(code))
                             },
-                            cashbackDisplayText = coupon.getCashbackDisplayText()
+                            cashbackDisplayText = coupon.getCashbackDisplayText(),
+                            debugSnapshot = debugSnapshot
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/HomeViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.example.coupontracker.data.SortOrder
 import com.example.coupontracker.data.model.Coupon
 import com.example.coupontracker.data.repository.CouponRepository
+import com.example.coupontracker.debug.ExtractionDebugRepository
+import com.example.coupontracker.debug.ExtractionDebugSnapshot
 import com.example.coupontracker.ui.model.CouponStatusFilter
 import com.example.coupontracker.ui.model.ExpiryRange
 import com.example.coupontracker.ui.model.FilterState
@@ -51,14 +53,16 @@ data class HomeUiState(
     val modelProgress: Int = 0,
     val modelMessage: String = "",
     val showModelCard: Boolean = true,
-    val modelError: String? = null
+    val modelError: String? = null,
+    val extractionDebug: Map<Long, ExtractionDebugSnapshot> = emptyMap()
 )
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val couponRepository: CouponRepository,
     private val modelImportManager: com.example.coupontracker.model.ModelImportManager,
-    private val securePreferencesManager: com.example.coupontracker.util.SecurePreferencesManager
+    private val securePreferencesManager: com.example.coupontracker.util.SecurePreferencesManager,
+    private val debugRepository: ExtractionDebugRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
@@ -101,8 +105,9 @@ class HomeViewModel @Inject constructor(
         combine(
             allCouponsFlow,
             modelStatusFlow,
-            _filters
-        ) { coupons, modelStatus, filters ->
+            _filters,
+            debugRepository.snapshots
+        ) { coupons, modelStatus, filters, debugSnapshots ->
             val filteredCoupons = applyCouponFilters(coupons, filters)
             _uiState.value.copy(
                 coupons = filteredCoupons,
@@ -111,7 +116,8 @@ class HomeViewModel @Inject constructor(
                 modelProgress = modelProgressFlow.value,
                 modelMessage = modelMessageFlow.value,
                 modelError = if (modelStatus == ModelAvailabilityStatus.ERROR) modelMessageFlow.value else null,
-                showModelCard = shouldShowModelCard(modelStatus)
+                showModelCard = shouldShowModelCard(modelStatus),
+                extractionDebug = debugSnapshots
             )
         }.onEach { updated ->
             _uiState.value = updated

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -12,6 +12,9 @@ import androidx.lifecycle.viewModelScope
 import com.example.coupontracker.data.model.Coupon
 import com.example.coupontracker.data.model.CashbackInfo
 import com.example.coupontracker.data.repository.CouponRepository
+import com.example.coupontracker.debug.ExtractionDebugRepository
+import com.example.coupontracker.debug.ExtractionDebugScorer
+import com.example.coupontracker.debug.ExtractionDebugSnapshot
 import com.example.coupontracker.universal.UniversalExtractionService
 import com.example.coupontracker.universal.ExtractionContext
 import com.example.coupontracker.util.ExtractionPerformanceMonitor
@@ -64,7 +67,8 @@ class ScannerViewModel @Inject constructor(
     private val universalExtractionService: UniversalExtractionService,
     private val performanceMonitor: ExtractionPerformanceMonitor,
     private val analyticsTracker: AnalyticsTracker,
-    private val bitmapManager: com.example.coupontracker.util.BitmapManager  // V2: Injected bitmap memory management
+    private val bitmapManager: com.example.coupontracker.util.BitmapManager,  // V2: Injected bitmap memory management
+    private val debugRepository: ExtractionDebugRepository
 ) : AndroidViewModel(application) {
 
     private val _uiState = MutableStateFlow<ScannerUiState>(ScannerUiState.Initial)
@@ -347,7 +351,7 @@ class ScannerViewModel @Inject constructor(
                     
                     // Step 2: Build coupon from LLM result
                     val llmCoupon = buildCouponFromLlmResult(llmResult.info, imageUri)
-                    
+
                     // Step 3: Persist URI
                     val persistedUri = uriPersistenceManager.persistUri(imageUri)
                     val finalCoupon = finalizeCoupon(
@@ -355,7 +359,27 @@ class ScannerViewModel @Inject constructor(
                         ocrText = null,
                         captureTimestamp = null
                     )
-                    
+
+                    val debugSnapshot = ExtractionDebugScorer.fromLlmResult(llmResult, source = "llm_first")
+                    val normalizedDescription = CouponDedupUtils.normalizeDescription(finalCoupon.description)
+
+                    if (persistImmediately) {
+                        persistCoupon(
+                            coupon = finalCoupon,
+                            normalizedDescription = normalizedDescription,
+                            miniCpmStatus = MiniCpmProgress.SUCCESS,
+                            debugSnapshot = debugSnapshot
+                        )
+                    } else {
+                        pendingPreview = PendingPreview(
+                            coupon = finalCoupon,
+                            normalizedDescription = normalizedDescription,
+                            miniCpmStatus = MiniCpmProgress.SUCCESS,
+                            debugSnapshot = debugSnapshot
+                        )
+                        _uiState.value = ScannerUiState.Success(finalCoupon, MiniCpmProgress.SUCCESS)
+                    }
+
                     // Step 4: Learn patterns (store extraction result for learning)
                     lastExtractionResult = com.example.coupontracker.universal.UniversalExtractionResult(
                         coupon = finalCoupon,
@@ -380,8 +404,6 @@ class ScannerViewModel @Inject constructor(
                         fieldsExtracted = fieldsExtracted
                     )
                     
-                    // Step 6: Update UI
-                    _uiState.value = ScannerUiState.Success(finalCoupon, MiniCpmProgress.SUCCESS)
                     Log.d(TAG, "LLM_FIRST: Completed successfully in ${processingTime}ms")
                 }
                 
@@ -880,6 +902,7 @@ class ScannerViewModel @Inject constructor(
 
             // Extract text from detected fields using OCR
             val extractionResult = extractTextFromFields(couponInstance)
+            val debugSnapshot = extractionResult.debugSnapshot
 
             // Create coupon from extracted information
             val coupon = finalizeCoupon(
@@ -909,13 +932,15 @@ class ScannerViewModel @Inject constructor(
                 persistCoupon(
                     coupon = coupon,
                     normalizedDescription = normalizedDescription,
-                    miniCpmStatus = extractionResult.miniCpmStatus
+                    miniCpmStatus = extractionResult.miniCpmStatus,
+                    debugSnapshot = debugSnapshot
                 )
             } else {
                 pendingPreview = PendingPreview(
                     coupon = coupon,
                     normalizedDescription = normalizedDescription,
-                    miniCpmStatus = extractionResult.miniCpmStatus
+                    miniCpmStatus = extractionResult.miniCpmStatus,
+                    debugSnapshot = debugSnapshot
                 )
                 _uiState.value = ScannerUiState.Success(coupon, extractionResult.miniCpmStatus)
                 Log.d(TAG, "Preview ready for review without immediate persistence")
@@ -941,7 +966,8 @@ class ScannerViewModel @Inject constructor(
     private suspend fun persistCoupon(
         coupon: Coupon,
         normalizedDescription: String,
-        miniCpmStatus: MiniCpmProgress
+        miniCpmStatus: MiniCpmProgress,
+        debugSnapshot: ExtractionDebugSnapshot?
     ) {
         // First check if a duplicate already exists using the saveOrMerge helper
         val savedCouponId = couponRepository.saveOrMergeCoupon(
@@ -952,6 +978,10 @@ class ScannerViewModel @Inject constructor(
         )
 
         val savedCoupon = couponRepository.getCouponById(savedCouponId)
+
+        debugSnapshot?.let { snapshot ->
+            debugRepository.updateSnapshot(savedCouponId, snapshot)
+        }
 
         var analyticsResult = "created"
         var persistedFlag = true
@@ -998,7 +1028,8 @@ class ScannerViewModel @Inject constructor(
                 persistCoupon(
                     coupon = couponToPersist,
                     normalizedDescription = normalizedDescription,
-                    miniCpmStatus = preview.miniCpmStatus
+                    miniCpmStatus = preview.miniCpmStatus,
+                    debugSnapshot = preview.debugSnapshot
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "Error saving preview coupon", e)
@@ -1018,7 +1049,8 @@ class ScannerViewModel @Inject constructor(
         pendingPreview = PendingPreview(
             coupon = coupon,
             normalizedDescription = CouponDedupUtils.normalizeDescription(coupon.description),
-            miniCpmStatus = miniCpmStatus
+            miniCpmStatus = miniCpmStatus,
+            debugSnapshot = null
         )
     }
 
@@ -1254,14 +1286,22 @@ class ScannerViewModel @Inject constructor(
                 nativeAvailable = localLlmOcrService.isServiceAvailable(),
                 totalTimeMs = totalTime
             )
-            
+
             telemetryService.trackRunPath(runPath)
-            
+
             extractedInfo["minicpmProcessing"] = progress.name
             extractedInfo["runPath"] = "${runPath.strategy} → ${runPath.final}"
             extractedInfo["processingTimeMs"] = totalTime.toString()
 
-            FieldExtractionResult(extractedInfo, progress)
+            val baseResult = FieldExtractionResult(
+                fields = extractedInfo.toMap(),
+                miniCpmStatus = progress,
+                runPath = runPath
+            )
+
+            val snapshot = ExtractionDebugScorer.fromFieldExtraction(baseResult, runPath)
+
+            baseResult.copy(debugSnapshot = snapshot)
         }
     }
 
@@ -1488,13 +1528,18 @@ class ScannerViewModel @Inject constructor(
 
             if (extractionResult.success && extractionResult.confidence > 0.3f) {
                 Log.d(TAG, "Universal extraction successful with confidence: ${extractionResult.confidence}")
-                
+
                 // Use the universally extracted coupon
                 val persistedUri = uriPersistenceManager.persistUri(imageUri)
                 val coupon = extractionResult.coupon.copy(
                     imageUri = persistedUri?.toString()
                 )
-                
+                val debugSnapshot = ExtractionDebugScorer.fromUniversalResult(
+                    extractionResult,
+                    ocrText.isBlank()
+                )
+                val normalizedDescription = CouponDedupUtils.normalizeDescription(coupon.description)
+
                 // Record successful extraction
                 val fieldsExtracted = mutableSetOf<String>()
                 if (coupon.storeName != "Unknown Store") fieldsExtracted.add("storeName")
@@ -1512,12 +1557,12 @@ class ScannerViewModel @Inject constructor(
                 
                 // Store extraction result for potential feedback learning
                 lastExtractionResult = extractionResult to ocrText
-                
-                val normalizedDescription = CouponDedupUtils.normalizeDescription(coupon.description)
+
                 pendingPreview = PendingPreview(
                     coupon = coupon,
                     normalizedDescription = normalizedDescription,
-                    miniCpmStatus = MiniCpmProgress.SUCCESS
+                    miniCpmStatus = MiniCpmProgress.SUCCESS,
+                    debugSnapshot = debugSnapshot
                 )
 
                 _uiState.value = ScannerUiState.Success(coupon, MiniCpmProgress.SUCCESS)
@@ -1599,6 +1644,14 @@ class ScannerViewModel @Inject constructor(
                         )
                     } else {
                         val coupon = createCouponFromExtractedInfo(extractedInfo, finalUri.toString())
+                        val debugSnapshot = ExtractionDebugScorer.fromTraditionalOcr(extractedInfo)
+                        val normalizedDescription = CouponDedupUtils.normalizeDescription(coupon.description)
+                        pendingPreview = PendingPreview(
+                            coupon = coupon,
+                            normalizedDescription = normalizedDescription,
+                            miniCpmStatus = MiniCpmProgress.FALLBACK,
+                            debugSnapshot = debugSnapshot
+                        )
                         _uiState.value = ScannerUiState.Success(coupon, MiniCpmProgress.FALLBACK)
 
                         analyticsTracker.trackEvent(
@@ -1666,6 +1719,14 @@ class ScannerViewModel @Inject constructor(
                         )
                     } else {
                         val coupon = createCouponFromExtractedInfo(extractedInfo, imageUri?.toString())
+                        val debugSnapshot = ExtractionDebugScorer.fromTraditionalOcr(extractedInfo)
+                        val normalizedDescription = CouponDedupUtils.normalizeDescription(coupon.description)
+                        pendingPreview = PendingPreview(
+                            coupon = coupon,
+                            normalizedDescription = normalizedDescription,
+                            miniCpmStatus = MiniCpmProgress.FALLBACK,
+                            debugSnapshot = debugSnapshot
+                        )
                         _uiState.value = ScannerUiState.Success(coupon, MiniCpmProgress.FALLBACK)
 
                         analyticsTracker.trackEvent(
@@ -1990,7 +2051,8 @@ data class CouponProcessingSummary(
 private data class PendingPreview(
     val coupon: Coupon,
     val normalizedDescription: String,
-    val miniCpmStatus: MiniCpmProgress
+    val miniCpmStatus: MiniCpmProgress,
+    val debugSnapshot: ExtractionDebugSnapshot?
 )
 
 enum class MiniCpmProgress {
@@ -2008,5 +2070,7 @@ enum class MiniCpmProgress {
 
 data class FieldExtractionResult(
     val fields: Map<String, String>,
-    val miniCpmStatus: MiniCpmProgress
+    val miniCpmStatus: MiniCpmProgress,
+    val runPath: RunPath? = null,
+    val debugSnapshot: ExtractionDebugSnapshot? = null
 )

--- a/docs/debug_extraction_score_plan.md
+++ b/docs/debug_extraction_score_plan.md
@@ -1,0 +1,37 @@
+# Temporary Extraction Debug Score Plan
+
+## Objective
+Create a temporary, developer-facing diagnostic overlay that ranks every coupon extraction by stage so engineers can quickly identify whether a failure stemmed from detection (YOLO), OCR, LLM parsing, or fusion/validation. The overlay must be easy to remove before shipping to end users.
+
+## Guiding Principles
+1. **Non-production only** – Surface diagnostics only in debug/internal builds and keep the UI isolated so it can be deleted without impacting release APKs.
+2. **Leverage existing telemetry** – Reuse `ExtractResult`, `RunPath`, and confidence scores instead of building brand-new probes.
+3. **Deterministic attribution** – Always emit a primary culprit stage together with per-stage scores so QA knows where to look.
+4. **Minimal persistence** – Store diagnostics in-memory via a repository so we avoid schema migrations for a temporary feature.
+
+## Phased Workstream
+
+### Phase 1 – Diagnostic scaffolding
+- Define lightweight data models (`ExtractionDebugSnapshot`, `ExtractionStageScore`) capturing stage scores, status (healthy/degraded/failed), notes, and timestamp.
+- Implement `ExtractionDebugScorer` helpers that convert:
+  - `ExtractResult` (LLM path)
+  - `FieldExtractionResult` + `RunPath` (detector/OCR pipeline)
+  - Universal / traditional OCR fallbacks
+  into structured snapshots using heuristics derived from existing confidence metrics.
+- Add an in-memory `ExtractionDebugRepository` (Hilt singleton) exposing a `StateFlow<Map<Long, Snapshot>>` for the UI.
+
+### Phase 2 – Pipeline integration
+- Thread snapshots through extraction flows:
+  - Populate `FieldExtractionResult` with debug metadata during two-stage detection.
+  - Capture LLM-first, universal, and OCR fallback outcomes and attach snapshots to pending previews.
+  - When coupons are persisted (`persistCoupon` and batch saves), publish snapshots to the repository keyed by coupon ID.
+- Ensure previews keep their snapshots so delayed saves still report diagnostics.
+
+### Phase 3 – Debug UI surface
+- Extend `HomeViewModel` state with the repository flow and pass snapshots to the coupon list.
+- Update `EnhancedCouponCard` to render a compact debug panel (overall score + per-stage breakdown) only when `BuildConfig.DEBUG` is true and a snapshot exists.
+- Add clear styling to highlight the primary culprit stage for quick triage.
+
+### Phase 4 – Validation & cleanup hooks
+- Provide unit coverage for scorer heuristics to lock expected classifications for representative scenarios.
+- Document removal steps (delete repository + UI block) and flag TODO so the feature is not shipped in production builds.


### PR DESCRIPTION
## Summary
- add a temporary extraction debug plan outlining gating, instrumentation, UI, and cleanup phases
- introduce `ExtractionDebugScorer` utilities and an in-memory repository to capture stage-by-stage extraction diagnostics
- surface debug snapshots on coupon cards in debug builds and plumb diagnostic data through the scanner and home view models

## Testing
- `./gradlew :app:lintDebug --console=plain` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f0f78eb4848328a0a1181909f2cd69