### PR TITLE
Document and configure protected branches

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,50 @@
+repository:
+  name: coupontracker
+  allow_merge_commit: true
+  allow_squash_merge: true
+  allow_rebase_merge: false
+  delete_branch_on_merge: true
+
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        contexts: []
+      enforce_admins: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+        required_approving_review_count: 1
+      restrictions: null
+      required_linear_history: false
+      allow_force_pushes: false
+      allow_deletions: false
+  - name: release/*
+    protection:
+      required_status_checks:
+        strict: true
+        contexts: []
+      enforce_admins: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+        required_approving_review_count: 1
+      restrictions: null
+      required_linear_history: false
+      allow_force_pushes: false
+      allow_deletions: false
+  - name: hotfix/*
+    protection:
+      required_status_checks:
+        strict: true
+        contexts: []
+      enforce_admins: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+        required_approving_review_count: 1
+      restrictions: null
+      required_linear_history: false
+      allow_force_pushes: false
+      allow_deletions: false

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ python coupon_trainer_cli.py --url <URL> --output-dir <OUTPUT_DIR>
 ./gradlew assembleDebug
 ```
 
+## 🔐 Protected Branch Workflow
+
+We enforce branch protection on `main`, `release/*`, and `hotfix/*` to keep production code stable. All contributions must:
+
+- Land via pull requests with at least one approving review from the appropriate code owner.
+- Pass all required status checks before the merge button is enabled.
+- Avoid force pushes or history rewrites against the protected branches; create feature branches for new work instead.
+
+See [`docs/git-maintenance/protected-branches.md`](docs/git-maintenance/protected-branches.md) for the full policy, including expectations for release and hotfix procedures.
+
 ## 🧪 Testing
 
 ### **Unit Tests (Local JVM Stubs)**

--- a/docs/git-maintenance/protected-branches.md
+++ b/docs/git-maintenance/protected-branches.md
@@ -1,0 +1,30 @@
+# Protected Branches
+
+The following long-lived branches are designated as protected and should only be updated via approved pull requests:
+
+| Branch Pattern | Purpose | Update Policy |
+| -------------- | ------- | ------------- |
+| `main` | Primary integration branch that always reflects the latest production-ready code. | Only merge commits created through approved pull requests. Rebase, fast-forward, and direct pushes are prohibited. |
+| `release/*` | Release stabilization branches used to prepare tagged releases. | Only release managers may merge approved changes related to the upcoming release. Delete old release branches after the release has shipped. |
+| `hotfix/*` | Emergency fixes that must be applied to production quickly. | Hotfix branches are created from the latest production tag, reviewed, and merged back into both `main` and the relevant `release/*` branch as soon as they pass review. |
+
+## Required Reviews and Status Checks
+
+* Every pull request targeting a protected branch must receive at least one approving review from a code owner or designated reviewer.
+* All required status checks must pass before the pull request can be merged.
+* Squash or merge commits are allowed, but merge commits must be created via the pull request UI to preserve review history.
+
+## Merge Restrictions
+
+* Force pushes to protected branches are disabled.
+* Branch deletions are restricted to repository administrators.
+* Signed commits are recommended for merges into protected branches.
+
+## Contributor Workflow Expectations
+
+1. Create feature branches from `main` when starting work.
+2. Open a pull request targeting `main` (or the appropriate `release/*` or `hotfix/*` branch) once the work is ready for review.
+3. Ensure that automated checks pass before requesting a review.
+4. Obtain the required approvals and merge via the pull request interface.
+
+For questions about branch policies, reach out to the release management team in the `#dev-infra` channel.


### PR DESCRIPTION
## Summary
- add branch protection policy documentation for main, release, and hotfix branches
- configure repository settings to require reviews and block force pushes on protected branches
- update the README to communicate the new protection workflow to the team

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f512d89d4883288b86b9abf236141e