### PR TITLE
Add validator regression tests and CI guardrails

### DIFF
--- a/.github/workflows/validator-tests.yml
+++ b/.github/workflows/validator-tests.yml
@@ -1,0 +1,35 @@
+name: Validator Test Suite
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run validator test suite
+        run: ./gradlew test --stacktrace

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,13 @@ android {
         jvmTarget = "17"
     }
 
+    sourceSets {
+        getByName("test") {
+            java.srcDir("tests")
+            resources.srcDir("tests/fixtures")
+        }
+    }
+
     kapt {
         correctErrorTypes = true
     }

--- a/tests/common/TestBrandLexicon.kt
+++ b/tests/common/TestBrandLexicon.kt
@@ -1,0 +1,40 @@
+package com.example.coupontracker.extraction.validation
+
+import org.json.JSONObject
+
+internal object TestBrandLexicon {
+    fun create(): BrandLexicon {
+        val json = JSONObject(
+            """
+            {
+              "tiers": [
+                {
+                  "priority": 1,
+                  "entries": [
+                    {"canonical": "Myntra", "aliases": ["Myntra", "MYNTRA"]},
+                    {"canonical": "Nykaa", "aliases": ["Nykaa", "NYKAA"]},
+                    {"canonical": "boAt", "aliases": ["boAt", "Boat", "BOAT"]}
+                  ]
+                },
+                {
+                  "priority": 2,
+                  "entries": [
+                    {"canonical": "Amazon", "aliases": ["Amazon", "Amazon.in"]},
+                    {"canonical": "Flipkart", "aliases": ["Flipkart"]}
+                  ]
+                }
+              ],
+              "ctaStopwords": [
+                "shop now",
+                "tap to claim",
+                "claim now",
+                "redeem now",
+                "copy code",
+                "apply now"
+              ]
+            }
+            """.trimIndent()
+        )
+        return BrandLexicon.fromJson(json)
+    }
+}

--- a/tests/fixtures/brand_golden_set/dataset.json
+++ b/tests/fixtures/brand_golden_set/dataset.json
@@ -1,0 +1,61 @@
+[
+  {
+    "id": "banner_shop_now",
+    "type": "cta",
+    "source": "banner",
+    "value": "Shop Now",
+    "description": "Shop Now and get rewards",
+    "redeemCode": "SHOP100"
+  },
+  {
+    "id": "email_tap_to_claim",
+    "type": "cta",
+    "source": "email",
+    "value": "Tap to Claim",
+    "description": "Tap to claim your exclusive reward",
+    "redeemCode": "CLAIM50"
+  },
+  {
+    "id": "screenshot_claim_now_caps",
+    "type": "cta",
+    "source": "screenshot",
+    "value": "CLAIM NOW",
+    "description": "CLAIM NOW before it expires",
+    "redeemCode": "FAST10"
+  },
+  {
+    "id": "banner_copy_code",
+    "type": "cta",
+    "source": "banner",
+    "value": "Copy Code",
+    "description": "Copy code to use at checkout",
+    "redeemCode": "CODE11"
+  },
+  {
+    "id": "screenshot_myntra",
+    "type": "brand",
+    "source": "screenshot",
+    "value": "MYNTRA",
+    "description": "MYNTRA Big Fashion Days",
+    "redeemCode": "MYNTRA20",
+    "expectedCanonical": "Myntra"
+  },
+  {
+    "id": "email_boat",
+    "type": "brand",
+    "source": "email",
+    "value": "boAt",
+    "description": "boAt audio fest",
+    "redeemCode": "BOAT25",
+    "expectedCanonical": "boAt"
+  },
+  {
+    "id": "banner_nykaa_alias",
+    "type": "brand",
+    "source": "banner",
+    "value": "NYKAA",
+    "description": "Nykaa Pink Friday Sale",
+    "redeemCode": "NYKAA100",
+    "expectedCanonical": "Nykaa"
+  }
+]

