### PR TITLE
Honor advanced extraction strategies with instrumentation

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/BatchScannerViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.coupontracker.data.model.Coupon
 import com.example.coupontracker.data.repository.CouponRepository
+import com.example.coupontracker.util.AnalyticsTracker
 import com.example.coupontracker.util.CouponInputManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.util.Locale
 import javax.inject.Inject
 
 /**
@@ -31,7 +33,8 @@ class BatchScannerViewModel @Inject constructor(
     private val ocrEngine: com.example.coupontracker.ocr.OcrEngine,  // Tesseract OCR engine
     private val bitmapManager: com.example.coupontracker.util.BitmapManager,  // V2: Bitmap memory management
     private val localLlmOcrService: com.example.coupontracker.util.LocalLlmOcrService,  // V2: LLM service
-    private val universalExtractionService: com.example.coupontracker.universal.UniversalExtractionService  // V2: Universal extraction
+    private val universalExtractionService: com.example.coupontracker.universal.UniversalExtractionService,  // V2: Universal extraction
+    private val analyticsTracker: AnalyticsTracker
 ) : AndroidViewModel(application) {
 
     private val _uiState = MutableStateFlow(BatchScannerUiState())
@@ -48,6 +51,7 @@ class BatchScannerViewModel @Inject constructor(
 
     companion object {
         private const val TAG = "BatchScannerViewModel"
+        private const val STRATEGY_SURFACE_BATCH = "batch_capture"
     }
 
     private data class DetectorInitializationResult(
@@ -536,6 +540,11 @@ class BatchScannerViewModel @Inject constructor(
                         // Terminal fallback: Use LEGACY two-stage detection if available
                         Log.d(TAG, "LLM_FIRST failed with no OCR fallback allowed, using LEGACY")
                         if (allowLegacyFallback) {
+                            logStrategyExecution(
+                                requested = com.example.coupontracker.util.ExtractionStrategy.LLM_FIRST,
+                                executed = "legacy",
+                                reason = "llm_terminal_failure"
+                            )
                             processWithLegacyPath(uri, bitmap)
                         } else {
                             Log.w(TAG, "LLM_FIRST fallback to LEGACY disabled, returning placeholder coupon")
@@ -583,6 +592,11 @@ class BatchScannerViewModel @Inject constructor(
                             // Terminal fallback: Use LEGACY two-stage detection
                             Log.d(TAG, "OCR_FIRST failed with no LLM fallback allowed, using LEGACY")
                             if (allowLegacyFallback) {
+                                logStrategyExecution(
+                                    requested = com.example.coupontracker.util.ExtractionStrategy.OCR_FIRST,
+                                    executed = "legacy",
+                                    reason = "ocr_low_confidence"
+                                )
                                 processWithLegacyPath(uri, bitmap)
                             } else {
                                 Log.w(TAG, "OCR_FIRST fallback to LEGACY disabled, returning placeholder coupon")
@@ -605,6 +619,11 @@ class BatchScannerViewModel @Inject constructor(
                         // Terminal fallback: Use LEGACY two-stage detection
                         Log.d(TAG, "OCR_FIRST failed with no LLM fallback allowed, using LEGACY")
                         if (allowLegacyFallback) {
+                            logStrategyExecution(
+                                requested = com.example.coupontracker.util.ExtractionStrategy.OCR_FIRST,
+                                executed = "legacy",
+                                reason = "ocr_exception"
+                            )
                             processWithLegacyPath(uri, bitmap)
                         } else {
                             Log.w(TAG, "OCR_FIRST fallback to LEGACY disabled, returning placeholder coupon")
@@ -659,12 +678,52 @@ class BatchScannerViewModel @Inject constructor(
                 else -> {
                     // Both failed - use LEGACY
                     Log.d(TAG, "HYBRID: Both failed, falling back to LEGACY")
+                    logStrategyExecution(
+                        requested = com.example.coupontracker.util.ExtractionStrategy.HYBRID,
+                        executed = "legacy",
+                        reason = "hybrid_no_success"
+                    )
                     processWithLegacyPath(uri, bitmap)
                 }
             }
         }
     }
-    
+
+    private suspend fun logStrategyExecution(
+        requested: com.example.coupontracker.util.ExtractionStrategy,
+        executed: String,
+        reason: String? = null
+    ) {
+        val normalizedExecuted = executed.lowercase(Locale.getDefault())
+        val message = buildString {
+            append("Strategy[batch]: requested=")
+            append(requested.name)
+            append(", executed=")
+            append(normalizedExecuted)
+            if (!reason.isNullOrBlank()) {
+                append(", reason=")
+                append(reason)
+            }
+        }
+
+        Log.i(TAG, message)
+        analyticsTracker.trackStrategyExecution(
+            STRATEGY_SURFACE_BATCH,
+            requested,
+            normalizedExecuted,
+            reason
+        )
+
+        if (!requested.name.equals(normalizedExecuted, ignoreCase = true) && !reason.isNullOrBlank()) {
+            analyticsTracker.trackStrategyFallback(
+                STRATEGY_SURFACE_BATCH,
+                requested,
+                normalizedExecuted,
+                reason
+            )
+        }
+    }
+
     /**
      * Fuse LLM and OCR results by choosing best field per confidence
      * This is the REAL HYBRID fusion logic (mirrors ScannerViewModel)
@@ -1136,14 +1195,34 @@ class BatchScannerViewModel @Inject constructor(
         strategy: com.example.coupontracker.util.ExtractionStrategy
     ): Coupon {
         return when (strategy) {
-            com.example.coupontracker.util.ExtractionStrategy.LEGACY -> 
+            com.example.coupontracker.util.ExtractionStrategy.LEGACY -> {
+                logStrategyExecution(
+                    requested = strategy,
+                    executed = strategy.name.lowercase(Locale.getDefault())
+                )
                 processWithLegacyPath(uri, bitmap)
-            com.example.coupontracker.util.ExtractionStrategy.LLM_FIRST -> 
+            }
+            com.example.coupontracker.util.ExtractionStrategy.LLM_FIRST -> {
+                logStrategyExecution(
+                    requested = strategy,
+                    executed = strategy.name.lowercase(Locale.getDefault())
+                )
                 processWithLlmFirstPath(uri, bitmap)
-            com.example.coupontracker.util.ExtractionStrategy.OCR_FIRST -> 
+            }
+            com.example.coupontracker.util.ExtractionStrategy.OCR_FIRST -> {
+                logStrategyExecution(
+                    requested = strategy,
+                    executed = strategy.name.lowercase(Locale.getDefault())
+                )
                 processWithOcrFirstPath(uri, bitmap)
-            com.example.coupontracker.util.ExtractionStrategy.HYBRID -> 
+            }
+            com.example.coupontracker.util.ExtractionStrategy.HYBRID -> {
+                logStrategyExecution(
+                    requested = strategy,
+                    executed = strategy.name.lowercase(Locale.getDefault())
+                )
                 processWithHybridPath(uri, bitmap)
+            }
         }
     }
     

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -88,6 +88,7 @@ class ScannerViewModel @Inject constructor(
 
     companion object {
         private const val TAG = "ScannerViewModel"
+        private const val STRATEGY_SURFACE_SINGLE = "single_capture"
 
         @VisibleForTesting
         internal fun parseExpiryDate(
@@ -155,6 +156,28 @@ class ScannerViewModel @Inject constructor(
             }
 
             return null // Don't return fallback date - use null if parsing fails
+        }
+    }
+
+    private suspend fun logStrategyExecution(
+        requested: com.example.coupontracker.util.ExtractionStrategy,
+        executed: String,
+        surface: String,
+        reason: String? = null
+    ) {
+        val normalizedExecuted = executed.lowercase(Locale.getDefault())
+        val baseMessage = "Strategy[$surface]: requested=${requested.name}, executed=$normalizedExecuted"
+        val fullMessage = if (!reason.isNullOrBlank()) {
+            "$baseMessage, reason=$reason"
+        } else {
+            baseMessage
+        }
+
+        Log.i(TAG, fullMessage)
+        analyticsTracker.trackStrategyExecution(surface, requested, normalizedExecuted, reason)
+
+        if (!requested.name.equals(normalizedExecuted, ignoreCase = true) && !reason.isNullOrBlank()) {
+            analyticsTracker.trackStrategyFallback(surface, requested, normalizedExecuted, reason)
         }
     }
 
@@ -245,18 +268,38 @@ class ScannerViewModel @Inject constructor(
                 // V2: Route based on extraction strategy
                 when (strategy) {
                     com.example.coupontracker.util.ExtractionStrategy.LEGACY -> {
+                        logStrategyExecution(
+                            requested = strategy,
+                            executed = strategy.name.lowercase(Locale.getDefault()),
+                            surface = STRATEGY_SURFACE_SINGLE
+                        )
                         // LEGACY: Two-stage detection → LLM → OCR fallback
                         scanWithLegacyPath(imageUri, bitmap, persistImmediately)
                     }
                     com.example.coupontracker.util.ExtractionStrategy.LLM_FIRST -> {
+                        logStrategyExecution(
+                            requested = strategy,
+                            executed = strategy.name.lowercase(Locale.getDefault()),
+                            surface = STRATEGY_SURFACE_SINGLE
+                        )
                         // LLM_FIRST: LLM locates ROIs → OCR extracts → Fusion
                         scanWithLlmFirstPath(imageUri, bitmap, persistImmediately)
                     }
                     com.example.coupontracker.util.ExtractionStrategy.OCR_FIRST -> {
+                        logStrategyExecution(
+                            requested = strategy,
+                            executed = strategy.name.lowercase(Locale.getDefault()),
+                            surface = STRATEGY_SURFACE_SINGLE
+                        )
                         // OCR_FIRST: OCR finds text → LLM validates → Fusion
                         scanWithOcrFirstPath(imageUri, bitmap, persistImmediately)
                     }
                     com.example.coupontracker.util.ExtractionStrategy.HYBRID -> {
+                        logStrategyExecution(
+                            requested = strategy,
+                            executed = strategy.name.lowercase(Locale.getDefault()),
+                            surface = STRATEGY_SURFACE_SINGLE
+                        )
                         // HYBRID: Parallel LLM + OCR → Fusion arbitrates
                         scanWithHybridPath(imageUri, bitmap, persistImmediately)
                     }
@@ -725,7 +768,13 @@ class ScannerViewModel @Inject constructor(
                 
             } else {
                 Log.w(TAG, "HYBRID: Both methods failed, falling back to LEGACY")
-                
+                logStrategyExecution(
+                    requested = com.example.coupontracker.util.ExtractionStrategy.HYBRID,
+                    executed = "legacy",
+                    surface = STRATEGY_SURFACE_SINGLE,
+                    reason = "hybrid_no_success"
+                )
+
                 performanceMonitor.recordExtractionAttempt(
                     method = ExtractionMethod.HYBRID_FUSION,
                     success = false,
@@ -740,8 +789,14 @@ class ScannerViewModel @Inject constructor(
             
         } catch (e: Exception) {
             Log.e(TAG, "HYBRID: Exception during hybrid extraction", e)
+            logStrategyExecution(
+                requested = com.example.coupontracker.util.ExtractionStrategy.HYBRID,
+                executed = "legacy",
+                surface = STRATEGY_SURFACE_SINGLE,
+                reason = "hybrid_exception_${e.javaClass.simpleName}"
+            )
             val processingTime = System.currentTimeMillis() - startTime
-            
+
             performanceMonitor.recordExtractionAttempt(
                 method = ExtractionMethod.HYBRID_FUSION,
                 success = false,

--- a/app/src/main/kotlin/com/example/coupontracker/util/AnalyticsTracker.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/AnalyticsTracker.kt
@@ -41,6 +41,8 @@ class AnalyticsTracker @Inject constructor(
         const val EVENT_MULTIPLE_COUPONS_DETECTED = "multiple_coupons_detected"
         const val EVENT_QR_CODE_DETECTED = "qr_code_detected"
         const val EVENT_PROCESSING_TIME = "processing_time"
+        const val EVENT_STRATEGY_EXECUTED = "strategy_executed"
+        const val EVENT_STRATEGY_FALLBACK = "strategy_fallback"
     }
     
     // Get or create a unique user ID
@@ -128,6 +130,42 @@ class AnalyticsTracker @Inject constructor(
             "time_ms" to processingTimeMs,
             "operation" to operation
         ))
+    }
+
+    suspend fun trackStrategyExecution(
+        surface: String,
+        requestedStrategy: ExtractionStrategy,
+        executedStrategy: String,
+        reason: String? = null
+    ) {
+        val normalizedExecuted = executedStrategy.lowercase(Locale.getDefault())
+        val properties = mutableMapOf<String, Any>(
+            "surface" to surface,
+            "requested" to requestedStrategy.name.lowercase(Locale.getDefault()),
+            "executed" to normalizedExecuted
+        )
+
+        reason?.let { properties["reason"] = it }
+        val mismatch = !requestedStrategy.name.equals(normalizedExecuted, ignoreCase = true)
+        properties["mismatch"] = mismatch.toString()
+
+        trackEvent(EVENT_STRATEGY_EXECUTED, properties)
+    }
+
+    suspend fun trackStrategyFallback(
+        surface: String,
+        fromStrategy: ExtractionStrategy,
+        fallbackTarget: String,
+        reason: String
+    ) {
+        val properties = mapOf(
+            "surface" to surface,
+            "from" to fromStrategy.name.lowercase(Locale.getDefault()),
+            "to" to fallbackTarget.lowercase(Locale.getDefault()),
+            "reason" to reason
+        )
+
+        trackEvent(EVENT_STRATEGY_FALLBACK, properties)
     }
     
     /**

--- a/app/src/main/kotlin/com/example/coupontracker/util/ExtractionStrategy.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/ExtractionStrategy.kt
@@ -3,6 +3,7 @@ package com.example.coupontracker.util
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 
 /**
  * Extraction strategy for V2 architecture
@@ -44,13 +45,20 @@ object ExtractionConfig {
     private const val TAG = "ExtractionConfig"
     private const val PREFS_NAME = "extraction_config"
     private const val KEY_STRATEGY = "extraction_strategy"
-    
+    private const val KEY_ADVANCED_ENABLED = "advanced_strategies_enabled"
+
     private var prefs: SharedPreferences? = null
-    
+
     // Default strategy (OCR_FIRST - most reliable with current model availability)
     // LLM_FIRST and HYBRID disabled due to missing MLC-LLM binaries (see CRITICAL_PRODUCTION_BLOCKERS.md)
     private var _strategy: ExtractionStrategy = ExtractionStrategy.OCR_FIRST
+    @Volatile
+    private var advancedStrategiesEnabled: Boolean = false
+    @Volatile
+    private var pendingAdvancedFlag: PendingAdvancedFlag? = null
     private var isInitialized = false
+
+    private data class PendingAdvancedFlag(val enabled: Boolean, val persist: Boolean)
     
     /**
      * Initialize with application context
@@ -60,31 +68,31 @@ object ExtractionConfig {
         if (isInitialized) return
         
         prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        
-        // Load saved strategy
-        val savedStrategyName = prefs?.getString(KEY_STRATEGY, ExtractionStrategy.OCR_FIRST.name)
-        try {
-            val savedStrategy = ExtractionStrategy.valueOf(savedStrategyName ?: ExtractionStrategy.OCR_FIRST.name)
-            
-            // Block non-functional strategies due to missing models
-            _strategy = when (savedStrategy) {
-                ExtractionStrategy.LLM_FIRST -> {
-                    Log.w(TAG, "LLM_FIRST requires real MLC-LLM binaries - falling back to OCR_FIRST")
-                    ExtractionStrategy.OCR_FIRST
-                }
-                ExtractionStrategy.HYBRID -> {
-                    Log.w(TAG, "HYBRID requires real MLC-LLM binaries - falling back to OCR_FIRST")
-                    ExtractionStrategy.OCR_FIRST
-                }
-                else -> savedStrategy
+
+        val pending = pendingAdvancedFlag
+        val persistedAdvanced = prefs?.getBoolean(KEY_ADVANCED_ENABLED, false) ?: false
+        if (pending != null) {
+            advancedStrategiesEnabled = pending.enabled
+            if (pending.persist) {
+                prefs?.edit()?.putBoolean(KEY_ADVANCED_ENABLED, pending.enabled)?.apply()
             }
-            
-            Log.d(TAG, "Loaded strategy: ${_strategy.name}")
-        } catch (e: IllegalArgumentException) {
-            Log.w(TAG, "Invalid saved strategy: $savedStrategyName, defaulting to OCR_FIRST")
-            _strategy = ExtractionStrategy.OCR_FIRST
+            pendingAdvancedFlag = null
+        } else {
+            advancedStrategiesEnabled = persistedAdvanced
         }
-        
+
+        val savedStrategy = readSavedStrategy()
+        if (savedStrategy != null && !isStrategyAllowed(savedStrategy)) {
+            Log.i(
+                TAG,
+                "Saved strategy ${savedStrategy.name} blocked by rollout guard – using OCR_FIRST until enabled"
+            )
+        }
+
+        _strategy = savedStrategy?.takeIf { isStrategyAllowed(it) } ?: ExtractionStrategy.OCR_FIRST
+
+        Log.d(TAG, "Loaded strategy: ${_strategy.name} (advanced=${advancedStrategiesEnabled})")
+
         isInitialized = true
     }
     
@@ -103,36 +111,33 @@ object ExtractionConfig {
      * Note: LLM_FIRST and HYBRID are blocked at load time if real models not available
      */
     fun setStrategy(strategy: ExtractionStrategy) {
+        if (!isStrategyAllowed(strategy)) {
+            Log.w(TAG, "Attempted to set blocked strategy ${strategy.name} – ignoring due to rollout guard")
+            return
+        }
+
         if (_strategy != strategy) {
             Log.d(TAG, "Strategy changed: ${_strategy.name} → ${strategy.name}")
-            _strategy = strategy
-            
-            // Persist to SharedPreferences
-            prefs?.edit()?.putString(KEY_STRATEGY, strategy.name)?.apply()
+            updateStrategyInternal(strategy, persist = true)
         }
     }
