### PR TITLE
Enhance store validation telemetry and review UX

### DIFF
--- a/app/src/main/assets/brand_lexicon.json
+++ b/app/src/main/assets/brand_lexicon.json
@@ -1,0 +1,42 @@
+{
+  "tiers": [
+    {
+      "priority": 1,
+      "entries": [
+        {
+          "canonical": "Amazon",
+          "aliases": ["Amazon India", "Amazon.in", "Amazon Pay", "Amazon Prime"]
+        },
+        {
+          "canonical": "Flipkart",
+          "aliases": ["Flipkart Online", "Flipkart Supermart", "Flipkart Axis"]
+        },
+        {
+          "canonical": "Myntra",
+          "aliases": ["Myntra Fashion", "Myntra Insider", "Myntra Style"]
+        }
+      ]
+    },
+    {
+      "priority": 2,
+      "entries": [
+        {
+          "canonical": "Paytm",
+          "aliases": ["Paytm Mall", "Paytm Payments Bank", "Paytm Wallet"]
+        },
+        {
+          "canonical": "Swiggy",
+          "aliases": ["Swiggy Instamart", "Swiggy Genie", "Swiggy One"]
+        }
+      ]
+    }
+  ],
+  "ctaStopwords": [
+    "apply now",
+    "claim now",
+    "tap to claim",
+    "use coupon",
+    "copy code",
+    "redeem now"
+  ]
+}

--- a/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDatabase.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDatabase.kt
@@ -17,7 +17,7 @@ import com.google.gson.reflect.TypeToken
         LearnedPattern::class,          // V2: Pattern storage
         ExtractionFeedback::class       // V2: Feedback & telemetry
     ],
-    version = 9,
+    version = 10,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -343,12 +343,87 @@ abstract class CouponDatabase : RoomDatabase() {
                 database.execSQL("ALTER TABLE `coupons_v9` RENAME TO `coupons`")
             }
         }
