### PR TITLE
Adjust store validator attention threshold

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidators.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidators.kt
@@ -108,7 +108,7 @@ internal class StoreNameValidator(
         val meetsSignalThreshold = uniqueCategories.size >= 2
         val isAccepted = issues.isEmpty() && meetsSignalThreshold
         // @critical-invariant: require at least two independent signal categories before accepting store name.
-        val needsAttention = !isAccepted || highConfidenceCount < 2
+        val needsAttention = !isAccepted || highConfidenceCount == 0
 
         val assessment = Assessment(
             original = trimmed,


### PR DESCRIPTION
## Summary
- avoid flagging accepted store names for repair when at least one high-confidence signal is present

## Testing
- not run (Android SDK not configured in CI environment)

------
https://chatgpt.com/codex/tasks/task_e_68f36bd5234c83288ed36fd71aea34c1