--- a/tests/fuzz/StoreNameFuzzTest.kt
+++ b/tests/fuzz/StoreNameFuzzTest.kt
@@ -1,0 +1,56 @@
+package com.example.coupontracker.extraction.validation
+
+import kotlin.random.Random
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StoreNameFuzzTest {
+    private val validator = StoreNameValidator(TestBrandLexicon.create())
+    private val random = Random(20240519)
+
+    @Test
+    fun `cta adjacent tokens never slip past validation`() {
+        val ctaTokens = listOf(
+            "shop now",
+            "tap to claim",
+            "claim now",
+            "redeem now",
+            "copy code",
+            "apply now"
+        )
+
+        repeat(500) {
+            val prefix = randomNoise()
+            val suffix = randomNoise()
+            val token = ctaTokens[random.nextInt(ctaTokens.size)]
+            val candidate = listOf(prefix, token, suffix)
+                .filter { it.isNotBlank() }
+                .joinToString(separator = " ")
+                .trim()
+
+            val assessment = validator.assessCandidate(
+                value = candidate,
+                description = "${candidate} limited offer",
+                redeemCode = suffix.uppercase(),
+                source = if (it % 2 == 0) "ocr" else "structured"
+            )
+
+            assertFalse("$candidate should never be accepted", assessment.isAccepted)
+            assertTrue(
+                "CTA infused string must either be flagged or need attention",
+                assessment.issues.contains("cta_stopword") || assessment.needsAttention
+            )
+        }
+    }
+
+    private fun randomNoise(): String {
+        val length = random.nextInt(0, 6)
+        if (length == 0) return ""
+        val chars = CharArray(length) {
+            val choice = random.nextInt(0, 26)
+            ('a' + choice)
+        }
+        return String(chars)
+    }
+}

--- a/tests/golden/BrandGoldenSetTest.kt
+++ b/tests/golden/BrandGoldenSetTest.kt
@@ -1,0 +1,96 @@
+package com.example.coupontracker.extraction.validation
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import org.json.JSONArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BrandGoldenSetTest {
+    private val validator = StoreNameValidator(TestBrandLexicon.create())
+
+    data class Fixture(
+        val id: String,
+        val type: String,
+        val source: String,
+        val value: String,
+        val description: String?,
+        val redeemCode: String?,
+        val expectedCanonical: String?
+    )
+
+    @Test
+    fun `golden set prevents CTA strings from becoming brands`() {
+        val fixtures = loadFixtures().filter { it.type == "cta" }
+        assertTrue("The golden dataset must include CTA fixtures", fixtures.isNotEmpty())
+
+        fixtures.forEach { fixture ->
+            val assessment = validator.assessCandidate(
+                value = fixture.value,
+                description = fixture.description,
+                redeemCode = fixture.redeemCode,
+                source = fixture.source
+            )
+
+            assertFalse("${fixture.id} should never be accepted", assessment.isAccepted)
+            assertTrue(
+                "${fixture.id} should always expose the CTA issue",
+                assessment.issues.contains("cta_stopword")
+            )
+            assertTrue("${fixture.id} should always need operator review", assessment.needsAttention)
+        }
+    }
+
+    @Test
+    fun `golden set maintains canonical mapping for trusted brands`() {
+        val fixtures = loadFixtures().filter { it.type == "brand" }
+        assertTrue("The golden dataset must include brand fixtures", fixtures.isNotEmpty())
+
+        fixtures.forEach { fixture ->
+            val assessment = validator.assessCandidate(
+                value = fixture.value,
+                description = fixture.description,
+                redeemCode = fixture.redeemCode,
+                source = fixture.source
+            )
+
+            assertTrue("${fixture.id} expected to be accepted", assessment.isAccepted)
+            val canonical = assessment.canonical
+            assertNotNull("${fixture.id} should carry a canonical name", canonical)
+            assertEquals(fixture.expectedCanonical, canonical)
+        }
+    }
+
+    private fun loadFixtures(): List<Fixture> {
+        val resource = requireNotNull(
+            javaClass.classLoader?.getResource("brand_golden_set/dataset.json")
+        ) { "brand_golden_set/dataset.json missing from test resources" }
+        val text = resource.openStream().use { stream ->
+            BufferedReader(InputStreamReader(stream)).use { reader -> reader.readText() }
+        }
+        val array = JSONArray(text)
+        return buildList {
+            for (index in 0 until array.length()) {
+                val obj = array.getJSONObject(index)
+                add(
+                    Fixture(
+                        id = obj.getString("id"),
+                        type = obj.getString("type"),
+                        source = obj.getString("source"),
+                        value = obj.getString("value"),
+                        description = obj.optString("description", null),
+                        redeemCode = obj.optString("redeemCode", null),
+                        expectedCanonical = if (obj.has("expectedCanonical")) {
+                            obj.getString("expectedCanonical")
+                        } else {
+                            null
+                        }
+                    )
+                )
+            }
+        }
+    }
+}