+
+        val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `coupons_v10` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `storeName` TEXT NOT NULL,
+                        `description` TEXT NOT NULL,
+                        `normalizedDescription` TEXT,
+                        `expiryDate` INTEGER,
+                        `cashbackAmount` REAL NOT NULL,
+                        `redeemCode` TEXT,
+                        `cashbackType` TEXT,
+                        `cashbackValueNum` REAL,
+                        `cashbackCurrency` TEXT,
+                        `imageUri` TEXT,
+                        `imagePhash` TEXT,
+                        `imageSignature` TEXT,
+                        `category` TEXT,
+                        `status` TEXT,
+                        `minimumPurchase` REAL,
+                        `maximumDiscount` REAL,
+                        `isPriority` INTEGER NOT NULL DEFAULT 0,
+                        `paymentMethod` TEXT,
+                        `usageLimit` INTEGER,
+                        `usageCount` INTEGER NOT NULL DEFAULT 0,
+                        `reminderDate` INTEGER,
+                        `platformType` TEXT,
+                        `extractionQualityScore` INTEGER,
+                        `extractionConfidenceBreakdown` TEXT NOT NULL,
+                        `extractionStage` TEXT,
+                        `extractionRunPath` TEXT,
+                        `extractionTimestamp` INTEGER,
+                        `rating` TEXT,
+                        `createdAt` INTEGER NOT NULL,
+                        `updatedAt` INTEGER NOT NULL,
+                        `needsAttention` INTEGER NOT NULL DEFAULT 0,
+                        `storeNameSource` TEXT,
+                        `storeNameEvidence` TEXT
+                    )
+                    """.trimIndent()
+                )
+
+                database.execSQL(
+                    """
+                    INSERT INTO `coupons_v10` (
+                        `id`, `storeName`, `description`, `normalizedDescription`, `expiryDate`,
+                        `cashbackAmount`, `redeemCode`, `cashbackType`, `cashbackValueNum`, `cashbackCurrency`,
+                        `imageUri`, `imagePhash`, `imageSignature`, `category`, `status`,
+                        `minimumPurchase`, `maximumDiscount`, `isPriority`, `paymentMethod`, `usageLimit`,
+                        `usageCount`, `reminderDate`, `platformType`, `extractionQualityScore`, `extractionConfidenceBreakdown`,
+                        `extractionStage`, `extractionRunPath`, `extractionTimestamp`, `rating`, `createdAt`, `updatedAt`,
+                        `needsAttention`, `storeNameSource`, `storeNameEvidence`
+                    )
+                    SELECT
+                        `id`, `storeName`, `description`, `normalizedDescription`, `expiryDate`,
+                        `cashbackAmount`, `redeemCode`, `cashbackType`, `cashbackValueNum`, `cashbackCurrency`,
+                        `imageUri`, `imagePhash`, `imageSignature`, `category`, `status`,
+                        `minimumPurchase`, `maximumDiscount`, `isPriority`, `paymentMethod`, `usageLimit`,
+                        `usageCount`, `reminderDate`, `platformType`,
+                        `extractionQualityScore`, `extractionConfidenceBreakdown`,
+                        `extractionStage`, `extractionRunPath`, `extractionTimestamp`, `rating`, `createdAt`, `updatedAt`,
+                        0 AS `needsAttention`,
+                        NULL AS `storeNameSource`,
+                        NULL AS `storeNameEvidence`
+                    FROM `coupons`
+                    """.trimIndent()
+                )
+
+                database.execSQL("DROP TABLE `coupons`")
+                database.execSQL("ALTER TABLE `coupons_v10` RENAME TO `coupons`")
+            }
+        }
     }
 }
 
 object Converters {
     private val gson: Gson = Gson()
     private val floatMapType = object : TypeToken<Map<String, Float>>() {}.type
+    private val stringListType = object : TypeToken<List<String>>() {}.type
 
     @TypeConverter
     fun fromTimestamp(value: Long?): java.util.Date? {
@@ -374,5 +449,21 @@ object Converters {
             return null
         }
         return gson.toJson(map, floatMapType)
+    }
+
+    @TypeConverter
+    fun fromStringListJson(value: String?): List<String> {
+        if (value.isNullOrBlank()) {
+            return emptyList()
+        }
+        return gson.fromJson(value, stringListType)
+    }
+
+    @TypeConverter
+    fun stringListToJson(values: List<String>?): String? {
+        if (values.isNullOrEmpty()) {
+            return null
+        }
+        return gson.toJson(values, stringListType)
     }
 }

--- a/app/src/main/kotlin/com/example/coupontracker/data/model/Coupon.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/model/Coupon.kt
@@ -45,7 +45,12 @@ data class Coupon(
     // Existing tracking fields
     val rating: String? = null,
     val createdAt: Date = Date(),
-    val updatedAt: Date = Date()
+    val updatedAt: Date = Date(),
+
+    // Provenance metadata
+    val needsAttention: Boolean = false,
+    val storeNameSource: String? = null,
+    val storeNameEvidence: List<String> = emptyList()
 ) {
     /**
      * Gets the typed cashback information, falling back to legacy cashbackAmount if needed.

--- a/app/src/main/kotlin/com/example/coupontracker/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/di/DatabaseModule.kt
@@ -33,7 +33,8 @@ object DatabaseModule {
                 CouponDatabase.MIGRATION_5_6,
                 CouponDatabase.MIGRATION_6_7,  // V2: Pattern learning and feedback tables
                 CouponDatabase.MIGRATION_7_8,  // Drop deprecated offerText column
-                CouponDatabase.MIGRATION_8_9
+                CouponDatabase.MIGRATION_8_9,
+                CouponDatabase.MIGRATION_9_10
             )
             .fallbackToDestructiveMigration()
             .build()

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/BrandLexicon.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/BrandLexicon.kt
@@ -1,0 +1,99 @@
+package com.example.coupontracker.extraction.validation
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.Locale
+
+/**
+ * Brand lexicon loaded from assets with tiered priority information.
+ */
+class BrandLexicon private constructor(
+    private val aliasToEntry: Map<String, Entry>,
+    private val priorityMap: Map<String, Int>,
+    val ctaStopwords: Set<String>
+) {
+    data class Entry(
+        val canonical: String,
+        val priority: Int,
+        val aliases: Set<String>
+    )
+
+    data class Match(
+        val entry: Entry,
+        val alias: String,
+        val priority: Int
+    )
+
+    fun match(value: String?): Match? {
+        if (value.isNullOrBlank()) return null
+        val normalized = normalize(value)
+        val entry = aliasToEntry[normalized] ?: return null
+        val priority = priorityMap[entry.canonical] ?: entry.priority
+        return Match(entry, normalized, priority)
+    }
+
+    companion object {
+        private const val FILE_PATH = "brand_lexicon.json"
+        private const val TAG = "BrandLexicon"
+
+        fun load(context: Context): BrandLexicon {
+            return runCatching {
+                context.assets.open(FILE_PATH).bufferedReader().use { reader ->
+                    fromJson(JSONObject(reader.readText()))
+                }
+            }.getOrElse { error ->
+                Log.w(TAG, "Unable to load brand lexicon: ${error.message}")
+                empty()
+            }
+        }
+
+        fun fromJson(json: JSONObject): BrandLexicon {
+            val aliasMap = mutableMapOf<String, Entry>()
+            val priorityMap = mutableMapOf<String, Int>()
+            val tiers = json.optJSONArray("tiers") ?: JSONArray()
+            for (tierIndex in 0 until tiers.length()) {
+                val tierObject = tiers.optJSONObject(tierIndex) ?: continue
+                val priority = tierObject.optInt("priority", tierIndex + 1)
+                val entries = tierObject.optJSONArray("entries") ?: continue
+                for (entryIndex in 0 until entries.length()) {
+                    val entryObject = entries.optJSONObject(entryIndex) ?: continue
+                    val canonical = entryObject.optString("canonical")
+                    if (canonical.isBlank()) continue
+                    val aliasSet = buildSet {
+                        add(normalize(canonical))
+                        val aliases = entryObject.optJSONArray("aliases") ?: JSONArray()
+                        for (aliasIndex in 0 until aliases.length()) {
+                            val alias = aliases.optString(aliasIndex)
+                            if (alias.isNotBlank()) {
+                                add(normalize(alias))
+                            }
+                        }
+                    }
+                    val entry = Entry(canonical = canonical, priority = priority, aliases = aliasSet)
+                    priorityMap[canonical] = priority
+                    aliasSet.forEach { token -> aliasMap[token] = entry }
+                }
+            }
+
+            val stopwords = buildSet {
+                val array = json.optJSONArray("ctaStopwords") ?: JSONArray()
+                for (index in 0 until array.length()) {
+                    val value = array.optString(index)
+                    if (value.isNotBlank()) add(value.lowercase(Locale.ROOT))
+                }
+            }
+
+            return BrandLexicon(aliasMap, priorityMap, stopwords)
+        }
+
+        fun empty(): BrandLexicon = BrandLexicon(emptyMap(), emptyMap(), emptySet())
+
+        private fun normalize(value: String): String {
+            return value.lowercase(Locale.ROOT)
+                .replace("&", "and")
+                .replace(Regex("[^a-z0-9]"), "")
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinator.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinator.kt
@@ -11,7 +11,8 @@ import java.util.Date
  */
 data class FieldValidationSummary(
     val fields: FieldValueBundle,
-    val issues: List<FieldValidationIssue>
+    val issues: List<FieldValidationIssue>,
+    val storeResolution: StoreNameResolver.Resolution
 )
 
 /**
@@ -49,7 +50,7 @@ data class FieldValidationIssue(
  */
 internal class FieldValidationCoordinator(
     private val textExtractor: TextExtractor,
-    private val storeNameValidator: StoreNameValidator = StoreNameValidator(),
+    private val storeNameResolver: StoreNameResolver,
     private val descriptionValidator: DescriptionValidator = DescriptionValidator(),
     private val expiryDateValidator: ExpiryDateValidator = ExpiryDateValidator()
 ) {
@@ -73,15 +74,15 @@ internal class FieldValidationCoordinator(
 
         var bundle = initial
 
-        val storeDecision = storeNameValidator.repair(
+        val storeResolution = storeNameResolver.resolve(
             current = bundle.storeName,
             description = bundle.description,
             redeemCode = bundle.redeemCode,
             structuredCandidates = structuredStoreCandidates,
             fallbackStore = fallbackInfo?.storeName?.takeUnless { GenericFieldHeuristics.isGenericOrMissing(it) }
         )
-        bundle = bundle.copy(storeName = storeDecision.value)
-        storeDecision.issue?.let { issues += it }
+        bundle = bundle.copy(storeName = storeResolution.value)
+        storeResolution.issue?.let { issues += it }
 
         val descriptionDecision = descriptionValidator.repair(
             current = bundle.description,
@@ -100,6 +101,6 @@ internal class FieldValidationCoordinator(
         bundle = bundle.copy(expiryDateText = expiryDecision.value)
         expiryDecision.issue?.let { issues += it }
 
-        return FieldValidationSummary(bundle, issues)
+        return FieldValidationSummary(bundle, issues, storeResolution)
     }
 }

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidators.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidators.kt
@@ -1,5 +1,6 @@
 package com.example.coupontracker.extraction.validation
 
+import android.util.Log
 import com.example.coupontracker.data.model.FieldType
 import com.example.coupontracker.extraction.FieldCandidate
 import com.example.coupontracker.util.DateParser
@@ -14,69 +15,145 @@ internal data class FieldRepairDecision(
     val issue: FieldValidationIssue? = null
 )
 
-internal class StoreNameValidator {
-    fun repair(
-        current: String?,
+internal class StoreNameValidator(
+    private val brandLexicon: BrandLexicon = BrandLexicon.empty(),
+    private val sourceLogger: (StoreSourceLog) -> Unit = {}
+) {
+    data class Signal(
+        val category: String,
+        val detail: String,
+        val tier: Int
+    )
+
+    data class Assessment(
+        val original: String?,
+        val canonical: String?,
+        val normalized: String?,
+        val signals: List<Signal>,
+        val issues: List<String>,
+        val highConfidenceCount: Int,
+        val isAccepted: Boolean,
+        val needsAttention: Boolean
+    )
+
+    data class StoreSourceLog(
+        val source: String,
+        val candidate: String?,
+        val canonical: String?,
+        val signals: List<Signal>,
+        val issues: List<String>
+    )
+
+    private val ctaStopwords: Set<String> =
+        if (brandLexicon.ctaStopwords.isEmpty()) DEFAULT_CTA_STOPWORDS else brandLexicon.ctaStopwords
+
+    fun assessCandidate(
+        value: String?,
         description: String?,
         redeemCode: String?,
-        structuredCandidates: List<FieldCandidate>,
-        fallbackStore: String?
-    ): FieldRepairDecision {
-        val normalized = current?.trim()
-        if (isValid(normalized, description, redeemCode)) {
-            return FieldRepairDecision(normalized)
+        source: String
+    ): Assessment {
+        val trimmed = value?.trim()?.takeIf { it.isNotEmpty() }
+        val signals = mutableListOf<Signal>()
+        val issues = mutableListOf<String>()
+        var canonical: String? = trimmed
+        var normalized: String? = trimmed?.lowercase(Locale.ROOT)
+
+        if (trimmed == null) {
+            val assessment = Assessment(null, null, null, emptyList(), listOf("empty"), 0, false, true)
+            logAssessment(source, assessment)
+            return assessment
         }
 
-        val structured = structuredCandidates.firstOrNull { candidate ->
-            isValid(candidate.value, description, redeemCode)
-        }
-        if (structured != null) {
-            return FieldRepairDecision(
-                value = structured.value,
-                issue = FieldValidationIssue(
-                    field = FieldType.STORE_NAME,
-                    message = "Replaced invalid store name '${normalized.orEmpty()}' with '${structured.value}'",
-                    severity = FieldValidationSeverity.ERROR,
-                    replacementSource = structured.source
-                )
-            )
+        val lower = trimmed.lowercase()
+        if (ctaStopwords.any { lower.contains(it) }) {
+            issues += "cta_stopword"
         }
 
-        val fallback = fallbackStore?.trim()
-        if (isValid(fallback, description, redeemCode)) {
-            return FieldRepairDecision(
-                value = fallback,
-                issue = FieldValidationIssue(
-                    field = FieldType.STORE_NAME,
-                    message = "Replaced invalid store name '${normalized.orEmpty()}' with fallback '$fallback'",
-                    severity = FieldValidationSeverity.ERROR,
-                    replacementSource = "text_extractor"
-                )
-            )
+        if (trimmed.length < 3) issues += "too_short"
+        if (!trimmed.any { it.isLetter() }) issues += "no_letters"
+        if (trimmed.equals("unknown", ignoreCase = true) || trimmed.equals("unknown store", ignoreCase = true)) {
+            issues += "unknown_token"
         }
 
-        return FieldRepairDecision(
-            value = normalized,
-            issue = FieldValidationIssue(
-                field = FieldType.STORE_NAME,
-                message = "Store name '${normalized.orEmpty()}' failed validation and no fallback was available",
-                severity = FieldValidationSeverity.ERROR,
-                replacementSource = null
-            )
+        if (GenericFieldHeuristics.isGenericOrMissing(trimmed)) {
+            issues += "generic"
+        } else {
+            signals += Signal("heuristic", "non_generic", tier = 3)
+        }
+
+        if (GenericFieldHeuristics.areDuplicateFields(trimmed, redeemCode)) {
+            issues += "duplicate_code"
+        }
+        if (GenericFieldHeuristics.areDuplicateFields(trimmed, description)) {
+            issues += "duplicate_description"
+        }
+
+        val brandMatch = brandLexicon.match(trimmed)
+        if (brandMatch != null) {
+            canonical = brandMatch.entry.canonical
+            normalized = brandMatch.alias
+            signals += Signal("lexicon", "alias:${brandMatch.alias}", tier = brandMatch.priority)
+        }
+
+        if (issues.isEmpty()) {
+            signals += Signal("source", "${source.lowercase()}", tier = 3)
+            if (trimmed.any { it.isUpperCase() }) {
+                signals += Signal("shape", "capitalized", tier = 4)
+            }
+        }
+
+        val uniqueCategories = signals.map { it.category }.toSet()
+        val highConfidenceCount = signals.count { it.tier <= 2 }
+        val meetsSignalThreshold = uniqueCategories.size >= 2
+        val isAccepted = issues.isEmpty() && meetsSignalThreshold
+        // @critical-invariant: require at least two independent signal categories before accepting store name.
+        val needsAttention = !isAccepted || highConfidenceCount < 2
+
+        val assessment = Assessment(
+            original = trimmed,
+            canonical = canonical,
+            normalized = normalized,
+            signals = signals,
+            issues = issues,
+            highConfidenceCount = highConfidenceCount,
+            isAccepted = isAccepted,
+            needsAttention = needsAttention
         )
+        logAssessment(source, assessment)
+        return assessment
     }
 
-    private fun isValid(value: String?, description: String?, redeemCode: String?): Boolean {
-        if (value.isNullOrBlank()) return false
-        val normalized = value.trim()
-        if (normalized.equals("unknown", ignoreCase = true)) return false
-        if (normalized.equals("unknown store", ignoreCase = true)) return false
-        if (normalized.length < 3) return false
-        if (!normalized.any { it.isLetter() }) return false
-        if (GenericFieldHeuristics.isGenericOrMissing(normalized)) return false
-        if (GenericFieldHeuristics.areDuplicateFields(normalized, redeemCode)) return false
-        if (GenericFieldHeuristics.areDuplicateFields(normalized, description)) return false
-        return true
+    private fun logAssessment(source: String, assessment: Assessment) {
+        val log = StoreSourceLog(
+            source = source,
+            candidate = assessment.original,
+            canonical = assessment.canonical,
+            signals = assessment.signals,
+            issues = assessment.issues
+        )
+        sourceLogger(log)
+        if (LOGGING_ENABLED) {
+            runCatching {
+                Log.d(
+                    TAG,
+                    "store-source=${log.source} candidate='${log.candidate}' issues=${log.issues} signals=${log.signals}"
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "StoreNameValidator"
+        private val DEFAULT_CTA_STOPWORDS = setOf(
+            "apply now",
+            "claim now",
+            "tap to claim",
+            "use coupon",
+            "copy code",
+            "redeem now"
+        )
+        private const val LOGGING_ENABLED = true
     }
 }
 

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/StoreNameResolver.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/StoreNameResolver.kt
@@ -1,0 +1,115 @@
+package com.example.coupontracker.extraction.validation
+
+import com.example.coupontracker.data.model.FieldType
+import com.example.coupontracker.extraction.FieldCandidate
+import com.example.coupontracker.util.GenericFieldHeuristics
+
+/**
+ * Resolves store name candidates using the validator and exposes provenance metadata.
+ */
+class StoreNameResolver(
+    private val validator: StoreNameValidator
+) {
+    data class Resolution(
+        val value: String?,
+        val issue: FieldValidationIssue?,
+        val source: String?,
+        val evidence: List<String>,
+        val needsAttention: Boolean
+    )
+
+    fun resolve(
+        current: String?,
+        description: String?,
+        redeemCode: String?,
+        structuredCandidates: List<FieldCandidate>,
+        fallbackStore: String?
+    ): Resolution {
+        val llmAssessment = validator.assessCandidate(current, description, redeemCode, source = "llm")
+        if (llmAssessment.isAccepted) {
+            val value = llmAssessment.canonical ?: llmAssessment.original
+            return Resolution(
+                value = value,
+                issue = null,
+                source = "llm",
+                evidence = llmAssessment.signals.map { it.detail },
+                needsAttention = llmAssessment.needsAttention
+            )
+        }
+
+        val structuredBest = structuredCandidates
+            .map { candidate ->
+                candidate to validator.assessCandidate(
+                    value = candidate.value,
+                    description = description,
+                    redeemCode = redeemCode,
+                    source = candidate.source
+                )
+            }
+            .filter { (_, assessment) -> assessment.isAccepted }
+            .maxByOrNull { (_, assessment) -> assessment.highConfidenceCount }
+
+        if (structuredBest != null) {
+            val (candidate, assessment) = structuredBest
+            val canonical = assessment.canonical ?: candidate.value
+            val issue = FieldValidationIssue(
+                field = FieldType.STORE_NAME,
+                message = "Replaced invalid store name '${llmAssessment.original.orEmpty()}' with '${canonical}'",
+                severity = FieldValidationSeverity.ERROR,
+                replacementSource = candidate.source
+            )
+            return Resolution(
+                value = canonical,
+                issue = issue,
+                source = candidate.source,
+                evidence = assessment.signals.map { it.detail },
+                needsAttention = assessment.needsAttention
+            )
+        }
+
+        val fallbackAssessment = validator.assessCandidate(
+            value = fallbackStore,
+            description = description,
+            redeemCode = redeemCode,
+            source = "text_extractor"
+        )
+
+        if (fallbackAssessment.isAccepted) {
+            val canonical = fallbackAssessment.canonical ?: fallbackStore?.trim()
+            val issue = FieldValidationIssue(
+                field = FieldType.STORE_NAME,
+                message = "Replaced invalid store name '${llmAssessment.original.orEmpty()}' with fallback '${canonical.orEmpty()}'",
+                severity = FieldValidationSeverity.ERROR,
+                replacementSource = "text_extractor"
+            )
+            return Resolution(
+                value = canonical,
+                issue = issue,
+                source = "text_extractor",
+                evidence = fallbackAssessment.signals.map { it.detail },
+                needsAttention = fallbackAssessment.needsAttention
+            )
+        }
+
+        val fallbackValue = llmAssessment.canonical ?: llmAssessment.original
+        val evidence = (llmAssessment.signals.takeIf { it.isNotEmpty() }
+            ?: fallbackAssessment.signals)
+            .map { it.detail }
+        val issue = FieldValidationIssue(
+            field = FieldType.STORE_NAME,
+            message = "Store name '${fallbackValue.orEmpty()}' failed validation and needs manual review",
+            severity = FieldValidationSeverity.ERROR,
+            replacementSource = null
+        )
+
+        val sanitized = fallbackValue?.takeUnless { GenericFieldHeuristics.isGenericOrMissing(it) }
+        return Resolution(
+            value = sanitized,
+            issue = issue,
+            source = "unresolved",
+            evidence = evidence,
+            needsAttention = true
+        )
+    }
+}
+

--- a/app/src/main/kotlin/com/example/coupontracker/ui/components/RepairNeededDialog.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/components/RepairNeededDialog.kt
@@ -1,0 +1,86 @@
+package com.example.coupontracker.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.coupontracker.data.model.Coupon
+
+@Composable
+fun RepairNeededDialog(
+    coupon: Coupon,
+    onDismiss: () -> Unit,
+    onAcknowledge: () -> Unit
+) {
+    if (!coupon.needsAttention) {
+        return
+    }
+
+    val evidence = coupon.storeNameEvidence.take(3)
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = {
+                onAcknowledge()
+                onDismiss()
+            }) {
+                Text("Acknowledge")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Later")
+            }
+        },
+        title = {
+            Text("Review store name", style = MaterialTheme.typography.titleLarge)
+        },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = "We could not fully verify the store name from the current signals.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "Detected value: ${coupon.storeName}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+
+                if (coupon.storeNameSource != null) {
+                    Text(
+                        text = "Primary source: ${coupon.storeNameSource}",
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+
+                Divider(modifier = Modifier.padding(vertical = 8.dp))
+
+                if (evidence.isEmpty()) {
+                    Text(
+                        text = "No strong signals were available.",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                } else {
+                    evidence.forEachIndexed { index, item ->
+                        Text(
+                            text = "${index + 1}. $item",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.padding(vertical = 2.dp)
+                        )
+                    }
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/ScannerScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/ScannerScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Image
 import com.example.coupontracker.ui.components.ExtractionFeedbackDialog
+import com.example.coupontracker.ui.components.RepairNeededDialog
 import com.example.coupontracker.ui.components.CorrectedCoupon
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.PhotoCamera
@@ -117,6 +118,7 @@ fun ScannerScreen(
     var capturedImageUri by remember { mutableStateOf<Uri?>(null) }
     var showFeedbackDialog by remember { mutableStateOf(false) }
     var extractedCoupon by remember { mutableStateOf<com.example.coupontracker.data.model.Coupon?>(null) }
+    var showRepairDialog by remember { mutableStateOf(false) }
 
     // Form fields
     var code by remember { mutableStateOf("") }
@@ -159,7 +161,11 @@ fun ScannerScreen(
         val currentState = uiState
         if (currentState is ScannerUiState.Success) {
             extractedCoupon = currentState.coupon
-            
+
+            if (currentState.coupon.needsAttention) {
+                showRepairDialog = true
+            }
+
             // Show feedback dialog if we can collect feedback (universal extraction was used)
             if (viewModel.canCollectFeedback()) {
                 showFeedbackDialog = true
@@ -174,6 +180,8 @@ fun ScannerScreen(
                     )
                 }
             }
+        } else {
+            showRepairDialog = false
         }
     }
 
@@ -543,6 +551,14 @@ fun ScannerScreen(
                         )
                     }
                 }
+            )
+        }
+
+        if (showRepairDialog && extractedCoupon?.needsAttention == true) {
+            RepairNeededDialog(
+                coupon = extractedCoupon!!,
+                onDismiss = { showRepairDialog = false },
+                onAcknowledge = { showRepairDialog = false }
             )
         }
     }

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
@@ -1215,21 +1215,24 @@ class BatchScannerViewModel @Inject constructor(
         val runPathSummary = runPath.final.takeIf { it.isNotBlank() }?.let { final ->
             "${runPath.strategy} → $final"
         }
-        return Coupon(
-            id = 0,
-            storeName = couponInfo.storeName,
-            description = couponInfo.description,
-            cashbackAmount = couponInfo.cashbackAmount ?: 0.0,
-            cashbackType = couponInfo.discountType ?: "",
-            expiryDate = couponInfo.expiryDate,
-            redeemCode = couponInfo.redeemCode,
-            imageUri = uri.toString(),
-            status = "Active",
-            extractionQualityScore = signals.qualityScore,
-            extractionConfidenceBreakdown = signals.fieldConfidences,
-            extractionStage = signals.stage.name,
-            extractionRunPath = runPathSummary,
-            extractionTimestamp = java.util.Date(),
+            return Coupon(
+                id = 0,
+                storeName = couponInfo.storeName,
+                description = couponInfo.description,
+                cashbackAmount = couponInfo.cashbackAmount ?: 0.0,
+                cashbackType = couponInfo.discountType ?: "",
+                expiryDate = couponInfo.expiryDate,
+                redeemCode = couponInfo.redeemCode,
+                imageUri = uri.toString(),
+                status = "Active",
+                needsAttention = couponInfo.needsAttention,
+                storeNameSource = couponInfo.storeNameSource,
+                storeNameEvidence = couponInfo.storeNameEvidence,
+                extractionQualityScore = signals.qualityScore,
+                extractionConfidenceBreakdown = signals.fieldConfidences,
+                extractionStage = signals.stage.name,
+                extractionRunPath = runPathSummary,
+                extractionTimestamp = java.util.Date(),
             createdAt = java.util.Date(),
             updatedAt = java.util.Date()
         )

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -488,7 +488,10 @@ class ScannerViewModel @Inject constructor(
             updatedAt = Date(),
             cashbackType = cashbackInfo.type.name.lowercase(),
             cashbackValueNum = cashbackInfo.valueNum,
-            cashbackCurrency = cashbackInfo.currency
+            cashbackCurrency = cashbackInfo.currency,
+            needsAttention = couponInfo.needsAttention,
+            storeNameSource = couponInfo.storeNameSource,
+            storeNameEvidence = couponInfo.storeNameEvidence
         )
     }
     

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -7,9 +7,12 @@ import com.example.coupontracker.data.model.FieldType
 import com.example.coupontracker.extraction.ExtractionContext
 import com.example.coupontracker.extraction.FieldCandidate
 import com.example.coupontracker.extraction.StructuredFieldExtractor
+import com.example.coupontracker.extraction.validation.BrandLexicon
 import com.example.coupontracker.extraction.validation.FieldValidationCoordinator
 import com.example.coupontracker.extraction.validation.FieldValidationIssue
 import com.example.coupontracker.extraction.validation.FieldValueBundle
+import com.example.coupontracker.extraction.validation.StoreNameResolver
+import com.example.coupontracker.extraction.validation.StoreNameValidator
 import com.example.coupontracker.llm.LlmRuntimeManager
 import com.example.coupontracker.llm.LlmTelemetryService
 import com.example.coupontracker.ocr.OcrEngine
@@ -135,7 +138,18 @@ class LocalLlmOcrService(
     private val imagePreprocessor = ImagePreprocessor()
     private val textExtractor = TextExtractor() // Fallback
     private val structuredFieldExtractor = StructuredFieldExtractor()
-    private val fieldValidationCoordinator = FieldValidationCoordinator(textExtractor)
+    private val brandLexicon = BrandLexicon.load(context)
+    private val storeNameResolver = StoreNameResolver(
+        StoreNameValidator(brandLexicon) { log ->
+            runCatching {
+                Log.d(
+                    TAG,
+                    "store-source=${log.source} candidate='${log.candidate}' issues=${log.issues}"
+                )
+            }
+        }
+    )
+    private val fieldValidationCoordinator = FieldValidationCoordinator(textExtractor, storeNameResolver)
     private var modelPinned = false
     
     init {
@@ -745,7 +759,8 @@ $sanitizedOcr
                 Log.w(TAG, "Field validation ${issue.severity} for ${issue.field}: ${issue.message}$sourceInfo")
             }
 
-            val candidateStoreName = validationSummary.fields.storeName?.trim()
+            val storeResolution = validationSummary.storeResolution
+            val candidateStoreName = storeResolution.value?.trim()
             val candidateDescription = validationSummary.fields.description
             val candidateCode = validationSummary.fields.redeemCode
             val candidateExpiry = validationSummary.fields.expiryDateText
@@ -780,6 +795,10 @@ $sanitizedOcr
             val finalStoreName = finalStoreCandidate?.takeIf {
                 it.isNotBlank() && !GenericFieldHeuristics.isGenericOrMissing(it)
             } ?: "Unknown Store"
+
+            val storeNeedsAttention = storeResolution.needsAttention || finalStoreName == "Unknown Store"
+            val storeEvidence = storeResolution.evidence
+            val storeSource = storeResolution.source
 
             // Parse expiry date with enhanced pattern matching
             val parsedExpiryDate = candidateExpiry?.let { dateStr ->
@@ -832,6 +851,9 @@ $sanitizedOcr
                 expiryDate = resolvedExpiry,
                 cashbackAmount = null,
                 redeemCode = finalCode,
+                needsAttention = storeNeedsAttention,
+                storeNameSource = storeSource,
+                storeNameEvidence = storeEvidence,
                 minimumPurchase = null,
                 discountType = null
             )

--- a/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
@@ -23,6 +23,11 @@ data class CouponInfo(
     val status: String? = null,
     val discountType: String? = null, // "PERCENTAGE" or "AMOUNT"
 
+    // Provenance metadata
+    val needsAttention: Boolean = false,
+    val storeNameSource: String? = null,
+    val storeNameEvidence: List<String> = emptyList(),
+
     // New fields
     val minimumPurchase: Double? = null,
     val maximumDiscount: Double? = null,

--- a/app/src/test/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinatorTest.kt
@@ -13,7 +13,8 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class FieldValidationCoordinatorTest {
     private val textExtractor = TextExtractor()
-    private val coordinator = FieldValidationCoordinator(textExtractor)
+    private val storeNameResolver = StoreNameResolver(StoreNameValidator())
+    private val coordinator = FieldValidationCoordinator(textExtractor, storeNameResolver)
 
     @Test
     fun `refine replaces invalid store with structured candidate`() {
@@ -35,6 +36,7 @@ class FieldValidationCoordinatorTest {
         )
 
         assertEquals("Myntra", summary.fields.storeName)
+        assertEquals("Myntra", summary.storeResolution.value)
         assertTrue(summary.issues.any { it.field == FieldType.STORE_NAME })
     }
 


### PR DESCRIPTION
## Summary
- load a tiered brand lexicon with CTA stopwords and wire it into the store name validator
- add a provenance-aware store resolver that feeds LocalLlmOcrService and persists source/evidence metadata
- surface a repair-needed dialog for attention-required coupons and extend the Room schema to store attention flags

## Testing
- `./gradlew testDebugUnitTest` *(fails: Android SDK location not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68f336695288832886295112d23ce9e2