### PR TITLE
Capture validator overrides and corrections for offline retraining

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/CouponTrackerApplication.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/CouponTrackerApplication.kt
@@ -7,6 +7,8 @@ import androidx.work.Configuration
 import androidx.work.WorkManager
 import com.example.coupontracker.analytics.StoreNameMetricsTracker
 import com.example.coupontracker.worker.ReminderWorker
+import com.example.coupontracker.feedback.FeedbackFeatureToggle
+import com.example.coupontracker.worker.OfflineRetrainingWorker
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -14,6 +16,9 @@ import javax.inject.Inject
 class CouponTrackerApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
+
+    @Inject
+    lateinit var feedbackFeatureToggle: FeedbackFeatureToggle
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
@@ -48,6 +53,13 @@ class CouponTrackerApplication : Application(), Configuration.Provider {
             // Schedule daily reminder checks
             ReminderWorker.scheduleDaily(WorkManager.getInstance(this))
             Log.d("CouponTracker", "Scheduled reminder worker")
+
+            if (feedbackFeatureToggle.isOfflineRetrainingEnabled()) {
+                OfflineRetrainingWorker.schedule(WorkManager.getInstance(this))
+                Log.d("CouponTracker", "Scheduled offline retraining worker")
+            } else {
+                Log.d("CouponTracker", "Offline retraining worker disabled by feature flag")
+            }
         } catch (e: Exception) {
             Log.e("CouponTracker", "Error scheduling reminder worker", e)
         }

--- a/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDatabase.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/local/CouponDatabase.kt
@@ -15,9 +15,10 @@ import com.google.gson.reflect.TypeToken
     entities = [
         Coupon::class,
         LearnedPattern::class,          // V2: Pattern storage
-        ExtractionFeedback::class       // V2: Feedback & telemetry
+        ExtractionFeedback::class,      // V2: Feedback & telemetry
+        ValidatorFeedbackRecord::class  // Validator override & correction dataset
     ],
