### PR TITLE
Skip CI pipelines for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI Guardrails
 
 on:
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "**/*.mdx"
   push:
     branches: [main]
 

--- a/.github/workflows/validator-tests.yml
+++ b/.github/workflows/validator-tests.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - '**'
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "**/*.mdx"
 
 jobs:
   unit-tests:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ For CI or local scripting workflows, use the helper wrapper which simply forward
 ./scripts/run_connected_android_tests.sh
 ```
 
+### **Continuous Integration Status**
+Two CI workflows validate incoming pull requests:
+
+- **CI Guardrails** – enforces repository hygiene checks and linting.
+- **Validator Test Suite** – runs the end-to-end unit test suite.
+
+Both jobs can take several minutes to finish after a pull request is opened or updated. Wait for these checks to report a ✅ status before merging to ensure all automated quality gates have passed. Pure documentation-only pull requests automatically skip these pipelines so minor README or docs updates do not waste CI capacity.
+
 ## 📊 Key Features
 
 ### **Advanced OCR Pipeline**


### PR DESCRIPTION
## Summary
- configure both CI Guardrails and Validator Test Suite workflows to ignore documentation-only pull requests
- document in the README that doc-only changes bypass CI to preserve capacity

## Testing
- not run (workflow configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68f3e19e6f98832884dd407b1b8250c8