### PR TITLE
Strengthen description quality heuristics

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/CouponDetailScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/CouponDetailScreen.kt
@@ -579,7 +579,7 @@ private fun deriveQualityInsights(coupon: com.example.coupontracker.data.model.C
     val numericValue = coupon.getCashbackNumericValue()
     val amountValid = !GenericFieldHeuristics.isZeroOrMeaningless(numericValue)
     val expiryDate = coupon.expiryDate
-    val descriptionValid = !GenericFieldHeuristics.isGenericOrMissing(coupon.description)
+    val descriptionValid = GenericFieldHeuristics.isMeaningfulDescription(coupon.description)
 
     val expiryDescription = when {
         expiryDate == null -> "Add an expiry date to get reminders"
@@ -618,7 +618,7 @@ private fun deriveQualityInsights(coupon: com.example.coupontracker.data.model.C
         ),
         QualityMetric(
             label = "Offer clarity",
-            description = if (descriptionValid) "Offer description looks specific" else "Description is generic",
+            description = if (descriptionValid) "Offer description looks specific" else "Description looks incomplete",
             icon = Icons.Default.Article,
             earnedPoints = if (descriptionValid) 10 else 0,
             maxPoints = 10

--- a/app/src/main/kotlin/com/example/coupontracker/util/GenericFieldHeuristics.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/GenericFieldHeuristics.kt
@@ -8,7 +8,12 @@ import android.util.Log
  */
 object GenericFieldHeuristics {
     private const val TAG = "GenericFieldHeuristics"
-    
+    private val descriptionKeywords = setOf(
+        "off", "discount", "cashback", "save", "flat", "upto", "offer", "deal",
+        "free", "gift", "reward", "voucher", "bonus", "win"
+    )
+    private val currencyRegex = Regex("[₹$€£¥]")
+
     /**
      * Check if a field contains generic/boilerplate text that should be treated as missing
      */
@@ -54,6 +59,41 @@ object GenericFieldHeuristics {
             return true
         }
         return false
+    }
+
+    /**
+     * Determine if a description contains enough concrete detail to be treated as meaningful.
+     * Used for quality scoring so truncated or vague descriptions lose credit.
+     */
+    fun isMeaningfulDescription(value: String?): Boolean {
+        if (value.isNullOrBlank()) return false
+        if (isGenericOrMissing(value)) return false
+
+        val trimmed = value.trim()
+        val lower = trimmed.lowercase()
+        val words = lower.split(Regex("\\s+")).filter { it.isNotBlank() }
+        val hasNumberToken = trimmed.any { it.isDigit() } ||
+            trimmed.contains('%') ||
+            currencyRegex.containsMatchIn(trimmed)
+        val hasKeyword = descriptionKeywords.any { lower.contains(it) }
+        val looksTruncated = trimmed.endsWith("...") || trimmed.endsWith("..") || trimmed.endsWith("-")
+
+        if (looksTruncated) {
+            Log.d(TAG, "Treating '$value' as weak description - appears truncated")
+            return false
+        }
+
+        if (words.size < 3 && !hasNumberToken) {
+            Log.d(TAG, "Treating '$value' as weak description - too few words without numbers")
+            return false
+        }
+
+        if (!hasKeyword && !hasNumberToken) {
+            Log.d(TAG, "Treating '$value' as weak description - missing keywords or numbers")
+            return false
+        }
+
+        return true
     }
 
     fun isGenericOrMissingCode(value: String?): Boolean {

--- a/app/src/test/java/android/util/Log.kt
+++ b/app/src/test/java/android/util/Log.kt
@@ -1,0 +1,6 @@
+package android.util
+
+object Log {
+    @JvmStatic
+    fun d(tag: String, msg: String): Int = 0
+}

--- a/app/src/test/kotlin/com/example/coupontracker/util/GenericFieldHeuristicsTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/GenericFieldHeuristicsTest.kt
@@ -1,0 +1,33 @@
+package com.example.coupontracker.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GenericFieldHeuristicsTest {
+
+    @Test
+    fun `meaningful description passes when keywords present`() {
+        assertTrue(GenericFieldHeuristics.isMeaningfulDescription("Flat 20% off on electronics"))
+    }
+
+    @Test
+    fun `meaningful description passes when contains numbers`() {
+        assertTrue(GenericFieldHeuristics.isMeaningfulDescription("5% off"))
+    }
+
+    @Test
+    fun `weak description without detail fails`() {
+        assertFalse(GenericFieldHeuristics.isMeaningfulDescription("Leaf bass wireless"))
+    }
+
+    @Test
+    fun `truncated description fails`() {
+        assertFalse(GenericFieldHeuristics.isMeaningfulDescription("Flat 50% off..."))
+    }
+
+    @Test
+    fun `generic placeholder description fails`() {
+        assertFalse(GenericFieldHeuristics.isMeaningfulDescription("Coupon offer"))
+    }
+}


### PR DESCRIPTION
## Summary
- tighten description validation by requiring concrete keywords, numbers or length before awarding quality score credit
- surface the stricter description check in the coupon detail quality insights messaging
- add unit coverage for the new heuristics with a test Log stub to keep JVM tests self-contained

## Testing
- ./gradlew test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f129dca8b88328a24f9743e3606c6b