### PR TITLE
Add AI guardrail automation and store-name telemetry

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/ai_guardrails.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ai_guardrails.md
@@ -1,0 +1,16 @@
+## Summary
+- [ ] Explain the change clearly and why it is necessary.
+
+## Guardrails Checklist
+- [ ] Ran `python scripts/check_ai_invariants.py`
+- [ ] CTA stop-word diff reviewed and approved by guardrail owner
+- [ ] Validator, fuzz, and golden tests all pass locally
+- [ ] Confirmed provenance metadata is preserved for new field candidates
+- [ ] Documented any prompt template updates in release notes
+
+## Mini-ADR (200-400 characters)
+Provide a concise decision record covering the problem, chosen approach, and risk mitigations. Keep it between 200 and 400 characters.
+
+## Testing
+- [ ] Added or updated automated tests as needed
+- [ ] Manually verified critical flows when applicable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI Guardrails
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  guardrails:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run AI invariant validator
+        run: python scripts/check_ai_invariants.py --allow-empty
+
+      - name: Run validator tests
+        run: pytest tests/test_store_detection.py
+
+      - name: Run fuzz regression tests
+        run: pytest tests/fuzz -q
+
+      - name: Run golden corpus tests
+        run: pytest tests/golden -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.6
+    hooks:
+      - id: ruff
+        args: ["--select", "E,F"]
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: check-ai-invariants
+        name: check-ai-invariants
+        entry: python3 scripts/check_ai_invariants.py
+        language: system
+        pass_filenames: false
+        stages: [commit, push]

--- a/app/src/main/assets/prompt_templates/coupon_extraction_prompt.txt
+++ b/app/src/main/assets/prompt_templates/coupon_extraction_prompt.txt
@@ -1,0 +1,24 @@
+You are the on-device coupon extraction model. Produce STRICT JSON only.
+
+Hard requirements:
+- Preserve provenance: include storeNameEvidence, storeNameSource, and needsAttention flags exactly as received.
+- Do not invent values. If uncertain return "Unknown".
+- Honor CTA guardrails: never promote CTA phrases like "Shop Now" or "Claim" to store names.
+- Mirror rule: every evidence snippet you output MUST mirror the exact characters from the OCR text without paraphrasing.
+- Respect formatting: dates as DD/MM/YYYY, amounts include currency symbols, codes retain case.
+
+JSON schema to emit:
+{
+  "storeName": string,
+  "description": string,
+  "amount": string,
+  "code": string,
+  "expiryDate": string,
+  "cashbackAmount": string,
+  "minOrderAmount": string,
+  "storeNameSource": string,
+  "storeNameEvidence": [string],
+  "needsAttention": boolean
+}
+
+If a field is missing, return "Unknown" (or []/false for arrays/booleans). No additional commentary.

