### PR TITLE
Enable runtime-aware extraction strategy and stabilize LLM retries

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/llm/LlmRuntimeManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/LlmRuntimeManager.kt
@@ -462,7 +462,27 @@ class LlmRuntimeManager private constructor(private val context: Context) {
             return@withContext null
         }
     }
-    
+
+    fun cancelOngoingInference() {
+        val handle = modelHandle ?: return
+        runCatching {
+            nativeInterface.cancelInference(handle)
+        }.onFailure { error ->
+            Log.w(TAG, "Failed to cancel inference", error)
+        }
+    }
+
+    suspend fun resetAfterTimeout() {
+        lifecycleMutex.withLock {
+            autoUnloadJob?.cancel()
+            autoUnloadJob = null
+            unloadModelInternal(modelHandle)
+            modelHandle = null
+            referenceCount.set(0)
+            Log.d(TAG, "Model state reset after timeout")
+        }
+    }
+
     /**
      * Internal method to unload model (called under mutex)
      */

--- a/app/src/main/kotlin/com/example/coupontracker/util/ExtractionStrategy.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/ExtractionStrategy.kt
@@ -49,16 +49,32 @@ object ExtractionConfig {
 
     private var prefs: SharedPreferences? = null
 
-    // Default strategy (OCR_FIRST - most reliable with current model availability)
-    // LLM_FIRST and HYBRID disabled due to missing MLC-LLM binaries (see CRITICAL_PRODUCTION_BLOCKERS.md)
+    // Default strategy (OCR_FIRST - most reliable when advanced runtime unavailable)
     private var _strategy: ExtractionStrategy = ExtractionStrategy.OCR_FIRST
     @Volatile
     private var advancedStrategiesEnabled: Boolean = false
     @Volatile
     private var pendingAdvancedFlag: PendingAdvancedFlag? = null
     private var isInitialized = false
+    @Volatile
+    private var runtimeAdvancedAvailable: Boolean = false
 
     private data class PendingAdvancedFlag(val enabled: Boolean, val persist: Boolean)
+
+    @VisibleForTesting
+    internal var runtimeAvailabilityChecker: (Context) -> Boolean = { context ->
+        val nativeReady = runCatching {
+            com.example.coupontracker.llm.MlcLlmNative.loadLibrary(context)
+        }.getOrDefault(false) ||
+            runCatching { com.example.coupontracker.llm.MlcLlmNative.isAvailable() }
+                .getOrDefault(false)
+
+        val modelReady = runCatching {
+            com.example.coupontracker.llm.LlmRuntimeManager.getInstance(context).isModelAvailable()
+        }.getOrDefault(false)
+
+        nativeReady && modelReady
+    }
     
     /**
      * Initialize with application context
@@ -71,14 +87,23 @@ object ExtractionConfig {
 
         val pending = pendingAdvancedFlag
         val persistedAdvanced = prefs?.getBoolean(KEY_ADVANCED_ENABLED, false) ?: false
+        runtimeAdvancedAvailable = runCatching { runtimeAvailabilityChecker(context) }.getOrDefault(false)
+
+        advancedStrategiesEnabled = when {
+            pending != null -> pending.enabled
+            persistedAdvanced -> true
+            else -> runtimeAdvancedAvailable
+        }
+
         if (pending != null) {
-            advancedStrategiesEnabled = pending.enabled
             if (pending.persist) {
                 prefs?.edit()?.putBoolean(KEY_ADVANCED_ENABLED, pending.enabled)?.apply()
             }
             pendingAdvancedFlag = null
-        } else {
-            advancedStrategiesEnabled = persistedAdvanced
+        }
+
+        if (advancedStrategiesEnabled && !runtimeAdvancedAvailable) {
+            Log.i(TAG, "Advanced strategies preference set but runtime unavailable – awaiting model readiness")
         }
 
         val savedStrategy = readSavedStrategy()
@@ -89,7 +114,13 @@ object ExtractionConfig {
             )
         }
 
-        _strategy = savedStrategy?.takeIf { isStrategyAllowed(it) } ?: ExtractionStrategy.OCR_FIRST
+        val defaultStrategy = if (advancedStrategiesEnabled && runtimeAdvancedAvailable) {
+            ExtractionStrategy.LLM_FIRST
+        } else {
+            ExtractionStrategy.OCR_FIRST
+        }
+
+        _strategy = savedStrategy?.takeIf { isStrategyAllowed(it) } ?: defaultStrategy
 
         Log.d(TAG, "Loaded strategy: ${_strategy.name} (advanced=${advancedStrategiesEnabled})")
 
@@ -147,7 +178,7 @@ object ExtractionConfig {
         return getAvailableStrategies().contains(strategy)
     }
 
-    fun areAdvancedStrategiesEnabled(): Boolean = advancedStrategiesEnabled
+    fun areAdvancedStrategiesEnabled(): Boolean = advancedStrategiesEnabled && runtimeAdvancedAvailable
 
     fun setAdvancedStrategiesEnabled(enabled: Boolean, persist: Boolean = true) {
         if (!isInitialized) {
@@ -167,17 +198,43 @@ object ExtractionConfig {
             prefs?.edit()?.putBoolean(KEY_ADVANCED_ENABLED, enabled)?.apply()
         }
 
-        if (isInitialized) {
-            if (enabled) {
-                val savedStrategy = readSavedStrategy()
-                if (savedStrategy != null && isStrategyGuarded(savedStrategy)) {
-                    Log.i(TAG, "Advanced strategies enabled – restoring saved strategy ${savedStrategy.name}")
-                    updateStrategyInternal(savedStrategy, persist = false)
-                }
-            } else if (isStrategyGuarded(_strategy)) {
-                Log.i(TAG, "Advanced strategies disabled – reverting to OCR_FIRST in memory")
-                updateStrategyInternal(ExtractionStrategy.OCR_FIRST, persist = false)
+        if (!isInitialized) {
+            return
+        }
+
+        if (enabled) {
+            if (!runtimeAdvancedAvailable) {
+                Log.i(TAG, "Advanced strategies requested but runtime unavailable – waiting for availability")
+                return
             }
+
+            val savedStrategy = readSavedStrategy()
+            if (savedStrategy != null && isStrategyGuarded(savedStrategy)) {
+                Log.i(TAG, "Advanced strategies enabled – restoring saved strategy ${savedStrategy.name}")
+                updateStrategyInternal(savedStrategy, persist = false)
+            }
+        } else if (isStrategyGuarded(_strategy)) {
+            Log.i(TAG, "Advanced strategies disabled – reverting to OCR_FIRST in memory")
+            updateStrategyInternal(ExtractionStrategy.OCR_FIRST, persist = false)
+        }
+    }
+
+    fun refreshRuntimeAvailability(context: Context) {
+        if (!isInitialized) {
+            return
+        }
+
+        val previous = runtimeAdvancedAvailable
+        runtimeAdvancedAvailable = runCatching { runtimeAvailabilityChecker(context) }.getOrDefault(false)
+
+        if (!advancedStrategiesEnabled && runtimeAdvancedAvailable) {
+            Log.i(TAG, "Runtime advanced capabilities detected – enabling guarded strategies")
+            setAdvancedStrategiesEnabled(true, persist = false)
+        } else if (advancedStrategiesEnabled && !runtimeAdvancedAvailable) {
+            Log.w(TAG, "Runtime advanced capabilities lost – reverting to OCR_FIRST")
+            setAdvancedStrategiesEnabled(false, persist = false)
+        } else if (previous != runtimeAdvancedAvailable) {
+            Log.d(TAG, "Runtime advanced availability changed: $previous → $runtimeAdvancedAvailable")
         }
     }
 
@@ -188,6 +245,20 @@ object ExtractionConfig {
         advancedStrategiesEnabled = false
         pendingAdvancedFlag = null
         isInitialized = false
+        runtimeAdvancedAvailable = false
+        runtimeAvailabilityChecker = { context ->
+            val nativeReady = runCatching {
+                com.example.coupontracker.llm.MlcLlmNative.loadLibrary(context)
+            }.getOrDefault(false) ||
+                runCatching { com.example.coupontracker.llm.MlcLlmNative.isAvailable() }
+                    .getOrDefault(false)
+
+            val modelReady = runCatching {
+                com.example.coupontracker.llm.LlmRuntimeManager.getInstance(context).isModelAvailable()
+            }.getOrDefault(false)
+
+            nativeReady && modelReady
+        }
     }
 
     private fun updateStrategyInternal(strategy: ExtractionStrategy, persist: Boolean) {
@@ -215,7 +286,7 @@ object ExtractionConfig {
     }
 
     private fun isStrategyAllowed(strategy: ExtractionStrategy): Boolean {
-        return !isStrategyGuarded(strategy) || advancedStrategiesEnabled
+        return !isStrategyGuarded(strategy) || (advancedStrategiesEnabled && runtimeAdvancedAvailable)
     }
 
     private fun shouldExposeAdvancedStrategies(): Boolean {
@@ -227,11 +298,7 @@ object ExtractionConfig {
             return true
         }
 
-        return try {
-            com.example.coupontracker.llm.MlcLlmNative.isAvailable()
-        } catch (e: Exception) {
-            false
-        }
+        return runtimeAdvancedAvailable
     }
     
     /**

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -69,10 +69,12 @@ class LocalLlmOcrService(
         // Set to true to enable schema-driven prompts/validation, false to use manual/legacy
         private const val USE_SCHEMA_PROMPTS = true
         private const val USE_SCHEMA_VALIDATION = true
-        
+
         // Prompt optimization: Use compact prompts to reduce token count (920 → ~350 tokens)
         // Compact prompts rely on grammar enforcement for structure, reducing verbosity
         private const val USE_COMPACT_PROMPTS = true
+
+        private const val MAX_LLM_ATTEMPTS = 2
 
         private val STORE_CONTEXT_ANCHORS = listOf(
             "Claim Now",
@@ -124,6 +126,11 @@ class LocalLlmOcrService(
         }
 
     }
+
+    private data class LlmInferenceOutcome(
+        val response: String?,
+        val memoryUsageMb: Long
+    )
 
     private fun CouponInfo.toCanonicalContract(): CouponInfo {
         return copy(
@@ -277,6 +284,54 @@ class LocalLlmOcrService(
         }
     }
 
+    private suspend fun runLlmInferenceWithRetry(
+        rawOcrText: String,
+        prompt: String,
+        progressCallback: ((LlmProgressUpdate) -> Unit)?
+    ): LlmInferenceOutcome {
+        var attempt = 0
+        var lastMemoryUsage = 0L
+        var response: String? = null
+
+        while (attempt < MAX_LLM_ATTEMPTS && response == null) {
+            lastMemoryUsage = llmRuntime.getMemoryStats().modelLoadedMemoryMB.toLong()
+            val attemptStart = System.currentTimeMillis()
+            response = withTimeoutOrNull(INFERENCE_TIMEOUT_MS) {
+                llmRuntime.runTextInference(rawOcrText, prompt, keepLoaded = modelPinned)
+            }
+
+            if (response != null) {
+                break
+            }
+
+            val elapsed = System.currentTimeMillis() - attemptStart
+            telemetryService.recordTimeout(elapsed, lastMemoryUsage)
+            Log.w(
+                TAG,
+                "LLM inference timed out after ${elapsed}ms (attempt ${attempt + 1}/$MAX_LLM_ATTEMPTS)"
+            )
+
+            llmRuntime.cancelOngoingInference()
+            runCatching { llmRuntime.resetAfterTimeout() }
+                .onFailure { error -> Log.w(TAG, "Failed to reset LLM after timeout", error) }
+            modelPinned = false
+
+            if (attempt + 1 < MAX_LLM_ATTEMPTS) {
+                notifyProgress(
+                    stage = LlmProgressStage.WARMING_UP,
+                    percent = 30,
+                    message = "AI timeout – retrying…",
+                    progressCallback = progressCallback
+                )
+                ensureModelWarm("timeout_retry", progressCallback)
+            }
+
+            attempt++
+        }
+
+        return LlmInferenceOutcome(response, lastMemoryUsage)
+    }
+
     private fun notifyProgress(
         stage: LlmProgressStage,
         percent: Int?,
@@ -395,10 +450,9 @@ class LocalLlmOcrService(
                 message = "Running on-device AI…",
                 progressCallback = progressCallback
             )
-            memoryUsage = llmRuntime.getMemoryStats().modelLoadedMemoryMB.toLong()
-            val llmResponse = withTimeoutOrNull(INFERENCE_TIMEOUT_MS) {
-                llmRuntime.runTextInference(rawOcrText, prompt, keepLoaded = modelPinned)
-            }
+            val llmOutcome = runLlmInferenceWithRetry(rawOcrText, prompt, progressCallback)
+            memoryUsage = llmOutcome.memoryUsageMb
+            val llmResponse = llmOutcome.response
 
             // Step 5: Parse and validate response
             if (llmResponse != null) {
@@ -573,12 +627,11 @@ class LocalLlmOcrService(
             Log.d(TAG, "⏱️  Subsequent runs: ~10s")
             Log.d(TAG, "⏳ Please wait... (max ${INFERENCE_TIMEOUT_MS / 1000}s)")
             Log.d(TAG, "========================================")
-            memoryUsage = llmRuntime.getMemoryStats().modelLoadedMemoryMB.toLong()
             val inferenceStartTime = System.currentTimeMillis()
-            val llmResponse = withTimeoutOrNull(INFERENCE_TIMEOUT_MS) {
-                llmRuntime.runTextInference(ocrText, prompt, keepLoaded = modelPinned)
-            }
+            val llmOutcome = runLlmInferenceWithRetry(ocrText, prompt, progressCallback = null)
             val inferenceElapsed = System.currentTimeMillis() - inferenceStartTime
+            memoryUsage = llmOutcome.memoryUsageMb
+            val llmResponse = llmOutcome.response
             Log.d(TAG, "⏱️  Inference completed in ${inferenceElapsed / 1000}s")
 
             // Step 6: Parse and validate response

--- a/app/src/test/kotlin/com/example/coupontracker/util/ExtractionConfigTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/ExtractionConfigTest.kt
@@ -25,6 +25,7 @@ class ExtractionConfigTest {
         clearPreferences()
         MlcLlmNative.resetForTests()
         ExtractionConfig.resetForTesting()
+        ExtractionConfig.runtimeAvailabilityChecker = { false }
     }
 
     @After
@@ -32,6 +33,7 @@ class ExtractionConfigTest {
         MlcLlmNative.libraryLoader = originalLoader
         MlcLlmNative.resetForTests()
         ExtractionConfig.resetForTesting()
+        ExtractionConfig.runtimeAvailabilityChecker = { false }
         clearPreferences()
     }
 
@@ -45,6 +47,7 @@ class ExtractionConfigTest {
 
     @Test
     fun enablingAdvancedStrategiesRestoresPersistedSelection() {
+        ExtractionConfig.runtimeAvailabilityChecker = { true }
         ExtractionConfig.init(context)
         ExtractionConfig.setAdvancedStrategiesEnabled(true)
         assertTrue(ExtractionConfig.areAdvancedStrategiesEnabled())
@@ -53,6 +56,7 @@ class ExtractionConfigTest {
         assertEquals(ExtractionStrategy.LLM_FIRST, ExtractionConfig.getStrategy())
 
         ExtractionConfig.resetForTesting()
+        ExtractionConfig.runtimeAvailabilityChecker = { true }
         ExtractionConfig.init(context)
 
         assertTrue(ExtractionConfig.areAdvancedStrategiesEnabled())
@@ -61,6 +65,7 @@ class ExtractionConfigTest {
 
     @Test
     fun persistedAdvancedSelectionResumesWhenGuardToggledOn() {
+        ExtractionConfig.runtimeAvailabilityChecker = { false }
         ExtractionConfig.init(context)
         context.getSharedPreferences("extraction_config", Context.MODE_PRIVATE)
             .edit()
@@ -68,10 +73,13 @@ class ExtractionConfigTest {
             .apply()
 
         ExtractionConfig.resetForTesting()
+        ExtractionConfig.runtimeAvailabilityChecker = { false }
         ExtractionConfig.init(context)
 
         assertEquals(ExtractionStrategy.OCR_FIRST, ExtractionConfig.getStrategy())
 
+        ExtractionConfig.runtimeAvailabilityChecker = { true }
+        ExtractionConfig.refreshRuntimeAvailability(context)
         ExtractionConfig.setAdvancedStrategiesEnabled(true)
 
         assertTrue(ExtractionConfig.areAdvancedStrategiesEnabled())
@@ -80,14 +88,7 @@ class ExtractionConfigTest {
 
     @Test
     fun availableStrategiesIncludeAdvancedWhenLibraryReadyAndGuardEnabled() {
-        val stubLoader = object : MlcLlmNative.Companion.NativeLibraryLoader {
-            override fun loadLibrary(name: String) {}
-            override fun load(path: String) {}
-        }
-        MlcLlmNative.libraryLoader = stubLoader
-        assertTrue(MlcLlmNative.loadLibrary(context))
-        assertTrue(MlcLlmNative.isAvailable())
-
+        ExtractionConfig.runtimeAvailabilityChecker = { true }
         ExtractionConfig.init(context)
         ExtractionConfig.setAdvancedStrategiesEnabled(true)
 
@@ -95,6 +96,15 @@ class ExtractionConfigTest {
 
         assertTrue(strategies.contains(ExtractionStrategy.LLM_FIRST))
         assertTrue(strategies.contains(ExtractionStrategy.HYBRID))
+    }
+
+    @Test
+    fun runtimeAvailabilityAutomaticallyEnablesAdvancedStrategies() {
+        ExtractionConfig.runtimeAvailabilityChecker = { true }
+        ExtractionConfig.init(context)
+
+        assertTrue(ExtractionConfig.areAdvancedStrategiesEnabled())
+        assertEquals(ExtractionStrategy.LLM_FIRST, ExtractionConfig.getStrategy())
     }
 
     private fun clearPreferences() {

--- a/docs/OCR_LLM_PIPELINE_ISSUES.md
+++ b/docs/OCR_LLM_PIPELINE_ISSUES.md
@@ -1,0 +1,44 @@
+# OCR ↔ LLM Pipeline Audit and Fix Plan
+
+## How the current pipeline stitches OCR and the LLM together
+- `LocalLlmOcrService.processCouponImageTyped` always begins by running on-device OCR to build the prompt that is handed to the LLM, and aborts if that OCR transcript is blank. 【F:app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt†L362-L487】
+- The LLM path returns structured coupon JSON when inference succeeds; otherwise `ScannerViewModel.scanWithLlmFirstPath` falls back to the universal extractor and, ultimately, the legacy OCR heuristics. 【F:app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt†L390-L512】【F:app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt†L1594-L1788】
+- The OCR-first strategy and all fallbacks reuse the same OCR transcript so deterministic passes, progressive extraction, and the learning hooks can continue processing even if the LLM response is rejected. 【F:app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt†L560-L614】【F:app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt†L1594-L1779】
+
+## Issues uncovered
+
+### 1. Strategy gating keeps production stuck on OCR/legacy paths
+`ExtractionConfig` exposes only `OCR_FIRST` and `LEGACY` unless the hidden "advanced" flag is toggled, so any saved `LLM_FIRST` or `HYBRID` choice is rejected during startup. In practice, the strategy resolver loads `LEGACY` for many users and never lets the progressive or LLM-first flows execute. 【F:app/src/main/kotlin/com/example/coupontracker/util/ExtractionStrategy.kt†L52-L141】
+
+**Plan**
+1. Detect real model availability during boot and enable `LLM_FIRST` / `HYBRID` when files are present instead of hiding them behind a persisted flag.
+2. Allow Remote Config and Settings selections to persist without being downgraded, falling back to `LEGACY` only when the chosen strategy throws.
+3. Add telemetry on strategy coercions so QA can catch unexpected downgrades quickly.
+
+### 2. LLM inference times out before returning structured JSON
+`processCouponImageTyped` runs the MiniCPM text inference under a 90 s timeout. When the runtime stalls or the model has to warm up, the coroutine times out and surfaces `ExtractResult.Failed`, immediately forcing the pipeline down to the OCR-only path. 【F:app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt†L399-L512】
+
+**Plan**
+1. Warm the model proactively during app startup and reuse the handle between requests instead of deferring warmup to the first capture.
+2. Stream token chunks out of `runTextInference` so long prompts do not hit the timeout; fail fast only when the runtime is unresponsive.
+3. Surface richer error metadata to the validator so the app can retry the LLM path (or switch to a lighter prompt) before giving up on structured extraction.
+
+### 3. OCR transcripts are discarded before reaching the universal extractor
+All OCR-first and fallback paths collapse `MultiEngineOCR.OCRResult.Success` to `extractedInfo.values.joinToString(" ")` rather than using the raw `text` field. That replaces the cleaned transcript with heuristic guesses, preventing the progressive pipeline from seeing the real OCR output. 【F:app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt†L560-L583】【F:app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt†L1600-L1635】【F:app/src/main/kotlin/com/example/coupontracker/util/MultiEngineOCR.kt†L35-L118】
+
+**Plan**
+1. Pass the raw `text` payload through every universal extraction call and persist it alongside heuristic fields for auditing.
+2. Update `MultiCouponExtractionService`, `HybridCouponDetector`, and batch flows to do the same so the progressive passes never operate on lossy data.
+3. Add regression tests that fail whenever the OCR transcript is replaced by derived fields.
+
+### 4. Legacy `TextExtractor` heuristics remain the terminal fallback
+When universal extraction or the LLM fails, `createCouponFromExtractedInfo` drops back to `TextExtractor`'s frequency/regex heuristics, which still mislabel merchants and codes on noisy receipts. 【F:app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt†L103-L200】【F:app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/ScannerViewModel.kt†L1916-L1950】
+
+**Plan**
+1. Replace the `TextExtractor` fallback with the progressive extractor’s field fusion so the same candidate scoring logic runs in every path.
+2. Feed fallback coupons and their OCR transcripts into the learning APIs so repeated corrections retrain the detector instead of masking issues.
+3. Gate the legacy heuristics behind a developer toggle for debugging only, ensuring production users always hit the progressive or LLM-based flows.
+
+## Long-term safeguards
+- Instrument strategy selection, LLM latency, and fallback counts in telemetry dashboards to detect regressions early.
+- Maintain end-to-end tests that exercise each strategy (LLM-first, OCR-first, hybrid, legacy) so future refactors cannot silently reintroduce the same failures.


### PR DESCRIPTION
## Summary
- let `ExtractionConfig` automatically expose LLM/HYBRID strategies when the native runtime and model are available and provide a refresh hook for runtime changes
- add cancellation/reset helpers to `LlmRuntimeManager` and leverage them for a retryable MiniCPM inference path in `LocalLlmOcrService`
- update Robolectric coverage so advanced-strategy persistence is validated under the new runtime-aware gating

## Testing
- not run (Android SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f4fc5680508328a74045663e45e7ca