### PR TITLE
Fix visibility leaks and stabilize scanner UI state handling

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/analytics/StoreNameMetricsTracker.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/analytics/StoreNameMetricsTracker.kt
@@ -50,7 +50,7 @@ object StoreNameMetricsTracker {
         }
     }
 
-    fun recordAssessment(source: String, assessment: StoreNameValidator.Assessment) {
+    internal fun recordAssessment(source: String, assessment: StoreNameValidator.Assessment) {
         if (!initialized) {
             Log.w(TAG, "recordAssessment called before initialization")
             return

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinator.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidationCoordinator.kt
@@ -12,7 +12,7 @@ import java.util.Date
 data class FieldValidationSummary(
     val fields: FieldValueBundle,
     val issues: List<FieldValidationIssue>,
-    val storeResolution: StoreNameResolver.Resolution
+    val storeResolution: StoreNameResolution
 )
 
 /**

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/StoreNameResolver.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/StoreNameResolver.kt
@@ -4,21 +4,22 @@ import com.example.coupontracker.data.model.FieldType
 import com.example.coupontracker.extraction.FieldCandidate
 import com.example.coupontracker.util.GenericFieldHeuristics
 
+data class StoreNameResolution(
+    val value: String?,
+    val issue: FieldValidationIssue?,
+    val source: String?,
+    val evidence: List<String>,
+    val needsAttention: Boolean,
+    val violations: List<String>,
+    val confidence: Float?
+)
+
 /**
  * Resolves store name candidates using the validator and exposes provenance metadata.
  */
-class StoreNameResolver(
+internal class StoreNameResolver(
     private val validator: StoreNameValidator
 ) {
-    data class Resolution(
-        val value: String?,
-        val issue: FieldValidationIssue?,
-        val source: String?,
-        val evidence: List<String>,
-        val needsAttention: Boolean,
-        val violations: List<String>,
-        val confidence: Float?
-    )
 
     fun resolve(
         current: String?,
@@ -26,11 +27,11 @@ class StoreNameResolver(
         redeemCode: String?,
         structuredCandidates: List<FieldCandidate>,
         fallbackStore: String?
-    ): Resolution {
+    ): StoreNameResolution {
         val llmAssessment = validator.assessCandidate(current, description, redeemCode, source = "llm")
         if (llmAssessment.isAccepted) {
             val value = llmAssessment.canonical ?: llmAssessment.original
-            return Resolution(
+            return StoreNameResolution(
                 value = value,
                 issue = null,
                 source = "llm",
@@ -62,7 +63,7 @@ class StoreNameResolver(
                 severity = FieldValidationSeverity.ERROR,
                 replacementSource = candidate.source
             )
-            return Resolution(
+            return StoreNameResolution(
                 value = canonical,
                 issue = issue,
                 source = candidate.source,
@@ -88,7 +89,7 @@ class StoreNameResolver(
                 severity = FieldValidationSeverity.ERROR,
                 replacementSource = "text_extractor"
             )
-            return Resolution(
+            return StoreNameResolution(
                 value = canonical,
                 issue = issue,
                 source = "text_extractor",
@@ -111,7 +112,7 @@ class StoreNameResolver(
         )
 
         val sanitized = fallbackValue?.takeUnless { GenericFieldHeuristics.isGenericOrMissing(it) }
-        return Resolution(
+        return StoreNameResolution(
             value = sanitized,
             issue = issue,
             source = "unresolved",

--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/ScannerScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/ScannerScreen.kt
@@ -212,6 +212,7 @@ fun ScannerScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
+            val currentState = uiState
             when {
                 showCamera -> {
                     CameraView(
@@ -254,12 +255,12 @@ fun ScannerScreen(
                     }
                 }
 
-                uiState is ScannerUiState.Scanning -> {
+                currentState is ScannerUiState.Scanning -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center
                     ) {
-                        val progress = uiState.progress
+                        val progress = currentState.progress
                         val message = progress?.message ?: stringResource(id = R.string.scanner_progress_default)
                         val percent = progress?.percent
                         Column(
@@ -467,7 +468,7 @@ fun ScannerScreen(
                                 }
 
                                 // Show success message
-                                if (uiState is ScannerUiState.Saved) {
+                                if (currentState is ScannerUiState.Saved) {
                                     Spacer(modifier = Modifier.height(16.dp))
                                     Text(
                                         text = "Coupon saved successfully!",
@@ -483,8 +484,8 @@ fun ScannerScreen(
                                 }
 
                                 // Show already saved message
-                                if (uiState is ScannerUiState.AlreadySaved) {
-                                    val alreadySavedState = uiState as ScannerUiState.AlreadySaved
+                                if (currentState is ScannerUiState.AlreadySaved) {
+                                    val alreadySavedState = currentState
                                     Spacer(modifier = Modifier.height(16.dp))
                                     Text(
                                         text = "Coupon already saved: ${alreadySavedState.existingCoupon.redeemCode ?: alreadySavedState.existingCoupon.storeName}",
@@ -500,10 +501,10 @@ fun ScannerScreen(
                                 }
 
                                 // Show error message
-                                if (uiState is ScannerUiState.Error) {
+                                if (currentState is ScannerUiState.Error) {
                                     Spacer(modifier = Modifier.height(16.dp))
                                     Text(
-                                        text = (uiState as ScannerUiState.Error).message,
+                                        text = currentState.message,
                                         color = MaterialTheme.colorScheme.error,
                                         style = MaterialTheme.typography.bodyMedium
                                     )


### PR DESCRIPTION
## Summary
- restrict StoreNameMetricsTracker assessment recording to internal usage
- expose a public StoreNameResolution snapshot while keeping the resolver internal
- cache the scanner UI state locally so smart casts compile with delegated state

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3ce243bbc8328b601790df78bfcb0