--- a/tests/validators/StoreNameValidatorTest.kt
+++ b/tests/validators/StoreNameValidatorTest.kt
@@ -1,0 +1,112 @@
+package com.example.coupontracker.extraction.validation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StoreNameValidatorTest {
+    private val validator = StoreNameValidator(TestBrandLexicon.create())
+
+    @Test
+    fun `cta stopwords are rejected even when surrounded by noise`() {
+        val assessment = validator.assessCandidate(
+            value = "*** Shop Now ***",
+            description = "Shop now for festival deals",
+            redeemCode = "FEST100",
+            source = "ocr"
+        )
+
+        assertTrue(assessment.issues.contains("cta_stopword"))
+        assertFalse("CTA heavy candidates must never be accepted", assessment.isAccepted)
+        assertTrue("CTA heavy candidates should always need attention", assessment.needsAttention)
+    }
+
+    @Test
+    fun `lexicon backed brands earn acceptance through multiple signals`() {
+        val assessment = validator.assessCandidate(
+            value = "Myntra",
+            description = "Myntra End of Reason Sale",
+            redeemCode = "MYNTRA20",
+            source = "structured"
+        )
+
+        assertTrue("Known brands should be accepted", assessment.isAccepted)
+        assertEquals("Myntra", assessment.canonical)
+        val categories = assessment.signals.map { it.category }.toSet()
+        assertTrue("Expected lexicon signal", categories.contains("lexicon"))
+        assertTrue("Expected heuristic signal", categories.contains("heuristic"))
+        assertTrue("Expected structured source signal", categories.contains("source"))
+        assertTrue("Accepted brands still need a second high confidence signal", assessment.needsAttention)
+        assertEquals(1, assessment.highConfidenceCount)
+    }
+
+    @Test
+    fun `duplicate fields raise cross domain issues`() {
+        val assessment = validator.assessCandidate(
+            value = "SAVE20",
+            description = "SAVE20",
+            redeemCode = "SAVE20",
+            source = "ocr"
+        )
+
+        assertTrue(assessment.issues.contains("duplicate_code"))
+        assertTrue(assessment.issues.contains("duplicate_description"))
+        assertFalse("Duplicate tokens cannot be accepted", assessment.isAccepted)
+    }
+
+    @Test
+    fun `null or blank store names always require attention`() {
+        val blankAssessment = validator.assessCandidate(
+            value = "   ",
+            description = "Seasonal offer",
+            redeemCode = "FALL50",
+            source = "ocr"
+        )
+        assertTrue(blankAssessment.issues.contains("empty"))
+        assertFalse(blankAssessment.isAccepted)
+        assertTrue(blankAssessment.needsAttention)
+        assertEquals(null, blankAssessment.original)
+
+        val nullAssessment = validator.assessCandidate(
+            value = null,
+            description = "Mega Sale",
+            redeemCode = "SALE50",
+            source = "structured"
+        )
+        assertTrue(nullAssessment.issues.contains("empty"))
+        assertFalse(nullAssessment.isAccepted)
+        assertTrue(nullAssessment.needsAttention)
+    }
+
+    @Test
+    fun `single signal fallbacks never pass acceptance gate`() {
+        val assessment = validator.assessCandidate(
+            value = "Shop",
+            description = "Daily shop deals",
+            redeemCode = "SHOP2024",
+            source = "ocr"
+        )
+
+        assertTrue("Generic labels should be flagged", assessment.issues.contains("generic"))
+        assertFalse("Generic fallback must not be accepted", assessment.isAccepted)
+    }
+
+    @Test
+    fun `accepted assessments always include the original token`() {
+        val assessment = validator.assessCandidate(
+            value = "Nykaa",
+            description = "Nykaa Pink Friday Deals",
+            redeemCode = "NYKAA100",
+            source = "structured"
+        )
+
+        assertTrue(assessment.isAccepted)
+        assertNotNull("Accepted assessments should preserve the original candidate", assessment.original)
+        assertTrue(
+            "If this test fails the validator started allowing optional store names",
+            assessment.original!!.isNotBlank()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated StoreNameValidator unit coverage including CTA exclusions, cross-field duplicates, and contract invariants
- introduce property-based fuzzing and a golden dataset suite to guard CTA-as-brand regressions
- wire new validator-focused tests into Gradle and configure CI to run them on every pull request

## Testing
- `./gradlew test` *(fails: requires Android Build Tools/NDK artifacts that are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f36691ad5c832889ab2fff9a726f98