### PR TITLE
Fix remaining state references in ScannerScreen

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/ScannerScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/ScannerScreen.kt
@@ -468,7 +468,7 @@ fun ScannerScreen(
                                 }
 
                                 // Show success message
-                                if (currentState is ScannerUiState.Saved) {
+                                if (state is ScannerUiState.Saved) {
                                     Spacer(modifier = Modifier.height(16.dp))
                                     Text(
                                         text = "Coupon saved successfully!",
@@ -484,8 +484,8 @@ fun ScannerScreen(
                                 }
 
                                 // Show already saved message
-                                if (currentState is ScannerUiState.AlreadySaved) {
-                                    val alreadySavedState = currentState
+                                if (state is ScannerUiState.AlreadySaved) {
+                                    val alreadySavedState = state as ScannerUiState.AlreadySaved
                                     Spacer(modifier = Modifier.height(16.dp))
                                     Text(
                                         text = "Coupon already saved: ${alreadySavedState.existingCoupon.redeemCode ?: alreadySavedState.existingCoupon.storeName}",
@@ -501,10 +501,10 @@ fun ScannerScreen(
                                 }
 
                                 // Show error message
-                                if (currentState is ScannerUiState.Error) {
+                                if (state is ScannerUiState.Error) {
                                     Spacer(modifier = Modifier.height(16.dp))
                                     Text(
-                                        text = currentState.message,
+                                        text = state.message,
                                         color = MaterialTheme.colorScheme.error,
                                         style = MaterialTheme.typography.bodyMedium
                                     )


### PR DESCRIPTION
## Summary
- replace lingering `currentState` usages in ScannerScreen with the bound `state` snapshot
- update the AlreadySaved handling to cast from the shared state variable
- ensure error messaging reads from the unified state reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3ded899c48328a040e44a6cab3da7