### PR TITLE
Enable OCR fallback for batch scanning

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ml/HybridCouponDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ml/HybridCouponDetector.kt
@@ -34,7 +34,12 @@ class HybridCouponDetector(
         null
     }
     
-    private val ocrSegmenter = OcrAnchorSegmenter(ocrEngine)
+    private val ocrSegmenter: OcrAnchorSegmenter? = try {
+        OcrAnchorSegmenter(ocrEngine)
+    } catch (e: Exception) {
+        Log.e(TAG, "OcrAnchorSegmenter not available: ${e.message}", e)
+        null
+    }
     
     companion object {
         private const val TAG = "HybridCouponDetector"
@@ -96,10 +101,15 @@ class HybridCouponDetector(
         }
         
         // Step 2: Run OCR anchor-based segmentation
-        val ocrSegments = try {
-            ocrSegmenter.segmentByAnchors(bitmap, ocrResult)
-        } catch (e: Exception) {
-            Log.w(TAG, "OCR segmentation failed: ${e.message}")
+        val ocrSegments = if (ocrSegmenter != null) {
+            try {
+                ocrSegmenter.segmentByAnchors(bitmap, ocrResult)
+            } catch (e: Exception) {
+                Log.w(TAG, "OCR segmentation failed: ${e.message}")
+                emptyList()
+            }
+        } else {
+            Log.w(TAG, "OCR segmenter unavailable, skipping OCR fallback")
             emptyList()
         }
         
@@ -308,7 +318,7 @@ class HybridCouponDetector(
      * Check if at least one detection method is available
      */
     fun isPartiallyAvailable(): Boolean {
-        return twoStageDetector != null || ocrSegmenter != null
+        return twoStageDetector != null || isOcrFallbackAvailable()
     }
 
     /**
@@ -317,7 +327,16 @@ class HybridCouponDetector(
      * but we can still segment coupons using OCR anchor heuristics.
      */
     fun isOcrOnlyMode(): Boolean {
-        return twoStageDetector == null && ocrSegmenter != null
+        return twoStageDetector == null && isOcrFallbackAvailable()
+    }
+
+    private fun isOcrFallbackAvailable(): Boolean {
+        return try {
+            ocrSegmenter != null && ocrEngine.isReady()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error checking OCR fallback availability", e)
+            false
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/example/coupontracker/ml/HybridCouponDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ml/HybridCouponDetector.kt
@@ -303,12 +303,21 @@ class HybridCouponDetector(
     fun isFullyAvailable(): Boolean {
         return twoStageDetector != null
     }
-    
+
     /**
      * Check if at least one detection method is available
      */
     fun isPartiallyAvailable(): Boolean {
         return twoStageDetector != null || ocrSegmenter != null
+    }
+
+    /**
+     * Returns true when the detector is operating in OCR-only fallback mode.
+     * This happens when the dedicated two-stage detector models are missing,
+     * but we can still segment coupons using OCR anchor heuristics.
+     */
+    fun isOcrOnlyMode(): Boolean {
+        return twoStageDetector == null && ocrSegmenter != null
     }
 }
 

--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/BatchScannerScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/BatchScannerScreen.kt
@@ -148,26 +148,40 @@ fun BatchScannerScreen(
             }
         }
     ) { paddingValues ->
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            // Check if TwoStageDetector is available
-            val detectorAvailable = viewModel.isTwoStageDetectorAvailable()
-            
-            if (!detectorAvailable && uiState.selectedImages.isNotEmpty() && !uiState.isProcessing) {
-                // Show warning about batch scanning unavailability
-                BatchScanningUnavailableWarning(
-                    onUseSingleScan = {
-                        Toast.makeText(context, "Please use single scan mode", Toast.LENGTH_SHORT).show()
-                        navController.popBackStack()
-                    },
-                    onClearImages = {
-                        viewModel.clearImages()
-                    }
+            val usingFallback = viewModel.isOcrFallbackActive()
+
+            if (usingFallback) {
+                BatchScanningFallbackBanner(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
                 )
-            } else when {
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .weight(1f, fill = true)
+            ) {
+                val batchScanningSupported = viewModel.isBatchScanningSupported()
+
+                if (!batchScanningSupported && uiState.selectedImages.isNotEmpty() && !uiState.isProcessing) {
+                    // Show warning about batch scanning unavailability
+                    BatchScanningUnavailableWarning(
+                        onUseSingleScan = {
+                            Toast.makeText(context, "Please use single scan mode", Toast.LENGTH_SHORT).show()
+                            navController.popBackStack()
+                        },
+                        onClearImages = {
+                            viewModel.clearImages()
+                        }
+                    )
+                } else when {
                 uiState.isProcessing -> {
                     // Show loading indicator
                     Box(
@@ -255,6 +269,51 @@ fun BatchScannerScreen(
                         }
                     )
                 }
+            }
+        }
+    }
+}
+
+@Composable
+fun BatchScanningFallbackBanner(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Info,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.secondary
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "OCR Fallback Active",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "YOLO multi-coupon models are unavailable in this build. We're using OCR anchor segmentation instead.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Results may need a quick review before saving.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
@@ -77,8 +77,16 @@ class BatchScannerViewModel @Inject constructor(
 
         detectorInitErrorMessage?.let { error ->
             val message = "Multi-coupon detection unavailable: $error"
-            Log.e(TAG, message, detectorInitializationResult.exception)
-            updateState { it.copy(error = message) }
+            if (hybridDetector.isPartiallyAvailable()) {
+                Log.w(
+                    TAG,
+                    "$message - falling back to OCR anchor segmentation for batch scanning",
+                    detectorInitializationResult.exception
+                )
+            } else {
+                Log.e(TAG, message, detectorInitializationResult.exception)
+                updateState { it.copy(error = message) }
+            }
         }
     }
 
@@ -172,14 +180,28 @@ class BatchScannerViewModel @Inject constructor(
     }
     
     /**
-     * Check if TwoStageDetector is available for batch scanning
-     * Returns false if detector is null or models are not loaded
+     * Check if batch scanning is supported on this build. We consider the
+     * feature available when either the dedicated two-stage detector is ready
+     * or the OCR anchor fallback path can handle segmentation.
      */
-    fun isTwoStageDetectorAvailable(): Boolean {
+    fun isBatchScanningSupported(): Boolean {
         return try {
-            twoStageDetector != null && twoStageDetector?.getMemoryStats() != null
+            twoStageDetector != null || hybridDetector.isPartiallyAvailable()
         } catch (e: Exception) {
-            Log.e(TAG, "Error checking TwoStageDetector availability", e)
+            Log.e(TAG, "Error checking batch scanning support", e)
+            false
+        }
+    }
+
+    /**
+     * Indicates whether we're currently relying on the OCR-only fallback for
+     * coupon segmentation (i.e., two-stage models are unavailable).
+     */
+    fun isOcrFallbackActive(): Boolean {
+        return try {
+            twoStageDetector == null && hybridDetector.isOcrOnlyMode()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error checking OCR fallback state", e)
             false
         }
     }
@@ -195,11 +217,13 @@ class BatchScannerViewModel @Inject constructor(
                 val strategy = com.example.coupontracker.util.ExtractionConfig.getStrategy()
                 Log.d(TAG, "Batch: Starting with strategy ${strategy.name}, ${_uiState.value.selectedImages.size} images")
 
-                if (twoStageDetector == null) {
+                if (twoStageDetector == null && !hybridDetector.isPartiallyAvailable()) {
                     val message = detectorInitErrorMessage ?: "Multi-coupon detector is unavailable."
-                    Log.e(TAG, "Batch: TwoStageDetector unavailable - aborting processing")
+                    Log.e(TAG, "Batch: No detector or fallback available - aborting processing")
                     updateState { it.copy(isProcessing = false, error = message) }
                     return@launch
+                } else if (twoStageDetector == null) {
+                    Log.w(TAG, "Batch: TwoStageDetector unavailable - using OCR anchor fallback")
                 }
 
                 updateState {
@@ -420,8 +444,15 @@ class BatchScannerViewModel @Inject constructor(
      */
     private suspend fun processWithLegacyPath(uri: Uri, bitmap: android.graphics.Bitmap): Coupon {
         return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-            val detector = twoStageDetector
-                ?: throw IllegalStateException(detectorInitErrorMessage ?: "Multi-coupon detector is unavailable.")
+            val detector = twoStageDetector ?: run {
+                Log.w(TAG, "LEGACY path requested but TwoStageDetector is unavailable. Using OCR fallback instead.")
+                return@withContext processWithOcrFirstPath(
+                    uri = uri,
+                    bitmap = bitmap,
+                    allowLlmFallback = true,
+                    allowLegacyFallback = false
+                )
+            }
 
             // Run two-stage detection
             val couponInstances = detector.detectMultiCoupons(bitmap)
@@ -473,9 +504,10 @@ class BatchScannerViewModel @Inject constructor(
      * @param allowOcrFallback If true, can fall back to OCR. If false, falls back to LEGACY to prevent infinite loops.
      */
     private suspend fun processWithLlmFirstPath(
-        uri: Uri, 
+        uri: Uri,
         bitmap: android.graphics.Bitmap,
-        allowOcrFallback: Boolean = true
+        allowOcrFallback: Boolean = true,
+        allowLegacyFallback: Boolean = true
     ): Coupon {
         return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
             val llmResult = localLlmOcrService.processCouponImageTyped(bitmap)
@@ -488,11 +520,21 @@ class BatchScannerViewModel @Inject constructor(
                     if (allowOcrFallback) {
                         // First fallback: Try OCR (but don't allow it to call back to LLM)
                         Log.d(TAG, "LLM_FIRST failed, falling back to OCR_FIRST (terminal)")
-                        processWithOcrFirstPath(uri, bitmap, allowLlmFallback = false)
+                        processWithOcrFirstPath(
+                            uri = uri,
+                            bitmap = bitmap,
+                            allowLlmFallback = false,
+                            allowLegacyFallback = allowLegacyFallback
+                        )
                     } else {
-                        // Terminal fallback: Use LEGACY two-stage detection
+                        // Terminal fallback: Use LEGACY two-stage detection if available
                         Log.d(TAG, "LLM_FIRST failed with no OCR fallback allowed, using LEGACY")
-                        processWithLegacyPath(uri, bitmap)
+                        if (allowLegacyFallback) {
+                            processWithLegacyPath(uri, bitmap)
+                        } else {
+                            Log.w(TAG, "LLM_FIRST fallback to LEGACY disabled, returning placeholder coupon")
+                            buildPlaceholderCoupon(uri)
+                        }
                     }
                 }
             }
@@ -504,9 +546,10 @@ class BatchScannerViewModel @Inject constructor(
      * @param allowLlmFallback If true, can fall back to LLM. If false, falls back to LEGACY to prevent infinite loops.
      */
     private suspend fun processWithOcrFirstPath(
-        uri: Uri, 
+        uri: Uri,
         bitmap: android.graphics.Bitmap,
-        allowLlmFallback: Boolean = true
+        allowLlmFallback: Boolean = true,
+        allowLegacyFallback: Boolean = true
     ): Coupon {
         return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
             val ocrResult = multiEngineOCR.processImage(bitmap)
@@ -524,11 +567,21 @@ class BatchScannerViewModel @Inject constructor(
                         if (allowLlmFallback) {
                             // First fallback: Try LLM (but don't allow it to call back to OCR)
                             Log.d(TAG, "OCR_FIRST low confidence, falling back to LLM_FIRST (terminal)")
-                            processWithLlmFirstPath(uri, bitmap, allowOcrFallback = false)
+                            processWithLlmFirstPath(
+                                uri = uri,
+                                bitmap = bitmap,
+                                allowOcrFallback = false,
+                                allowLegacyFallback = allowLegacyFallback
+                            )
                         } else {
                             // Terminal fallback: Use LEGACY two-stage detection
                             Log.d(TAG, "OCR_FIRST failed with no LLM fallback allowed, using LEGACY")
-                            processWithLegacyPath(uri, bitmap)
+                            if (allowLegacyFallback) {
+                                processWithLegacyPath(uri, bitmap)
+                            } else {
+                                Log.w(TAG, "OCR_FIRST fallback to LEGACY disabled, returning placeholder coupon")
+                                buildPlaceholderCoupon(uri)
+                            }
                         }
                     }
                 }
@@ -536,11 +589,21 @@ class BatchScannerViewModel @Inject constructor(
                     if (allowLlmFallback) {
                         // First fallback: Try LLM (but don't allow it to call back to OCR)
                         Log.d(TAG, "OCR_FIRST error, falling back to LLM_FIRST (terminal)")
-                        processWithLlmFirstPath(uri, bitmap, allowOcrFallback = false)
+                        processWithLlmFirstPath(
+                            uri = uri,
+                            bitmap = bitmap,
+                            allowOcrFallback = false,
+                            allowLegacyFallback = allowLegacyFallback
+                        )
                     } else {
                         // Terminal fallback: Use LEGACY two-stage detection
                         Log.d(TAG, "OCR_FIRST failed with no LLM fallback allowed, using LEGACY")
-                        processWithLegacyPath(uri, bitmap)
+                        if (allowLegacyFallback) {
+                            processWithLegacyPath(uri, bitmap)
+                        } else {
+                            Log.w(TAG, "OCR_FIRST fallback to LEGACY disabled, returning placeholder coupon")
+                            buildPlaceholderCoupon(uri)
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
@@ -77,7 +77,13 @@ class BatchScannerViewModel @Inject constructor(
 
         detectorInitErrorMessage?.let { error ->
             val message = "Multi-coupon detection unavailable: $error"
-            if (hybridDetector.isPartiallyAvailable()) {
+            val anyDetectorAvailable = runCatching { hybridDetector.isPartiallyAvailable() }
+                .onFailure { throwable ->
+                    Log.e(TAG, "Failed to evaluate hybrid detector availability", throwable)
+                }
+                .getOrDefault(false)
+
+            if (anyDetectorAvailable) {
                 Log.w(
                     TAG,
                     "$message - falling back to OCR anchor segmentation for batch scanning",
@@ -186,7 +192,7 @@ class BatchScannerViewModel @Inject constructor(
      */
     fun isBatchScanningSupported(): Boolean {
         return try {
-            twoStageDetector != null || hybridDetector.isPartiallyAvailable()
+            hybridDetector.isPartiallyAvailable()
         } catch (e: Exception) {
             Log.e(TAG, "Error checking batch scanning support", e)
             false
@@ -199,7 +205,7 @@ class BatchScannerViewModel @Inject constructor(
      */
     fun isOcrFallbackActive(): Boolean {
         return try {
-            twoStageDetector == null && hybridDetector.isOcrOnlyMode()
+            hybridDetector.isOcrOnlyMode()
         } catch (e: Exception) {
             Log.e(TAG, "Error checking OCR fallback state", e)
             false


### PR DESCRIPTION
## Summary
- allow the batch scanner to continue when YOLO assets are missing by switching to the OCR anchor fallback
- harden the legacy/LLM/OCR processing pipelines so they no longer depend on the two-stage detector being present
- surface an in-app banner to let users know the OCR fallback mode is active instead of blocking the flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f11cadee188328ba0d2136d81ba53c