-    version = 10,
+    version = 11,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -25,6 +26,7 @@ abstract class CouponDatabase : RoomDatabase() {
     abstract fun couponDao(): CouponDao
     abstract fun learnedPatternDao(): LearnedPatternDao              // V2: Pattern management
     abstract fun extractionFeedbackDao(): ExtractionFeedbackDao      // V2: Feedback management
+    abstract fun validatorFeedbackDao(): ValidatorFeedbackDao        // Validator dataset management
 
     companion object {
         const val DATABASE_NAME = "coupon_database"
@@ -415,6 +417,32 @@ abstract class CouponDatabase : RoomDatabase() {
 
                 database.execSQL("DROP TABLE `coupons`")
                 database.execSQL("ALTER TABLE `coupons_v10` RENAME TO `coupons`")
+            }
+        }
+
+        val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `validator_feedback_v1` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `eventType` TEXT NOT NULL,
+                        `fieldOutcomesJson` TEXT NOT NULL,
+                        `rationaleJson` TEXT NOT NULL,
+                        `metadataJson` TEXT NOT NULL,
+                        `ocrHash` TEXT,
+                        `ocrPreview` TEXT,
+                        `timestamp` INTEGER NOT NULL
+                    )
+                    """.trimIndent()
+                )
+
+                database.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_validator_feedback_v1_timestamp` ON `validator_feedback_v1` (`timestamp` DESC)"
+                )
+                database.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_validator_feedback_v1_eventType` ON `validator_feedback_v1` (`eventType`)"
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/example/coupontracker/data/local/ValidatorFeedbackRecord.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/local/ValidatorFeedbackRecord.kt
@@ -1,0 +1,49 @@
+package com.example.coupontracker.data.local
+
+import androidx.room.*
+
+/**
+ * Entity capturing validator override and user correction datasets for offline training.
+ */
+@Entity(
+    tableName = "validator_feedback_v1",
+    indices = [
+        Index(value = ["timestamp"], orders = [Index.Order.DESC]),
+        Index(value = ["eventType"])
+    ]
+)
+data class ValidatorFeedbackRecord(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val eventType: String,
+    val fieldOutcomesJson: String,
+    val rationaleJson: String,
+    val metadataJson: String,
+    val ocrHash: String?,
+    val ocrPreview: String?,
+    val timestamp: Long = System.currentTimeMillis()
+)
+
+@Dao
+interface ValidatorFeedbackDao {
+    @Insert
+    suspend fun insert(record: ValidatorFeedbackRecord): Long
+
+    @Query(
+        """
+        SELECT * FROM validator_feedback_v1
+        WHERE eventType = :eventType
+        ORDER BY timestamp DESC
+        LIMIT :limit
+        """
+    )
+    suspend fun getRecent(eventType: String, limit: Int): List<ValidatorFeedbackRecord>
+
+    @Query(
+        """
+        DELETE FROM validator_feedback_v1
+        WHERE timestamp < :cutoff
+        """
+    )
+    suspend fun purgeOlderThan(cutoff: Long): Int
+}

--- a/app/src/main/kotlin/com/example/coupontracker/data/repository/FeedbackDatasetRepository.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/repository/FeedbackDatasetRepository.kt
@@ -1,0 +1,76 @@
+package com.example.coupontracker.data.repository
+
+import android.util.Log
+import com.example.coupontracker.data.local.ValidatorFeedbackDao
+import com.example.coupontracker.data.local.ValidatorFeedbackRecord
+import com.example.coupontracker.feedback.FeedbackFeatureToggle
+import com.example.coupontracker.feedback.OcrAnonymizer
+import com.example.coupontracker.feedback.ValidatorFeedbackEvent
+import com.google.gson.Gson
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+interface FeedbackDatasetRepository {
+    fun recordEvent(event: ValidatorFeedbackEvent)
+    suspend fun getRecentEvents(
+        eventType: ValidatorFeedbackEvent.EventType,
+        limit: Int
+    ): List<ValidatorFeedbackRecord>
+    suspend fun purgeOlderThan(days: Int): Int
+}
+
+@Singleton
+class FeedbackDatasetRepositoryImpl @Inject constructor(
+    private val validatorFeedbackDao: ValidatorFeedbackDao,
+    private val featureToggle: FeedbackFeatureToggle,
+    private val gson: Gson
+) : FeedbackDatasetRepository {
+
+    companion object {
+        private const val TAG = "FeedbackDatasetRepo"
+        private const val MILLIS_PER_DAY = 24 * 60 * 60 * 1000L
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun recordEvent(event: ValidatorFeedbackEvent) {
+        val featureEnabled = featureToggle.isValidationDatasetEnabled()
+        if (!featureEnabled) {
+            Log.d(TAG, "Validation dataset capture disabled - skipping ${event.eventType}")
+            return
+        }
+
+        scope.launch {
+            try {
+                val record = ValidatorFeedbackRecord(
+                    eventType = event.eventType.name.lowercase(),
+                    fieldOutcomesJson = gson.toJson(event.fieldOutcomes),
+                    rationaleJson = gson.toJson(event.rationale),
+                    metadataJson = gson.toJson(event.metadata),
+                    ocrHash = OcrAnonymizer.sha256(event.ocrText),
+                    ocrPreview = OcrAnonymizer.preview(event.ocrText)
+                )
+                validatorFeedbackDao.insert(record)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to persist feedback event", e)
+            }
+        }
+    }
+
+    override suspend fun getRecentEvents(
+        eventType: ValidatorFeedbackEvent.EventType,
+        limit: Int
+    ): List<ValidatorFeedbackRecord> = withContext(Dispatchers.IO) {
+        validatorFeedbackDao.getRecent(eventType.name.lowercase(), limit)
+    }
+
+    override suspend fun purgeOlderThan(days: Int): Int = withContext(Dispatchers.IO) {
+        val cutoff = System.currentTimeMillis() - (days * MILLIS_PER_DAY)
+        validatorFeedbackDao.purgeOlderThan(cutoff)
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/di/DatabaseModule.kt
@@ -34,7 +34,8 @@ object DatabaseModule {
                 CouponDatabase.MIGRATION_6_7,  // V2: Pattern learning and feedback tables
                 CouponDatabase.MIGRATION_7_8,  // Drop deprecated offerText column
                 CouponDatabase.MIGRATION_8_9,
-                CouponDatabase.MIGRATION_9_10
+                CouponDatabase.MIGRATION_9_10,
+                CouponDatabase.MIGRATION_10_11
             )
             .fallbackToDestructiveMigration()
             .build()
@@ -53,8 +54,13 @@ object DatabaseModule {
     // V2: Provide feedback DAO
     @Provides
     @Singleton
-    fun provideExtractionFeedbackDao(database: CouponDatabase): ExtractionFeedbackDao = 
+    fun provideExtractionFeedbackDao(database: CouponDatabase): ExtractionFeedbackDao =
         database.extractionFeedbackDao()
+
+    @Provides
+    @Singleton
+    fun provideValidatorFeedbackDao(database: CouponDatabase): ValidatorFeedbackDao =
+        database.validatorFeedbackDao()
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/example/coupontracker/di/FeedbackModule.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/di/FeedbackModule.kt
@@ -1,0 +1,19 @@
+package com.example.coupontracker.di
+
+import com.example.coupontracker.data.repository.FeedbackDatasetRepository
+import com.example.coupontracker.data.repository.FeedbackDatasetRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class FeedbackModule {
+    @Binds
+    @Singleton
+    abstract fun bindFeedbackDatasetRepository(
+        impl: FeedbackDatasetRepositoryImpl
+    ): FeedbackDatasetRepository
+}

--- a/app/src/main/kotlin/com/example/coupontracker/di/LlmModule.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/di/LlmModule.kt
@@ -1,6 +1,7 @@
 package com.example.coupontracker.di
 
 import android.content.Context
+import com.example.coupontracker.feedback.ValidatorFeedbackRecorder
 import com.example.coupontracker.llm.LlmRuntimeManager
 import com.example.coupontracker.llm.LlmTelemetryService
 import com.example.coupontracker.llm.ModelDownloadManager
@@ -53,9 +54,10 @@ object LlmModule {
     fun provideLocalLlmOcrService(
         @ApplicationContext context: Context,
         ocrEngine: com.example.coupontracker.ocr.OcrEngine,
-        llmRuntimeManager: LlmRuntimeManager
+        llmRuntimeManager: LlmRuntimeManager,
+        validatorFeedbackRecorder: ValidatorFeedbackRecorder
     ): LocalLlmOcrService {
-        return LocalLlmOcrService(context, ocrEngine, llmRuntimeManager)
+        return LocalLlmOcrService(context, ocrEngine, llmRuntimeManager, validatorFeedbackRecorder = validatorFeedbackRecorder)
     }
 
     @Provides

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinator.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinator.kt
@@ -43,6 +43,21 @@ data class FieldValidationIssue(
     val replacementSource: String?
 )
 
+data class ValidationEvent(
+    val initial: FieldValueBundle,
+    val summary: FieldValidationSummary,
+    val structuredCandidates: Map<FieldType, List<FieldCandidate>>,
+    val rawOcrText: String?
+)
+
+fun interface ValidationEventLogger {
+    fun log(event: ValidationEvent)
+
+    companion object {
+        val NO_OP = ValidationEventLogger { _ -> }
+    }
+}
+
 /**
  * Coordinates validation of the core coupon fields returned by the LLM.
  * Uses deterministic heuristics and structured extraction fallbacks to keep
@@ -52,7 +67,8 @@ internal class FieldValidationCoordinator(
     private val textExtractor: TextExtractor,
     private val storeNameResolver: StoreNameResolver,
     private val descriptionValidator: DescriptionValidator = DescriptionValidator(),
-    private val expiryDateValidator: ExpiryDateValidator = ExpiryDateValidator()
+    private val expiryDateValidator: ExpiryDateValidator = ExpiryDateValidator(),
+    private val validationEventLogger: ValidationEventLogger = ValidationEventLogger.NO_OP
 ) {
     internal fun refine(
         initial: FieldValueBundle,
@@ -101,6 +117,16 @@ internal class FieldValidationCoordinator(
         bundle = bundle.copy(expiryDateText = expiryDecision.value)
         expiryDecision.issue?.let { issues += it }
 
-        return FieldValidationSummary(bundle, issues, storeResolution)
+        val summary = FieldValidationSummary(bundle, issues, storeResolution)
+        validationEventLogger.log(
+            ValidationEvent(
+                initial = initial,
+                summary = summary,
+                structuredCandidates = structuredCandidates,
+                rawOcrText = rawOcrText
+            )
+        )
+
+        return summary
     }
 }

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/StoreNameResolver.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/StoreNameResolver.kt
@@ -15,7 +15,9 @@ class StoreNameResolver(
         val issue: FieldValidationIssue?,
         val source: String?,
         val evidence: List<String>,
-        val needsAttention: Boolean
+        val needsAttention: Boolean,
+        val violations: List<String>,
+        val confidence: Float?
     )
 
     fun resolve(
@@ -33,7 +35,9 @@ class StoreNameResolver(
                 issue = null,
                 source = "llm",
                 evidence = llmAssessment.signals.map { it.detail },
-                needsAttention = llmAssessment.needsAttention
+                needsAttention = llmAssessment.needsAttention,
+                violations = llmAssessment.issues,
+                confidence = null
             )
         }
 
@@ -63,7 +67,9 @@ class StoreNameResolver(
                 issue = issue,
                 source = candidate.source,
                 evidence = assessment.signals.map { it.detail },
-                needsAttention = assessment.needsAttention
+                needsAttention = assessment.needsAttention,
+                violations = llmAssessment.issues + assessment.issues,
+                confidence = candidate.confidence
             )
         }
 
@@ -87,7 +93,9 @@ class StoreNameResolver(
                 issue = issue,
                 source = "text_extractor",
                 evidence = fallbackAssessment.signals.map { it.detail },
-                needsAttention = fallbackAssessment.needsAttention
+                needsAttention = fallbackAssessment.needsAttention,
+                violations = llmAssessment.issues + fallbackAssessment.issues,
+                confidence = null
             )
         }
 
@@ -108,7 +116,9 @@ class StoreNameResolver(
             issue = issue,
             source = "unresolved",
             evidence = evidence,
-            needsAttention = true
+            needsAttention = true,
+            violations = llmAssessment.issues,
+            confidence = null
         )
     }
 }

--- a/app/src/main/kotlin/com/example/coupontracker/feedback/FeedbackFeatureToggle.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/feedback/FeedbackFeatureToggle.kt
@@ -1,0 +1,34 @@
+package com.example.coupontracker.feedback
+
+import com.example.coupontracker.util.SecurePreferencesManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Feature flag access for feedback-driven learning flows.
+ */
+@Singleton
+class FeedbackFeatureToggle @Inject constructor(
+    private val securePreferencesManager: SecurePreferencesManager
+) {
+    companion object {
+        const val KEY_CAPTURE_VALIDATION_DATA = "feature_capture_validation_feedback"
+        const val KEY_ENABLE_OFFLINE_RETRAINING = "feature_enable_offline_retraining"
+    }
+
+    fun isValidationDatasetEnabled(): Boolean {
+        return securePreferencesManager.getBoolean(KEY_CAPTURE_VALIDATION_DATA, true)
+    }
+
+    fun isOfflineRetrainingEnabled(): Boolean {
+        return securePreferencesManager.getBoolean(KEY_ENABLE_OFFLINE_RETRAINING, false)
+    }
+
+    fun setValidationDatasetEnabled(enabled: Boolean) {
+        securePreferencesManager.saveBoolean(KEY_CAPTURE_VALIDATION_DATA, enabled)
+    }
+
+    fun setOfflineRetrainingEnabled(enabled: Boolean) {
+        securePreferencesManager.saveBoolean(KEY_ENABLE_OFFLINE_RETRAINING, enabled)
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/feedback/OcrAnonymizer.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/feedback/OcrAnonymizer.kt
@@ -1,0 +1,30 @@
+package com.example.coupontracker.feedback
+
+import java.security.MessageDigest
+import java.util.Locale
+
+/**
+ * Utility helpers for anonymising OCR payloads before persistence.
+ */
+object OcrAnonymizer {
+    private val whitespaceRegex = Regex("\\s+")
+    private val digitRegex = Regex("\\d")
+
+    fun sha256(text: String?): String? {
+        val normalized = text?.takeIf { it.isNotBlank() } ?: return null
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(normalized.toByteArray())
+        return hash.joinToString(separator = "") { byte ->
+            String.format(Locale.US, "%02x", byte)
+        }
+    }
+
+    fun preview(text: String?, maxLength: Int = 160): String? {
+        val normalized = text?.takeIf { it.isNotBlank() } ?: return null
+        val collapsed = whitespaceRegex.replace(normalized.trim(), " ")
+        val obfuscatedDigits = digitRegex.replace(collapsed) { matchResult ->
+            "#".repeat(matchResult.value.length)
+        }
+        return obfuscatedDigits.take(maxLength)
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/feedback/ValidatorFeedbackEvent.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/feedback/ValidatorFeedbackEvent.kt
@@ -1,0 +1,30 @@
+package com.example.coupontracker.feedback
+
+import com.example.coupontracker.data.model.FieldType
+
+/**
+ * Structured representation of a validator-driven feedback event.
+ */
+data class ValidatorFeedbackEvent(
+    val eventType: EventType,
+    val ocrText: String?,
+    val fieldOutcomes: List<FieldOutcome>,
+    val rationale: Map<String, Any?>,
+    val metadata: Map<String, Any?>
+) {
+    enum class EventType {
+        VALIDATOR_OVERRIDE,
+        USER_CORRECTION
+    }
+
+    data class FieldOutcome(
+        val field: FieldType,
+        val originalValue: String?,
+        val resolvedValue: String?,
+        val confidence: Float?,
+        val status: String,
+        val ruleViolations: List<String>,
+        val evidence: List<String>,
+        val replacementSource: String?
+    )
+}

--- a/app/src/main/kotlin/com/example/coupontracker/feedback/ValidatorFeedbackRecorder.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/feedback/ValidatorFeedbackRecorder.kt
@@ -1,0 +1,176 @@
+package com.example.coupontracker.feedback
+
+import com.example.coupontracker.data.model.Coupon
+import com.example.coupontracker.data.model.FieldType
+import com.example.coupontracker.data.repository.FeedbackDatasetRepository
+import com.example.coupontracker.extraction.FieldCandidate
+import com.example.coupontracker.extraction.validation.FieldValidationIssue
+import com.example.coupontracker.extraction.validation.FieldValidationSummary
+import com.example.coupontracker.extraction.validation.FieldValueBundle
+import com.example.coupontracker.universal.UniversalExtractionResult
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ValidatorFeedbackRecorder @Inject constructor(
+    private val feedbackDatasetRepository: FeedbackDatasetRepository
+) {
+    fun recordValidatorOverride(
+        rawOcrText: String?,
+        initialBundle: FieldValueBundle,
+        summary: FieldValidationSummary,
+        structuredCandidates: Map<FieldType, List<FieldCandidate>>,
+        metadata: Map<String, Any?>
+    ) {
+        val outcomes = buildOverrideOutcomes(initialBundle, summary, structuredCandidates)
+        if (outcomes.isEmpty()) {
+            return
+        }
+
+        val rationale = mapOf(
+            "issueCount" to summary.issues.size,
+            "storeNeedsAttention" to summary.storeResolution.needsAttention,
+            "storeViolations" to summary.storeResolution.violations,
+            "storeEvidence" to summary.storeResolution.evidence
+        )
+
+        val event = ValidatorFeedbackEvent(
+            eventType = ValidatorFeedbackEvent.EventType.VALIDATOR_OVERRIDE,
+            ocrText = rawOcrText,
+            fieldOutcomes = outcomes,
+            rationale = rationale,
+            metadata = metadata
+        )
+
+        feedbackDatasetRepository.recordEvent(event)
+    }
+
+    fun recordUserCorrection(
+        rawOcrText: String?,
+        extractionResult: UniversalExtractionResult,
+        correctedCoupon: Coupon,
+        metadata: Map<String, Any?>
+    ) {
+        val outcomes = buildCorrectionOutcomes(extractionResult, correctedCoupon)
+        if (outcomes.isEmpty()) {
+            return
+        }
+
+        val rationale = mapOf(
+            "correctedFields" to outcomes.map { it.field.name },
+            "confidence" to extractionResult.confidence
+        )
+
+        val event = ValidatorFeedbackEvent(
+            eventType = ValidatorFeedbackEvent.EventType.USER_CORRECTION,
+            ocrText = rawOcrText,
+            fieldOutcomes = outcomes,
+            rationale = rationale,
+            metadata = metadata
+        )
+
+        feedbackDatasetRepository.recordEvent(event)
+    }
+
+    private fun buildOverrideOutcomes(
+        initial: FieldValueBundle,
+        summary: FieldValidationSummary,
+        structuredCandidates: Map<FieldType, List<FieldCandidate>>
+    ): List<ValidatorFeedbackEvent.FieldOutcome> {
+        val issuesByField = summary.issues.groupBy { it.field }
+        val outcomes = mutableListOf<ValidatorFeedbackEvent.FieldOutcome>()
+
+        fun resolveStatus(field: FieldType, before: String?, after: String?, issue: FieldValidationIssue?): String {
+            return when {
+                issue != null && before != after -> "replaced"
+                issue != null -> "needs_review"
+                else -> "unchanged"
+            }
+        }
+
+        val storeIssue = issuesByField[FieldType.STORE_NAME]?.firstOrNull()
+        outcomes += ValidatorFeedbackEvent.FieldOutcome(
+            field = FieldType.STORE_NAME,
+            originalValue = initial.storeName,
+            resolvedValue = summary.fields.storeName,
+            confidence = summary.storeResolution.confidence,
+            status = resolveStatus(FieldType.STORE_NAME, initial.storeName, summary.fields.storeName, storeIssue),
+            ruleViolations = summary.storeResolution.violations,
+            evidence = summary.storeResolution.evidence,
+            replacementSource = storeIssue?.replacementSource
+        )
+
+        val descriptionIssue = issuesByField[FieldType.DESCRIPTION]?.firstOrNull()
+        if (initial.description != summary.fields.description || descriptionIssue != null) {
+            outcomes += ValidatorFeedbackEvent.FieldOutcome(
+                field = FieldType.DESCRIPTION,
+                originalValue = initial.description,
+                resolvedValue = summary.fields.description,
+                confidence = null,
+                status = resolveStatus(FieldType.DESCRIPTION, initial.description, summary.fields.description, descriptionIssue),
+                ruleViolations = descriptionIssue?.let { listOf(it.message) } ?: emptyList(),
+                evidence = emptyList(),
+                replacementSource = descriptionIssue?.replacementSource
+            )
+        }
+
+        val expiryIssue = issuesByField[FieldType.EXPIRY_DATE]?.firstOrNull()
+        if (initial.expiryDateText != summary.fields.expiryDateText || expiryIssue != null) {
+            val structuredConfidence = structuredCandidates[FieldType.EXPIRY_DATE]
+                ?.firstOrNull { it.value == summary.fields.expiryDateText }
+                ?.confidence
+            outcomes += ValidatorFeedbackEvent.FieldOutcome(
+                field = FieldType.EXPIRY_DATE,
+                originalValue = initial.expiryDateText,
+                resolvedValue = summary.fields.expiryDateText,
+                confidence = structuredConfidence,
+                status = resolveStatus(FieldType.EXPIRY_DATE, initial.expiryDateText, summary.fields.expiryDateText, expiryIssue),
+                ruleViolations = expiryIssue?.let { listOf(it.message) } ?: emptyList(),
+                evidence = emptyList(),
+                replacementSource = expiryIssue?.replacementSource
+            )
+        }
+
+        return outcomes.filterNot { outcome ->
+            outcome.originalValue == outcome.resolvedValue && outcome.ruleViolations.isEmpty()
+        }
+    }
+
+    private fun buildCorrectionOutcomes(
+        extractionResult: UniversalExtractionResult,
+        correctedCoupon: Coupon
+    ): List<ValidatorFeedbackEvent.FieldOutcome> {
+        val outcomes = mutableListOf<ValidatorFeedbackEvent.FieldOutcome>()
+        val extractedFields = extractionResult.extractedFields
+
+        fun addIfChanged(fieldType: FieldType, original: String?, corrected: String?) {
+            if ((original ?: "") == (corrected ?: "")) return
+            val confidence = extractedFields[fieldType]?.confidence
+            outcomes += ValidatorFeedbackEvent.FieldOutcome(
+                field = fieldType,
+                originalValue = original,
+                resolvedValue = corrected,
+                confidence = confidence,
+                status = "user_corrected",
+                ruleViolations = listOf("user_override"),
+                evidence = emptyList(),
+                replacementSource = "user"
+            )
+        }
+
+        addIfChanged(FieldType.STORE_NAME, extractionResult.coupon.storeName, correctedCoupon.storeName)
+        addIfChanged(FieldType.COUPON_CODE, extractionResult.coupon.redeemCode, correctedCoupon.redeemCode)
+        addIfChanged(
+            FieldType.EXPIRY_DATE,
+            extractionResult.coupon.expiryDate?.toString(),
+            correctedCoupon.expiryDate?.toString()
+        )
+        addIfChanged(
+            FieldType.DESCRIPTION,
+            extractionResult.coupon.description,
+            correctedCoupon.description
+        )
+
+        return outcomes
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt
@@ -33,6 +33,7 @@ import com.example.coupontracker.util.ExtractionConfig
 import com.example.coupontracker.util.ExtractionLogBuffer
 import com.example.coupontracker.util.ExtractionStage
 import com.example.coupontracker.util.ExtractionTelemetryService
+import com.example.coupontracker.feedback.ValidatorFeedbackRecorder
 import com.example.coupontracker.util.GenericFieldHeuristics
 import com.example.coupontracker.util.IndianCurrencyParser
 import com.example.coupontracker.util.LocalLlmOcrService
@@ -68,7 +69,8 @@ class ScannerViewModel @Inject constructor(
     private val performanceMonitor: ExtractionPerformanceMonitor,
     private val analyticsTracker: AnalyticsTracker,
     private val bitmapManager: com.example.coupontracker.util.BitmapManager,  // V2: Injected bitmap memory management
-    private val debugRepository: ExtractionDebugRepository
+    private val debugRepository: ExtractionDebugRepository,
+    private val validatorFeedbackRecorder: ValidatorFeedbackRecorder
 ) : AndroidViewModel(application) {
 
     private val _uiState = MutableStateFlow<ScannerUiState>(ScannerUiState.Initial)
@@ -1956,6 +1958,16 @@ class ScannerViewModel @Inject constructor(
                         correctedCoupon = correctedCoupon,
                         originalText = ocrText,
                         context = context
+                    )
+
+                    validatorFeedbackRecorder.recordUserCorrection(
+                        rawOcrText = ocrText,
+                        extractionResult = extractionResult,
+                        correctedCoupon = correctedCoupon,
+                        metadata = mapOf(
+                            "source" to TAG,
+                            "strategy" to ExtractionMethod.UNIVERSAL_EXTRACTION.name
+                        )
                     )
                     
                     // Update the current coupon with corrections if it's still in preview

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -13,9 +13,11 @@ import com.example.coupontracker.extraction.validation.FieldValidationIssue
 import com.example.coupontracker.extraction.validation.FieldValueBundle
 import com.example.coupontracker.extraction.validation.StoreNameResolver
 import com.example.coupontracker.extraction.validation.StoreNameValidator
+import com.example.coupontracker.extraction.validation.ValidationEventLogger
 import com.example.coupontracker.llm.LlmRuntimeManager
 import com.example.coupontracker.llm.LlmTelemetryService
 import com.example.coupontracker.ocr.OcrEngine
+import com.example.coupontracker.feedback.ValidatorFeedbackRecorder
 import com.example.coupontracker.schema.CouponSchema
 import com.example.coupontracker.schema.PromptGenerator
 import com.example.coupontracker.schema.SchemaValidator
@@ -40,7 +42,8 @@ class LocalLlmOcrService(
     private val ocrEngine: OcrEngine,
     private val injectedLlmRuntimeManager: LlmRuntimeManager? = null,
     private val injectedTelemetryService: LlmTelemetryService? = null,
-    private val customOcrTextProvider: (suspend (Bitmap) -> String?)? = null
+    private val customOcrTextProvider: (suspend (Bitmap) -> String?)? = null,
+    private val validatorFeedbackRecorder: ValidatorFeedbackRecorder? = null
 ) {
     
     companion object {
@@ -149,7 +152,27 @@ class LocalLlmOcrService(
             }
         }
     )
-    private val fieldValidationCoordinator = FieldValidationCoordinator(textExtractor, storeNameResolver)
+    private val validationEventLogger = ValidationEventLogger { event ->
+        if (event.summary.issues.isEmpty()) {
+            return@ValidationEventLogger
+        }
+        validatorFeedbackRecorder?.recordValidatorOverride(
+            rawOcrText = event.rawOcrText,
+            initialBundle = event.initial,
+            summary = event.summary,
+            structuredCandidates = event.structuredCandidates,
+            metadata = mapOf(
+                "serviceVersion" to SERVICE_VERSION,
+                "validator" to "FieldValidationCoordinator",
+                "modelVersion" to SUPPORTED_MODEL_VERSION
+            )
+        )
+    }
+    private val fieldValidationCoordinator = FieldValidationCoordinator(
+        textExtractor,
+        storeNameResolver,
+        validationEventLogger = validationEventLogger
+    )
     private var modelPinned = false
     
     init {

--- a/app/src/main/kotlin/com/example/coupontracker/worker/OfflineRetrainingWorker.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/worker/OfflineRetrainingWorker.kt
@@ -1,0 +1,154 @@
+package com.example.coupontracker.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.example.coupontracker.data.model.FieldType
+import com.example.coupontracker.data.repository.FeedbackDatasetRepository
+import com.example.coupontracker.feedback.FeedbackFeatureToggle
+import com.example.coupontracker.feedback.ValidatorFeedbackEvent
+import com.example.coupontracker.util.ExtractionConfig
+import com.example.coupontracker.util.SecurePreferencesManager
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.util.concurrent.TimeUnit
+
+@HiltWorker
+class OfflineRetrainingWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val feedbackDatasetRepository: FeedbackDatasetRepository,
+    private val featureToggle: FeedbackFeatureToggle,
+    private val securePreferencesManager: SecurePreferencesManager,
+    private val gson: Gson
+) : CoroutineWorker(appContext, workerParams) {
+
+    companion object {
+        private const val TAG = "OfflineRetraining"
+        private const val PREF_KEY_SUMMARY = "offline_retraining_summary"
+        private const val UNIQUE_WORK_NAME = "offline_retraining_job"
+
+        fun schedule(workManager: WorkManager) {
+            val request = PeriodicWorkRequestBuilder<OfflineRetrainingWorker>(7, TimeUnit.DAYS)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.NOT_REQUIRED)
+                        .setRequiresBatteryNotLow(true)
+                        .build()
+                )
+                .build()
+
+            workManager.enqueueUniquePeriodicWork(
+                UNIQUE_WORK_NAME,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                request
+            )
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        if (!featureToggle.isOfflineRetrainingEnabled()) {
+            Log.d(TAG, "Offline retraining disabled via feature flag")
+            return Result.success()
+        }
+
+        return try {
+            val records = feedbackDatasetRepository.getRecentEvents(
+                ValidatorFeedbackEvent.EventType.USER_CORRECTION,
+                limit = 200
+            )
+
+            if (records.isEmpty()) {
+                Log.d(TAG, "No user corrections available for offline retraining")
+                return Result.success()
+            }
+
+            val type = object : TypeToken<List<ValidatorFeedbackEvent.FieldOutcome>>() {}.type
+            val correctionCounts = mutableMapOf<FieldType, Int>()
+            val violationCounts = mutableMapOf<String, Int>()
+
+            records.forEach { record ->
+                val outcomes: List<ValidatorFeedbackEvent.FieldOutcome> = gson.fromJson(
+                    record.fieldOutcomesJson,
+                    type
+                )
+                outcomes.forEach { outcome ->
+                    correctionCounts[outcome.field] = correctionCounts.getOrDefault(outcome.field, 0) + 1
+                    outcome.ruleViolations.forEach { violation ->
+                        violationCounts[violation] = violationCounts.getOrDefault(violation, 0) + 1
+                    }
+                }
+            }
+
+            val adjustments = adjustThresholds(correctionCounts)
+
+            val summary = mapOf(
+                "timestamp" to System.currentTimeMillis(),
+                "corrections" to correctionCounts.mapKeys { it.key.name.lowercase() },
+                "violations" to violationCounts,
+                "thresholdAdjustments" to adjustments
+            )
+
+            securePreferencesManager.saveString(PREF_KEY_SUMMARY, gson.toJson(summary))
+            Log.i(TAG, "Offline retraining summary generated: $summary")
+
+            feedbackDatasetRepository.purgeOlderThan(days = 45)
+
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "Offline retraining failed", e)
+            Result.retry()
+        }
+    }
+
+    private fun adjustThresholds(correctionCounts: Map<FieldType, Int>): Map<String, Float> {
+        val adjustments = mutableMapOf<String, Float>()
+
+        correctionCounts.forEach { (field, count) ->
+            if (count < 5) return@forEach
+            val adjustment = (count / 25f).coerceAtMost(0.15f)
+            when (field) {
+                FieldType.STORE_NAME -> {
+                    val newValue = (ExtractionConfig.Thresholds.storeName + adjustment).coerceAtMost(0.9f)
+                    if (newValue != ExtractionConfig.Thresholds.storeName) {
+                        ExtractionConfig.Thresholds.storeName = newValue
+                        adjustments["storeName"] = newValue
+                    }
+                }
+                FieldType.COUPON_CODE -> {
+                    val newValue = (ExtractionConfig.Thresholds.code + adjustment).coerceAtMost(0.95f)
+                    if (newValue != ExtractionConfig.Thresholds.code) {
+                        ExtractionConfig.Thresholds.code = newValue
+                        adjustments["code"] = newValue
+                    }
+                }
+                FieldType.EXPIRY_DATE -> {
+                    val newValue = (ExtractionConfig.Thresholds.expiry + adjustment).coerceAtMost(0.9f)
+                    if (newValue != ExtractionConfig.Thresholds.expiry) {
+                        ExtractionConfig.Thresholds.expiry = newValue
+                        adjustments["expiry"] = newValue
+                    }
+                }
+                FieldType.AMOUNT -> {
+                    val newValue = (ExtractionConfig.Thresholds.cashback + adjustment).coerceAtMost(0.9f)
+                    if (newValue != ExtractionConfig.Thresholds.cashback) {
+                        ExtractionConfig.Thresholds.cashback = newValue
+                        adjustments["cashback"] = newValue
+                    }
+                }
+                else -> Unit
+            }
+        }
+
+        return adjustments
+    }
+}


### PR DESCRIPTION
## Summary
- add a validator feedback dataset table, repository, and anonymization utilities to capture override and correction events
- record validation issues and user corrections through LocalLlmOcrService and ScannerViewModel to build the feedback corpus
- schedule an offline retraining worker gated by feature flags to analyse feedback and adjust extraction thresholds

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: Android SDK not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3c3805de88328ad9a8f75b735329e