--- a/app/src/main/kotlin/com/example/coupontracker/CouponTrackerApplication.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/CouponTrackerApplication.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import androidx.work.WorkManager
+import com.example.coupontracker.analytics.StoreNameMetricsTracker
 import com.example.coupontracker.worker.ReminderWorker
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
@@ -41,6 +42,9 @@ class CouponTrackerApplication : Application(), Configuration.Provider {
 
     private fun initializeWorkers() {
         try {
+            // Initialize AI telemetry guardrails
+            StoreNameMetricsTracker.initialize(this)
+
             // Schedule daily reminder checks
             ReminderWorker.scheduleDaily(WorkManager.getInstance(this))
             Log.d("CouponTracker", "Scheduled reminder worker")

--- a/app/src/main/kotlin/com/example/coupontracker/analytics/StoreNameMetricsTracker.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/analytics/StoreNameMetricsTracker.kt
@@ -1,0 +1,222 @@
+package com.example.coupontracker.analytics
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.example.coupontracker.extraction.validation.StoreNameValidator
+import com.example.coupontracker.util.SecurePreferencesManager
+import com.example.coupontracker.worker.StoreNameEvidenceWorker
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import kotlin.math.max
+import org.json.JSONArray
+import org.json.JSONObject
+
+object StoreNameMetricsTracker {
+    private const val TAG = "StoreNameMetrics"
+    private const val PREFS_NAME = "store_name_metrics"
+    private const val KEY_TOTAL = "total_assessments"
+    private const val KEY_MULTI_SIGNAL = "multi_signal"
+    private const val KEY_HEURISTIC_ONLY = "heuristic_only"
+    private const val KEY_NEEDS_ATTENTION = "needs_attention"
+    private const val KEY_CTA_FALSE = "cta_false_positive"
+    private const val KEY_PENDING = "pending_provenance"
+    private const val SECURE_KEY_PROVENANCE = "store_name_provenance_samples"
+    private const val MAX_PENDING = 200
+    private const val MAX_SECURE = 200
+    private const val PROVENANCE_SAMPLE_RATE = 0.01
+    private const val WORK_NAME = "store_name_provenance_sampling"
+
+    private val lock = Any()
+    private var initialized = false
+    private var jobScheduled = false
+    private lateinit var appContext: Context
+    private lateinit var prefs: SharedPreferences
+    private lateinit var securePrefs: SecurePreferencesManager
+    private val random = java.util.Random()
+
+    fun initialize(context: Context) {
+        if (initialized) return
+        synchronized(lock) {
+            if (initialized) return
+            appContext = context.applicationContext
+            prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            securePrefs = SecurePreferencesManager(appContext).apply { initialize() }
+            scheduleEvidenceSampling(appContext)
+            initialized = true
+        }
+    }
+
+    fun recordAssessment(source: String, assessment: StoreNameValidator.Assessment) {
+        if (!initialized) {
+            Log.w(TAG, "recordAssessment called before initialization")
+            return
+        }
+        synchronized(lock) {
+            val total = prefs.getInt(KEY_TOTAL, 0) + 1
+            val uniqueCategories = assessment.signals.map { it.category }.toSet()
+            val multiSignalIncrement = if (uniqueCategories.size >= 2) 1 else 0
+            val heuristicOnlyIncrement = if (
+                uniqueCategories.size == 1 && uniqueCategories.firstOrNull() == "heuristic"
+            ) 1 else 0
+            val needsAttentionIncrement = if (assessment.needsAttention) 1 else 0
+            val ctaIncrement = if (assessment.issues.any { it.contains("cta_stopword") }) 1 else 0
+
+            prefs.edit()
+                .putInt(KEY_TOTAL, total)
+                .putInt(KEY_MULTI_SIGNAL, prefs.getInt(KEY_MULTI_SIGNAL, 0) + multiSignalIncrement)
+                .putInt(KEY_HEURISTIC_ONLY, prefs.getInt(KEY_HEURISTIC_ONLY, 0) + heuristicOnlyIncrement)
+                .putInt(KEY_NEEDS_ATTENTION, prefs.getInt(KEY_NEEDS_ATTENTION, 0) + needsAttentionIncrement)
+                .putInt(KEY_CTA_FALSE, prefs.getInt(KEY_CTA_FALSE, 0) + ctaIncrement)
+                .apply()
+
+            if (ctaIncrement > 0) {
+                Log.w(TAG, "CTA stop-word triggered for source=$source value=${assessment.original}")
+            }
+
+            emitPercentages(total)
+            enqueuePendingEvidence(source, assessment)
+        }
+    }
+
+    fun recordCtaFalsePositive(source: String, candidate: String?) {
+        if (!initialized) return
+        synchronized(lock) {
+            val total = prefs.getInt(KEY_TOTAL, 0)
+            prefs.edit()
+                .putInt(KEY_CTA_FALSE, prefs.getInt(KEY_CTA_FALSE, 0) + 1)
+                .apply()
+            Log.w(TAG, "CTA false positive recorded for source=$source candidate=$candidate (total assessments=$total)")
+        }
+    }
+
+    private fun emitPercentages(total: Int) {
+        if (total == 0) return
+        val multi = prefs.getInt(KEY_MULTI_SIGNAL, 0)
+        val heuristicOnly = prefs.getInt(KEY_HEURISTIC_ONLY, 0)
+        val needsAttention = prefs.getInt(KEY_NEEDS_ATTENTION, 0)
+        val cta = prefs.getInt(KEY_CTA_FALSE, 0)
+
+        val multiPct = 100f * multi / total
+        val heuristicPct = 100f * heuristicOnly / total
+        val needsPct = 100f * needsAttention / total
+
+        Log.i(
+            TAG,
+            String.format(
+                Locale.US,
+                "store-metrics total=%d multi=%.1f%% heuristic_only=%.1f%% needs_attention=%.1f%% cta_false=%d",
+                total,
+                multiPct,
+                heuristicPct,
+                needsPct,
+                cta
+            )
+        )
+    }
+
+    private fun enqueuePendingEvidence(source: String, assessment: StoreNameValidator.Assessment) {
+        if (random.nextDouble() >= PROVENANCE_SAMPLE_RATE) {
+            return
+        }
+        try {
+            val pendingRaw = prefs.getString(KEY_PENDING, "[]") ?: "[]"
+            val pendingArray = JSONArray(pendingRaw)
+            val entry = JSONObject().apply {
+                put("timestamp", System.currentTimeMillis())
+                put("source", source)
+                put("original", assessment.original)
+                put("canonical", assessment.canonical)
+                put("normalized", assessment.normalized)
+                put(
+                    "signals",
+                    JSONArray().apply {
+                        assessment.signals.forEach { signal ->
+                            put(
+                                JSONObject().apply {
+                                    put("category", signal.category)
+                                    put("detail", signal.detail)
+                                    put("tier", signal.tier)
+                                }
+                            )
+                        }
+                    }
+                )
+                put("issues", JSONArray(assessment.issues))
+                put("needsAttention", assessment.needsAttention)
+            }
+            pendingArray.put(entry)
+
+            val trimmed = JSONArray()
+            val start = max(0, pendingArray.length() - MAX_PENDING)
+            for (i in start until pendingArray.length()) {
+                trimmed.put(pendingArray.get(i))
+            }
+
+            prefs.edit().putString(KEY_PENDING, trimmed.toString()).apply()
+        } catch (t: Throwable) {
+            Log.e(TAG, "Failed to enqueue provenance evidence", t)
+        }
+    }
+
+    fun scheduleEvidenceSampling(context: Context) {
+        synchronized(lock) {
+            if (jobScheduled) return
+            val request = PeriodicWorkRequestBuilder<StoreNameEvidenceWorker>(24, TimeUnit.HOURS)
+                .build()
+            WorkManager.getInstance(context.applicationContext).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request
+            )
+            jobScheduled = true
+        }
+    }
+
+    fun samplePendingEvidence() {
+        if (!initialized) return
+        synchronized(lock) {
+            val pendingRaw = prefs.getString(KEY_PENDING, "[]") ?: "[]"
+            val pendingArray = JSONArray(pendingRaw)
+            if (pendingArray.length() == 0) {
+                return
+            }
+
+            val sampleSize = max(1, (pendingArray.length() * PROVENANCE_SAMPLE_RATE).toInt())
+            val indices = (0 until pendingArray.length()).shuffled(random).take(sampleSize).sorted()
+            val selected = JSONArray()
+            indices.forEach { index ->
+                selected.put(pendingArray.get(index))
+            }
+
+            val existingRaw = securePrefs.getString(SECURE_KEY_PROVENANCE, "[]") ?: "[]"
+            val secureArray = JSONArray(existingRaw)
+            for (i in 0 until selected.length()) {
+                secureArray.put(selected.get(i))
+            }
+
+            val trimmed = JSONArray()
+            val start = max(0, secureArray.length() - MAX_SECURE)
+            for (i in start until secureArray.length()) {
+                trimmed.put(secureArray.get(i))
+            }
+            securePrefs.saveString(SECURE_KEY_PROVENANCE, trimmed.toString())
+
+            val remaining = JSONArray()
+            var pointer = 0
+            for (i in 0 until pendingArray.length()) {
+                if (pointer < indices.size && indices[pointer] == i) {
+                    pointer += 1
+                } else {
+                    remaining.put(pendingArray.get(i))
+                }
+            }
+            prefs.edit().putString(KEY_PENDING, remaining.toString()).apply()
+
+            Log.i(TAG, "Sampled ${selected.length()} provenance records into secure storage")
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidators.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidators.kt
@@ -1,6 +1,7 @@
 package com.example.coupontracker.extraction.validation
 
 import android.util.Log
+import com.example.coupontracker.analytics.StoreNameMetricsTracker
 import com.example.coupontracker.data.model.FieldType
 import com.example.coupontracker.extraction.FieldCandidate
 import com.example.coupontracker.util.DateParser
@@ -120,6 +121,7 @@ internal class StoreNameValidator(
             isAccepted = isAccepted,
             needsAttention = needsAttention
         )
+        StoreNameMetricsTracker.recordAssessment(source, assessment)
         logAssessment(source, assessment)
         return assessment
     }

--- a/app/src/main/kotlin/com/example/coupontracker/worker/StoreNameEvidenceWorker.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/worker/StoreNameEvidenceWorker.kt
@@ -1,0 +1,32 @@
+package com.example.coupontracker.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.example.coupontracker.analytics.StoreNameMetricsTracker
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class StoreNameEvidenceWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            StoreNameMetricsTracker.initialize(applicationContext)
+            StoreNameMetricsTracker.samplePendingEvidence()
+            Result.success()
+        } catch (t: Throwable) {
+            Log.e(TAG, "Failed to sample provenance evidence", t)
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val TAG = "StoreNameEvidenceWkr"
+    }
+}

--- a/scripts/check_ai_invariants.py
+++ b/scripts/check_ai_invariants.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Guardrail checks for AI-related diffs.
+
+This script is intended to run in pre-commit and CI contexts. It inspects the
+staged diff to detect changes that could weaken safety guardrails around store
+name validation, CTA stop-word filtering, or provenance tracking. If a
+potentially dangerous change is detected the script prints a descriptive error
+message and exits with a non-zero status so the change cannot be merged by
+mistake.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Set
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CTA_FILE = Path(
+    "app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidators.kt"
+)
+FIELD_CANDIDATE_PATTERN = re.compile(r"FieldCandidate\s*\(([^)]*)\)", re.DOTALL)
+
+
+class GuardrailViolation(RuntimeError):
+    """Custom exception used for early exits."""
+
+
+@dataclass
+class DiffFile:
+    path: Path
+    diff_text: str
+
+
+_DIFF_HEADER_RE = re.compile(r"^diff --git a/(.*?) b/(.*?)$", re.MULTILINE)
+def run_git_command(args: Sequence[str]) -> str:
+    result = subprocess.run(args, cwd=REPO_ROOT, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to run {' '.join(args)}: {result.stderr.strip() or result.stdout.strip()}"
+        )
+    return result.stdout
+
+
+def load_staged_diff() -> List[DiffFile]:
+    diff_output = run_git_command(["git", "diff", "--cached", "--no-color"])
+    if not diff_output.strip():
+        return []
+
+    files: List[DiffFile] = []
+    for match in _DIFF_HEADER_RE.finditer(diff_output):
+        start = match.start()
+        end = diff_output.find("diff --git", start + 1)
+        if end == -1:
+            end = len(diff_output)
+        block = diff_output[start:end]
+        path = Path(match.group(2))
+        files.append(DiffFile(path=path, diff_text=block))
+    return files
+
+
+def parse_cta_stopwords(text: str) -> Set[str]:
+    match = re.search(r"DEFAULT_CTA_STOPWORDS\s*=\s*setOf\((.*?)\)", text, re.DOTALL)
+    if not match:
+        return set()
+    body = match.group(1)
+    entries = []
+    for line in body.splitlines():
+        line = line.strip().strip(",")
+        if not line:
+            continue
+        entry = line.strip().strip("\"")
+        if entry:
+            entries.append(entry.lower())
+    return set(entries)
+
+
+def check_cta_stopwords() -> None:
+    if not CTA_FILE.exists():
+        return
+
+    status_output = run_git_command(["git", "diff", "--cached", "--name-only", "--", str(CTA_FILE)])
+    if not status_output.strip():
+        return
+
+    try:
+        old_text = run_git_command(["git", "show", f"HEAD:{CTA_FILE.as_posix()}"])
+    except RuntimeError:
+        old_text = ""
+    try:
+        new_text = run_git_command(["git", "show", f":{CTA_FILE.as_posix()}"])
+    except RuntimeError as exc:  # pragma: no cover - staged deletion or rename
+        raise GuardrailViolation(
+            "AI guardrail violation: unable to read staged version of FieldValidators.kt"
+        ) from exc
+
+    old_words = parse_cta_stopwords(old_text)
+    new_words = parse_cta_stopwords(new_text)
+
+    if old_words and not new_words:
+        raise GuardrailViolation(
+            "AI guardrail violation: CTA stop-word set missing in staged changes."
+        )
+
+    if len(new_words) < len(old_words):
+        removed = ", ".join(sorted(old_words - new_words)) or "(unknown)"
+        raise GuardrailViolation(
+            "AI guardrail violation: CTA stop-word list shrank. Removed entries: " + removed
+        )
+
+
+def check_critical_invariants(diff_files: Sequence[DiffFile]) -> None:
+    for diff in diff_files:
+        for line in diff.diff_text.splitlines():
+            if line.startswith("-") and "@critical-invariant" in line:
+                raise GuardrailViolation(
+                    "AI guardrail violation: modifications removed @critical-invariant commentary."
+                )
+
+
+def check_validator_relaxations(diff_files: Sequence[DiffFile]) -> None:
+    risky_tokens = (
+        "issues +=",
+        "needsAttention",
+        "FieldValidationSeverity.ERROR",
+        "highConfidenceCount",
+        "tier <=",
+    )
+    for diff in diff_files:
+        if "FieldValidators.kt" not in diff.path.as_posix() and "StoreNameResolver.kt" not in diff.path.as_posix():
+            continue
+        for line in diff.diff_text.splitlines():
+            if not line.startswith("-"):
+                continue
+            if any(token in line for token in risky_tokens):
+                raise GuardrailViolation(
+                    "AI guardrail violation: detected potential validator relaxation involving critical checks."
+                )
+
+
+def check_field_candidate_provenance(diff_files: Sequence[DiffFile]) -> None:
+    changed_files = [df.path for df in diff_files if df.path.suffix == ".kt"]
+    if not changed_files:
+        return
+
+    for path in changed_files:
+        try:
+            new_text = run_git_command(["git", "show", f":{path.as_posix()}"])
+        except RuntimeError:
+            continue
+        for match in FIELD_CANDIDATE_PATTERN.finditer(new_text):
+            args = match.group(1)
+            if "=" in args:
+                required = {"value", "confidence", "source", "context"}
+                present = {part.split("=")[0].strip() for part in args.split(",") if "=" in part}
+                if not required.issubset(present):
+                    raise GuardrailViolation(
+                        f"AI guardrail violation: FieldCandidate missing provenance fields in {path}."
+                    )
+            else:
+                parts = [part.strip() for part in args.split(",") if part.strip()]
+                if len(parts) < 4:
+                    raise GuardrailViolation(
+                        f"AI guardrail violation: FieldCandidate constructor missing arguments in {path}."
+                    )
+
+
+def check_cta_false_positive_changes(diff_files: Sequence[DiffFile]) -> None:
+    for diff in diff_files:
+        if diff.path != CTA_FILE:
+            continue
+        for line in diff.diff_text.splitlines():
+            if line.startswith("-") and "cta_stopword" in line:
+                raise GuardrailViolation(
+                    "AI guardrail violation: removal of CTA stop-word handling detected."
+                )
+
+
+def run_checks() -> None:
+    diff_files = load_staged_diff()
+    if not diff_files:
+        return
+
+    check_critical_invariants(diff_files)
+    check_validator_relaxations(diff_files)
+    check_cta_false_positive_changes(diff_files)
+    check_cta_stopwords()
+    check_field_candidate_provenance(diff_files)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate AI guardrail invariants")
+    parser.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help="Allow execution with no staged changes (useful for CI safety).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        run_checks()
+    except GuardrailViolation as err:
+        print(str(err), file=sys.stderr)
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"AI guardrail check failed: {exc}", file=sys.stderr)
+        return 2
+
+    if not args.allow_empty:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fuzz/test_store_name_fuzz.py
+++ b/tests/fuzz/test_store_name_fuzz.py
@@ -1,0 +1,30 @@
+import random
+import string
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from enhanced_field_extractor import EnhancedCouponFieldExtractor
+
+
+@pytest.mark.parametrize("seed", [13, 29, 71])
+def test_store_name_detection_is_stable_under_noise(seed):
+    random.seed(seed)
+    extractor = EnhancedCouponFieldExtractor()
+
+    for _ in range(25):
+        noise = " ".join(
+            "".join(random.choice(string.ascii_letters + string.digits) for _ in range(random.randint(3, 12)))
+            for _ in range(random.randint(3, 8))
+        )
+        prompt = f"{noise}\nClaim Now\nRedeem at Zenith Sports"
+        cleaned = extractor._clean_text(prompt)
+        result = extractor._detect_store(cleaned)
+
+        assert result["type"] in {"extracted", "unknown"}
+        assert isinstance(result.get("name"), str)
+        assert "Zenith" in prompt or result["type"] != "unknown"

--- a/tests/golden/test_store_name_golden.py
+++ b/tests/golden/test_store_name_golden.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from enhanced_field_extractor import EnhancedCouponFieldExtractor
+
+
+GOLDEN_DATA = [
+    {
+        "ocr": "Minimalist glow kit\nRedeem at Minimalist stores",
+        "expected_store": "Minimalist",
+    },
+    {
+        "ocr": "Amazon Festive Deals\nRedeem at Amazon",
+        "expected_store": "Amazon",
+    },
+    {
+        "ocr": "Flipkart Flash Sale\nRedeem at Flipkart Mall",
+        "expected_store": "Flipkart",
+    },
+]
+
+
+@pytest.mark.parametrize("case", GOLDEN_DATA)
+def test_store_name_matches_golden_cases(case):
+    extractor = EnhancedCouponFieldExtractor()
+    cleaned = extractor._clean_text(case["ocr"])
+    result = extractor._detect_store(cleaned)
+
+    assert result["type"] == "extracted"
+    assert result["name"].lower() == case["expected_store"].lower()


### PR DESCRIPTION
## Summary
- add a pre-commit/CI guardrail script to block risky store-name or provenance diffs and wire it into tooling
- extend GitHub Actions plus new fuzz and golden tests to exercise validator behavior and CTA stopword safety
- add store-name telemetry tracking, secure provenance sampling, and prompt template guardrails for the on-device LLM

## Testing
- python scripts/check_ai_invariants.py
- pytest tests/test_store_detection.py
- pytest tests/fuzz -q
- pytest tests/golden -q

------
https://chatgpt.com/codex/tasks/task_e_68f368625ce083289a06aa687f56c236