### PR TITLE
Surface extraction debug panel on coupon detail screen

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/components/BrandComponents.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/components/BrandComponents.kt
@@ -44,9 +44,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.example.coupontracker.BuildConfig
-import com.example.coupontracker.debug.ExtractionComponent
 import com.example.coupontracker.debug.ExtractionDebugSnapshot
-import com.example.coupontracker.debug.StageStatus
 import com.example.coupontracker.ui.theme.BrandColors
 import com.example.coupontracker.ui.theme.BrandShapes
 import com.example.coupontracker.ui.theme.BrandSpacing
@@ -708,88 +706,11 @@ fun EnhancedCouponCard(
 
                 if (BuildConfig.DEBUG && debugSnapshot != null) {
                     Spacer(modifier = Modifier.height(12.dp))
-                    DebugExtractionPanel(snapshot = debugSnapshot)
+                    ExtractionDebugPanel(snapshot = debugSnapshot)
                 }
             }
         }
     }
-}
-
-@Composable
-private fun DebugExtractionPanel(snapshot: ExtractionDebugSnapshot) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(10.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        tonalElevation = 0.dp,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
-    ) {
-        Column(modifier = Modifier.padding(12.dp)) {
-            val overallStatus = statusForScore(snapshot.overallScore)
-            Text(
-                text = "Debug score: ${snapshot.overallScore}",
-                style = MaterialTheme.typography.labelLarge,
-                color = statusColor(overallStatus)
-            )
-
-            snapshot.primaryCause?.let { cause ->
-                Text(
-                    text = "Primary culprit: ${cause.displayName}",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = BrandColors.Error,
-                    modifier = Modifier.padding(top = 4.dp)
-                )
-            }
-
-            snapshot.stageScores.forEach { stage ->
-                Spacer(modifier = Modifier.height(6.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = stage.component.displayName,
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Text(
-                        text = stage.score.toString(),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = statusColor(stage.status)
-                    )
-                }
-                if (stage.notes.isNotEmpty()) {
-                    Text(
-                        text = stage.notes.first(),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                    )
-                }
-            }
-
-            if (snapshot.notes.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = snapshot.notes.joinToString(separator = " • "),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                )
-            }
-        }
-    }
-}
-
-private fun statusColor(status: StageStatus): Color = when (status) {
-    StageStatus.HEALTHY -> BrandColors.Success
-    StageStatus.DEGRADED -> BrandColors.Warning
-    StageStatus.FAILED -> BrandColors.Error
-}
-
-private fun statusForScore(score: Int): StageStatus = when {
-    score >= 75 -> StageStatus.HEALTHY
-    score >= 45 -> StageStatus.DEGRADED
-    else -> StageStatus.FAILED
 }
 
 /**

--- a/app/src/main/kotlin/com/example/coupontracker/ui/components/ExtractionDebugPanel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/components/ExtractionDebugPanel.kt
@@ -1,0 +1,105 @@
+package com.example.coupontracker.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.coupontracker.debug.ExtractionDebugSnapshot
+import com.example.coupontracker.debug.StageStatus
+import com.example.coupontracker.ui.theme.BrandColors
+
+private const val HEALTHY_THRESHOLD = 75
+private const val DEGRADED_THRESHOLD = 45
+
+@Composable
+fun ExtractionDebugPanel(
+    snapshot: ExtractionDebugSnapshot,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(10.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 0.dp,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            val overallStatus = statusForScore(snapshot.overallScore)
+            Text(
+                text = "Debug score: ${snapshot.overallScore}",
+                style = MaterialTheme.typography.labelLarge,
+                color = statusColor(overallStatus)
+            )
+
+            snapshot.primaryCause?.let { cause ->
+                Text(
+                    text = "Primary culprit: ${cause.displayName}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = BrandColors.Error,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+
+            snapshot.stageScores.forEach { stage ->
+                Spacer(modifier = Modifier.height(6.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stage.component.displayName,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = stage.score.toString(),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = statusColor(stage.status)
+                    )
+                }
+                if (stage.notes.isNotEmpty()) {
+                    Text(
+                        text = stage.notes.first(),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+            }
+
+            if (snapshot.notes.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = snapshot.notes.joinToString(separator = " • "),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
+}
+
+private fun statusColor(status: StageStatus): Color = when (status) {
+    StageStatus.HEALTHY -> BrandColors.Success
+    StageStatus.DEGRADED -> BrandColors.Warning
+    StageStatus.FAILED -> BrandColors.Error
+}
+
+private fun statusForScore(score: Int): StageStatus = when {
+    score >= HEALTHY_THRESHOLD -> StageStatus.HEALTHY
+    score >= DEGRADED_THRESHOLD -> StageStatus.DEGRADED
+    else -> StageStatus.FAILED
+}

--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/CouponDetailScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/CouponDetailScreen.kt
@@ -23,20 +23,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.coupontracker.ui.components.ImagePreviewDialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.example.coupontracker.BuildConfig
 import com.example.coupontracker.R
+import com.example.coupontracker.debug.ExtractionDebugSnapshot
 import com.example.coupontracker.ui.components.DateFormatter
+import com.example.coupontracker.ui.components.ExtractionDebugPanel
 import com.example.coupontracker.data.model.CashbackType
 import com.example.coupontracker.ui.components.StatusType
 import com.example.coupontracker.ui.theme.BrandSpacing
@@ -52,8 +52,8 @@ fun CouponDetailScreen(
     // State for image preview
     var showImagePreview by remember { mutableStateOf(false) }
     val context = LocalContext.current
-    val clipboardManager = LocalClipboardManager.current
     val coupon by viewModel.coupon.collectAsState()
+    val debugSnapshot by viewModel.debugSnapshot.collectAsState()
 
     // Load the coupon when the screen is first displayed
     LaunchedEffect(couponId) {
@@ -98,7 +98,7 @@ fun CouponDetailScreen(
                     onToggleImagePreview = { showImagePreview = it },
                     onTrackUsage = { viewModel.trackUsage(coupon.cashbackAmount) },
                     context = context,
-                    clipboardManager = clipboardManager
+                    debugSnapshot = debugSnapshot
                 )
             } ?: run {
                 Box(
@@ -119,7 +119,7 @@ private fun CouponDetailContent(
     onToggleImagePreview: (Boolean) -> Unit,
     onTrackUsage: () -> Unit,
     context: Context,
-    clipboardManager: androidx.compose.ui.platform.ClipboardManager
+    debugSnapshot: ExtractionDebugSnapshot?
 ) {
     Column(
         modifier = Modifier
@@ -230,7 +230,9 @@ private fun CouponDetailContent(
                     )
 
                     IconButton(onClick = {
-                        clipboardManager.setText(AnnotatedString(coupon.redeemCode))
+                        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                        val clip = ClipData.newPlainText("Coupon code", coupon.redeemCode)
+                        clipboard.setPrimaryClip(clip)
                         Toast.makeText(context, "Code copied to clipboard", Toast.LENGTH_SHORT).show()
                     }) {
                         Icon(Icons.Default.ContentCopy, contentDescription = "Copy code")
@@ -238,6 +240,11 @@ private fun CouponDetailContent(
                 }
             }
 
+            Spacer(modifier = Modifier.height(BrandSpacing.Large))
+        }
+
+        if (BuildConfig.DEBUG && debugSnapshot != null) {
+            ExtractionDebugPanel(snapshot = debugSnapshot)
             Spacer(modifier = Modifier.height(BrandSpacing.Large))
         }
 

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/DetailViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/DetailViewModel.kt
@@ -5,10 +5,18 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.coupontracker.data.model.Coupon
 import com.example.coupontracker.data.repository.CouponRepository
+import com.example.coupontracker.debug.ExtractionDebugRepository
+import com.example.coupontracker.debug.ExtractionDebugSnapshot
 import com.example.coupontracker.util.CouponNotificationManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.Date
 import javax.inject.Inject
@@ -16,7 +24,8 @@ import javax.inject.Inject
 @HiltViewModel
 class DetailViewModel @Inject constructor(
     private val repository: CouponRepository,
-    private val notificationManager: CouponNotificationManager
+    private val notificationManager: CouponNotificationManager,
+    private val debugRepository: ExtractionDebugRepository
 ) : ViewModel() {
 
     companion object {
@@ -24,12 +33,29 @@ class DetailViewModel @Inject constructor(
     }
 
     private val _coupon = MutableStateFlow<Coupon?>(null)
-    val coupon: StateFlow<Coupon?> = _coupon
+    val coupon: StateFlow<Coupon?> = _coupon.asStateFlow()
+
+    private val currentCouponId = MutableStateFlow<Long?>(null)
+
+    val debugSnapshot: StateFlow<ExtractionDebugSnapshot?> = currentCouponId
+        .flatMapLatest { id ->
+            if (id == null) {
+                flowOf(null)
+            } else {
+                debugRepository.snapshots.map { it[id] }
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = null
+        )
 
     private var couponId: Long = 0
 
     fun loadCoupon(id: Long) {
         couponId = id
+        currentCouponId.value = id
         viewModelScope.launch {
             val couponData = repository.getCouponById(id)
             _coupon.value = couponData


### PR DESCRIPTION
## Summary
- extract the debug extraction panel into a reusable composable
- expose extraction debug snapshots from the detail view model and show them on the detail screen when running a debug build
- reuse the shared panel in the home card and copy coupon codes via the Android clipboard service

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f11a187438832884c7deb84780c02b