### PR TITLE
Add branch inventory review document

### DIFF
--- a/docs/branch_inventory.md
+++ b/docs/branch_inventory.md
@@ -1,0 +1,19 @@
+# Branch Inventory Review (October 19, 2025)
+
+- **Threshold for archival review:** 60 days
+- **Reference time:** Sun Oct 19 16:35:41 UTC 2025
+
+## Active Branches
+
+| Branch | Last Commit (UTC) | Age | Owner (from latest commit) | Action | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `work` | 2025-10-19 15:15:20 | < 1 day | Chetan <48746638+chetank2@users.noreply.github.com> | Keep | Branch is current development head. No rebase needed; aligned with latest `main`. |
+
+## Archived / Tagged Branches
+
+_No branches exceeded the 60-day threshold, so no archival tags were created._
+
+## Follow-up
+
+- Owner identified via `git show --summary work`. No additional outreach required because the branch is active and up to date.
+- Rebase check confirmed the branch is already equivalent to the latest `main` commit.


### PR DESCRIPTION
## Summary
- add a branch inventory review document capturing the 60-day threshold status
- document the active branch owner and confirm no archival tagging is required

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f512da7bdc83288adad88af359427e