-    
+
     /**
      * Get available strategies based on current model availability
      * Returns only OCR_FIRST and LEGACY until real MLC-LLM binaries are integrated
      */
     fun getAvailableStrategies(): List<ExtractionStrategy> {
-        val mlcAvailable = try {
-            com.example.coupontracker.llm.MlcLlmNative.isAvailable()
-        } catch (e: Exception) {
-            false
+        val strategies = linkedSetOf(
+            ExtractionStrategy.OCR_FIRST,
+            ExtractionStrategy.LEGACY
+        )
+
+        if (shouldExposeAdvancedStrategies()) {
+            strategies.add(ExtractionStrategy.LLM_FIRST)
+            strategies.add(ExtractionStrategy.HYBRID)
         }
-        
-        return if (mlcAvailable) {
-            // All strategies available when real MLC-LLM is present
-            ExtractionStrategy.values().toList()
-        } else {
-            // Only working strategies when using mock
-            listOf(
-                ExtractionStrategy.OCR_FIRST,  // ✅ Works with ML Kit OCR
-                ExtractionStrategy.LEGACY      // ✅ Works with fallback to OCR
-            )
-        }
+
+        return strategies.toList()
     }
     
     /**
@@ -140,6 +145,93 @@ object ExtractionConfig {
      */
     fun isStrategyAvailable(strategy: ExtractionStrategy): Boolean {
         return getAvailableStrategies().contains(strategy)
+    }
+
+    fun areAdvancedStrategiesEnabled(): Boolean = advancedStrategiesEnabled
+
+    fun setAdvancedStrategiesEnabled(enabled: Boolean, persist: Boolean = true) {
+        if (!isInitialized) {
+            pendingAdvancedFlag = PendingAdvancedFlag(enabled, persist)
+        }
+
+        if (advancedStrategiesEnabled == enabled) {
+            if (persist && isInitialized) {
+                prefs?.edit()?.putBoolean(KEY_ADVANCED_ENABLED, enabled)?.apply()
+            }
+            return
+        }
+
+        advancedStrategiesEnabled = enabled
+
+        if (persist && isInitialized) {
+            prefs?.edit()?.putBoolean(KEY_ADVANCED_ENABLED, enabled)?.apply()
+        }
+
+        if (isInitialized) {
+            if (enabled) {
+                val savedStrategy = readSavedStrategy()
+                if (savedStrategy != null && isStrategyGuarded(savedStrategy)) {
+                    Log.i(TAG, "Advanced strategies enabled – restoring saved strategy ${savedStrategy.name}")
+                    updateStrategyInternal(savedStrategy, persist = false)
+                }
+            } else if (isStrategyGuarded(_strategy)) {
+                Log.i(TAG, "Advanced strategies disabled – reverting to OCR_FIRST in memory")
+                updateStrategyInternal(ExtractionStrategy.OCR_FIRST, persist = false)
+            }
+        }
+    }
+
+    @VisibleForTesting
+    internal fun resetForTesting() {
+        prefs = null
+        _strategy = ExtractionStrategy.OCR_FIRST
+        advancedStrategiesEnabled = false
+        pendingAdvancedFlag = null
+        isInitialized = false
+    }
+
+    private fun updateStrategyInternal(strategy: ExtractionStrategy, persist: Boolean) {
+        _strategy = strategy
+        if (persist) {
+            prefs?.edit()?.putString(KEY_STRATEGY, strategy.name)?.apply()
+        }
+    }
+
+    private fun readSavedStrategy(): ExtractionStrategy? {
+        val savedStrategyName = prefs?.getString(KEY_STRATEGY, null) ?: return null
+        return try {
+            ExtractionStrategy.valueOf(savedStrategyName)
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "Invalid saved strategy: $savedStrategyName, ignoring")
+            null
+        }
+    }
+
+    private fun isStrategyGuarded(strategy: ExtractionStrategy): Boolean {
+        return when (strategy) {
+            ExtractionStrategy.LLM_FIRST, ExtractionStrategy.HYBRID -> true
+            else -> false
+        }
+    }
+
+    private fun isStrategyAllowed(strategy: ExtractionStrategy): Boolean {
+        return !isStrategyGuarded(strategy) || advancedStrategiesEnabled
+    }
+
+    private fun shouldExposeAdvancedStrategies(): Boolean {
+        if (!advancedStrategiesEnabled) {
+            return false
+        }
+
+        if (isStrategyGuarded(_strategy)) {
+            return true
+        }
+
+        return try {
+            com.example.coupontracker.llm.MlcLlmNative.isAvailable()
+        } catch (e: Exception) {
+            false
+        }
     }
     
     /**

--- a/app/src/test/kotlin/com/example/coupontracker/util/ExtractionConfigTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/ExtractionConfigTest.kt
@@ -1,0 +1,103 @@
+package com.example.coupontracker.util
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.example.coupontracker.llm.MlcLlmNative
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.robolectric.RobolectricTestRunner
+import org.junit.runner.RunWith
+
+@RunWith(RobolectricTestRunner::class)
+class ExtractionConfigTest {
+
+    private lateinit var context: Context
+    private lateinit var originalLoader: MlcLlmNative.NativeLibraryLoader
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        originalLoader = MlcLlmNative.libraryLoader
+        clearPreferences()
+        MlcLlmNative.resetForTests()
+        ExtractionConfig.resetForTesting()
+    }
+
+    @After
+    fun tearDown() {
+        MlcLlmNative.libraryLoader = originalLoader
+        MlcLlmNative.resetForTests()
+        ExtractionConfig.resetForTesting()
+        clearPreferences()
+    }
+
+    @Test
+    fun defaultStrategy_isOcrFirst() {
+        ExtractionConfig.init(context)
+
+        assertEquals(ExtractionStrategy.OCR_FIRST, ExtractionConfig.getStrategy())
+        assertFalse(ExtractionConfig.areAdvancedStrategiesEnabled())
+    }
+
+    @Test
+    fun enablingAdvancedStrategiesRestoresPersistedSelection() {
+        ExtractionConfig.init(context)
+        ExtractionConfig.setAdvancedStrategiesEnabled(true)
+        ExtractionConfig.setStrategy(ExtractionStrategy.LLM_FIRST)
+
+        assertEquals(ExtractionStrategy.LLM_FIRST, ExtractionConfig.getStrategy())
+
+        ExtractionConfig.resetForTesting()
+        ExtractionConfig.init(context)
+
+        assertTrue(ExtractionConfig.areAdvancedStrategiesEnabled())
+        assertEquals(ExtractionStrategy.LLM_FIRST, ExtractionConfig.getStrategy())
+    }
+
+    @Test
+    fun persistedAdvancedSelectionResumesWhenGuardToggledOn() {
+        ExtractionConfig.init(context)
+        context.getSharedPreferences("extraction_config", Context.MODE_PRIVATE)
+            .edit()
+            .putString("extraction_strategy", ExtractionStrategy.HYBRID.name)
+            .apply()
+
+        ExtractionConfig.resetForTesting()
+        ExtractionConfig.init(context)
+
+        assertEquals(ExtractionStrategy.OCR_FIRST, ExtractionConfig.getStrategy())
+
+        ExtractionConfig.setAdvancedStrategiesEnabled(true)
+
+        assertEquals(ExtractionStrategy.HYBRID, ExtractionConfig.getStrategy())
+    }
+
+    @Test
+    fun availableStrategiesIncludeAdvancedWhenLibraryReadyAndGuardEnabled() {
+        val stubLoader = object : MlcLlmNative.NativeLibraryLoader {
+            override fun loadLibrary(name: String) {}
+            override fun load(path: String) {}
+        }
+        MlcLlmNative.libraryLoader = stubLoader
+        assertTrue(MlcLlmNative.loadLibrary(context))
+
+        ExtractionConfig.init(context)
+        ExtractionConfig.setAdvancedStrategiesEnabled(true)
+
+        val strategies = ExtractionConfig.getAvailableStrategies()
+
+        assertTrue(strategies.contains(ExtractionStrategy.LLM_FIRST))
+        assertTrue(strategies.contains(ExtractionStrategy.HYBRID))
+    }
+
+    private fun clearPreferences() {
+        context.getSharedPreferences("extraction_config", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+    }
+}


### PR DESCRIPTION
## Summary
- add a rollout guard that allows persisted LLM_FIRST and HYBRID selections to survive app restarts when enabled and expose helpers for tests
- emit structured analytics/logging for the executed extraction strategy (and fallbacks) in both ScannerViewModel and BatchScannerViewModel
- extend test coverage to ensure advanced strategies persist correctly and become available when the guard and native binaries are present

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3b8f91c548328bf80acbd47eb93ea