### PR TITLE
Configure validator CI with Android SDK installation

### DIFF
--- a/.github/workflows/validator-tests.yml
+++ b/.github/workflows/validator-tests.yml
@@ -18,6 +18,16 @@ jobs:
           distribution: temurin
           java-version: '17'
 
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          build-tools: 34.0.0
+
+      - name: Configure Android SDK location
+        run: |
+          echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
+
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- install the Android SDK on the validator test workflow so Gradle can locate required build tools
- generate a `local.properties` file pointing to the provisioned SDK before running the test task

## Testing
- not run (CI workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f36bd6fbf08328b96d1dcf4c8b0469