### PR TITLE
Add coupon editing flow

### DIFF
--- a/app/src/androidTest/java/com/example/coupontracker/ui/EditCouponFlowTest.kt
+++ b/app/src/androidTest/java/com/example/coupontracker/ui/EditCouponFlowTest.kt
@@ -1,0 +1,86 @@
+package com.example.coupontracker.ui
+
+import androidx.core.os.bundleOf
+import androidx.navigation.NavController
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.action.ViewActions.scrollTo
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.platform.app.InstrumentationRegistry
+import com.example.coupontracker.R
+import com.example.coupontracker.data.model.Coupon
+import com.example.coupontracker.data.repository.CouponRepository
+import com.example.coupontracker.ui.fragment.AddFragment
+import com.example.coupontracker.ui.fragment.DetailFragment
+import com.example.coupontracker.util.launchFragmentInHiltContainer
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import javax.inject.Inject
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@HiltAndroidTest
+class EditCouponFlowTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var couponRepository: CouponRepository
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun editingCouponUpdatesDetailScreen() {
+        val couponId = runBlocking {
+            couponRepository.insertCoupon(
+                Coupon(
+                    storeName = "Test Store",
+                    description = "Save 10%",
+                    cashbackAmount = 10.0,
+                    redeemCode = "CODE10",
+                    imageUri = null,
+                    status = "Active"
+                )
+            )
+        }
+
+        val args = bundleOf("couponId" to couponId)
+        lateinit var navController: NavController
+
+        launchFragmentInHiltContainer<AddFragment>(fragmentArgs = args) { controller ->
+            navController = controller
+            controller.setCurrentDestination(R.id.addFragment, args)
+        }
+
+        onView(withId(R.id.storeNameInput)).check(matches(withText("Test Store")))
+
+        val updatedDescription = "Updated savings"
+        onView(withId(R.id.descriptionInput)).perform(scrollTo(), replaceText(updatedDescription), closeSoftKeyboard())
+        onView(withId(R.id.saveButton)).perform(scrollTo(), click())
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        assertThat(navController.currentDestination?.id).isEqualTo(R.id.detailFragment)
+
+        val updatedCoupon = runBlocking { couponRepository.getCouponById(couponId) }
+        assertThat(updatedCoupon?.description).isEqualTo(updatedDescription)
+
+        launchFragmentInHiltContainer<DetailFragment>(fragmentArgs = bundleOf("couponId" to couponId)) { controller ->
+            controller.setCurrentDestination(R.id.detailFragment, bundleOf("couponId" to couponId))
+        }
+
+        onView(withId(R.id.description)).check(matches(withText(updatedDescription)))
+        onView(withId(R.id.storeName)).check(matches(withText("Test Store")))
+    }
+}

--- a/app/src/androidTest/java/com/example/coupontracker/util/HiltTestExtensions.kt
+++ b/app/src/androidTest/java/com/example/coupontracker/util/HiltTestExtensions.kt
@@ -1,0 +1,43 @@
+package com.example.coupontracker.util
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.annotation.StyleRes
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.navigation.NavController
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.example.coupontracker.HiltTestActivity
+import com.example.coupontracker.R
+
+inline fun <reified T : Fragment> launchFragmentInHiltContainer(
+    fragmentArgs: Bundle? = null,
+    @StyleRes themeResId: Int = R.style.Theme_CouponTracker,
+    crossinline action: T.(NavController) -> Unit = {}
+) {
+    val startActivityIntent = Intent(ApplicationProvider.getApplicationContext(), HiltTestActivity::class.java).apply {
+        putExtra(FragmentActivity.THEME_EXTRAS_BUNDLE_KEY, themeResId)
+    }
+
+    ActivityScenario.launch<HiltTestActivity>(startActivityIntent).onActivity { activity ->
+        val fragment = activity.supportFragmentManager.fragmentFactory.instantiate(
+            T::class.java.classLoader!!,
+            T::class.java.name
+        )
+        fragment.arguments = fragmentArgs
+
+        activity.supportFragmentManager.beginTransaction()
+            .replace(android.R.id.content, fragment)
+            .commitNow()
+
+        val navController = androidx.navigation.testing.TestNavHostController(activity)
+        navController.setGraph(R.navigation.nav_graph)
+        fragment.view?.let { view ->
+            androidx.navigation.Navigation.setViewNavController(view, navController)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        action(fragment as T, navController)
+    }
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.coupontracker">
+    <application>
+        <activity
+            android:name="com.example.coupontracker.HiltTestActivity"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/app/src/debug/java/com/example/coupontracker/HiltTestActivity.kt
+++ b/app/src/debug/java/com/example/coupontracker/HiltTestActivity.kt
@@ -1,0 +1,7 @@
+package com.example.coupontracker
+
+import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class HiltTestActivity : AppCompatActivity()

--- a/app/src/main/kotlin/com/example/coupontracker/ui/fragment/AddFragment.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/fragment/AddFragment.kt
@@ -27,8 +27,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
 import com.example.coupontracker.R
+import com.example.coupontracker.data.model.Coupon
 import com.example.coupontracker.databinding.FragmentAddBinding
 import com.example.coupontracker.ui.viewmodel.AddCouponViewModel
 import com.example.coupontracker.util.CouponInfo
@@ -59,7 +61,7 @@ class AddFragment : Fragment() {
     private var _binding: FragmentAddBinding? = null
     private val binding get() = _binding!!
     private val viewModel: AddCouponViewModel by viewModels()
-    private lateinit var cameraExecutor: ExecutorService
+    private var cameraExecutor: ExecutorService? = null
     private var imageUri: Uri? = null
     private var imageCapture: ImageCapture? = null
     @Inject lateinit var imageProcessor: com.example.coupontracker.util.ImageProcessor
@@ -68,6 +70,9 @@ class AddFragment : Fragment() {
     private lateinit var securePreferencesManager: SecurePreferencesManager
     @Inject lateinit var modelDownloadManager: ModelDownloadManager
     private var modelStatusJob: Job? = null
+    private val args: AddFragmentArgs by navArgs()
+    private var isEditMode: Boolean = false
+    private var hasBoundEditCoupon: Boolean = false
 
     companion object {
         private const val TAG = "AddFragment"
@@ -113,26 +118,34 @@ class AddFragment : Fragment() {
         sharedPreferences = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         securePreferencesManager = SecurePreferencesManager(requireContext())
         // modelDownloadManager = ModelDownloadManager(requireContext()) // This line is removed as it's now injected
-        setupCamera()
+        val couponIdArg = args.couponId
+        isEditMode = couponIdArg > 0
+
+        if (isEditMode) {
+            binding.toolbar.title = getString(R.string.edit_coupon)
+            binding.saveButton.text = getString(R.string.update_coupon)
+            binding.viewFinder.visibility = View.GONE
+            binding.selectedImageView.visibility = View.INVISIBLE
+            viewModel.loadCouponForEdit(couponIdArg)
+        } else {
+            setupCamera()
+        }
         setupClickListeners()
         setupMistralApiSwitch()
         setupLlmOcrControls()
         observeViewModel()
 
         // Handle arguments from scanner
-        arguments?.let { args ->
-            val safeArgs = AddFragmentArgs.fromBundle(args)
-            safeArgs.couponInfo?.let { couponInfo ->
-                populateFormWithCouponInfo(couponInfo)
-            }
+        args.couponInfo?.let { couponInfo ->
+            populateFormWithCouponInfo(couponInfo)
+        }
 
-            safeArgs.imageUri?.let { uriString ->
-                if (uriString.isNotEmpty()) {
-                    val uri = Uri.parse(uriString)
-                    imageUri = uri
-                    viewModel.setImageUri(uri)
-                    displaySelectedImage(uri)
-                }
+        args.imageUri?.let { uriString ->
+            if (uriString.isNotEmpty()) {
+                val uri = Uri.parse(uriString)
+                imageUri = uri
+                viewModel.setImageUri(uri)
+                displaySelectedImage(uri)
             }
         }
     }
@@ -235,9 +248,12 @@ class AddFragment : Fragment() {
             findNavController().navigateUp()
         }
 
-        binding.captureButton.setOnClickListener {
-            ExtractionLogBuffer.appendInfo(TAG, "Capture button tapped")
-            captureImage()
+        binding.captureButton.apply {
+            visibility = if (isEditMode) View.GONE else View.VISIBLE
+            setOnClickListener {
+                ExtractionLogBuffer.appendInfo(TAG, "Capture button tapped")
+                captureImage()
+            }
         }
 
         binding.galleryButton.setOnClickListener {
@@ -610,8 +626,8 @@ class AddFragment : Fragment() {
                         findNavController().navigate(
                             AddFragmentDirections.actionAddToDetail(viewModel.couponId)
                         )
-                    ExtractionLogBuffer.appendInfo(TAG, "Clearing logs after navigation")
-                    ExtractionLogBuffer.clear()
+                        ExtractionLogBuffer.appendInfo(TAG, "Clearing logs after navigation")
+                        ExtractionLogBuffer.clear()
                     }
                 }
             }
@@ -624,6 +640,17 @@ class AddFragment : Fragment() {
                         ExtractionLogBuffer.appendError(TAG, "Error from view model: $it")
                         Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
                         viewModel.clearError()
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.couponForEdit.collect { coupon ->
+                    if (coupon != null && !hasBoundEditCoupon) {
+                        populateFormWithCoupon(coupon)
+                        hasBoundEditCoupon = true
                     }
                 }
             }
@@ -851,6 +878,37 @@ class AddFragment : Fragment() {
         }
     }
 
+    private fun populateFormWithCoupon(coupon: Coupon) {
+        val couponInfo = couponInputManager.toCouponInfo(coupon)
+        populateFormWithCouponInfo(couponInfo)
+
+        coupon.expiryDate?.let { date ->
+            val dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+            binding.expiryDateInput.setText(dateFormat.format(date))
+            viewModel.setExpiryDate(date)
+        }
+
+        coupon.reminderDate?.let { reminder ->
+            val dateFormat = SimpleDateFormat("MMM dd, yyyy HH:mm", Locale.getDefault())
+            binding.reminderDateText.text = "Reminder set for: ${dateFormat.format(reminder)}"
+            binding.reminderDateText.visibility = View.VISIBLE
+            viewModel.setReminderDate(reminder)
+        } ?: run {
+            binding.reminderDateText.visibility = View.GONE
+        }
+
+        binding.priorityCheckbox.isChecked = coupon.isPriority
+        viewModel.setPriority(coupon.isPriority)
+
+        coupon.imageUri?.let { storedUri ->
+            runCatching { Uri.parse(storedUri) }.getOrNull()?.let { uri ->
+                imageUri = uri
+                viewModel.setImageUri(uri)
+                displaySelectedImage(uri)
+            }
+        }
+    }
+
     private fun showDatePicker() {
         val datePicker = MaterialDatePicker.Builder.datePicker()
             .setTitleText("Select Expiry Date")
@@ -925,8 +983,9 @@ class AddFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        cameraExecutor.shutdown()
+        cameraExecutor?.shutdown()
         modelStatusJob?.cancel()
+        hasBoundEditCoupon = false
         _binding = null
     }
 }

--- a/app/src/main/kotlin/com/example/coupontracker/ui/fragment/DetailFragment.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/fragment/DetailFragment.kt
@@ -78,7 +78,7 @@ class DetailFragment : Fragment() {
                 return when (menuItem.itemId) {
                     R.id.action_edit -> {
                         findNavController().navigate(
-                            DetailFragmentDirections.actionDetailFragmentToEditFragment(args.couponId)
+                            DetailFragmentDirections.actionDetailFragmentToEdit(args.couponId)
                         )
                         true
                     }

--- a/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/AddCouponViewModel.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/viewmodel/AddCouponViewModel.kt
@@ -32,6 +32,9 @@ class AddCouponViewModel @Inject constructor(
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error
 
+    private val _couponForEdit = MutableStateFlow<Coupon?>(null)
+    val couponForEdit: StateFlow<Coupon?> = _couponForEdit
+
     var couponId: Long = 0
         private set
 
@@ -40,6 +43,8 @@ class AddCouponViewModel @Inject constructor(
     private var currentExpiryDate: Date? = null
     private var currentReminderDate: Date? = null
     private var isPriority: Boolean = false
+    private var isEditMode: Boolean = false
+    private var originalCoupon: Coupon? = null
 
     fun setImageUri(uri: Uri) {
         currentImageUri = uri
@@ -59,6 +64,27 @@ class AddCouponViewModel @Inject constructor(
 
     fun clearError() {
         _error.value = null
+    }
+
+    fun loadCouponForEdit(couponId: Long) {
+        if (couponId <= 0) {
+            return
+        }
+
+        isEditMode = true
+        this.couponId = couponId
+        viewModelScope.launch {
+            val coupon = repository.getCouponById(couponId)
+            originalCoupon = coupon
+            _couponForEdit.value = coupon
+            coupon?.let {
+                currentImageUri = it.imageUri?.let(Uri::parse)
+                currentExpiryDate = it.expiryDate
+                currentReminderDate = it.reminderDate
+                isPriority = it.isPriority
+            }
+            _couponSaved.value = false
+        }
     }
 
     fun saveCoupon(
@@ -83,31 +109,62 @@ class AddCouponViewModel @Inject constructor(
         viewModelScope.launch {
             _savingState.value = SavingState.Saving
             try {
-                // Persist the image URI if available
                 val persistedImageUri = currentImageUri?.let { uri ->
                     uriPersistenceManager.persistUri(uri)?.toString() ?: uri.toString()
                 }
 
-                val coupon = Coupon(
-                    storeName = storeName,
-                    description = description,
-                    expiryDate = currentExpiryDate,
-                    cashbackAmount = cashbackAmount,
-                    redeemCode = redeemCode,
-                    imageUri = persistedImageUri,
-                    category = category,
-                    rating = rating,
-                    status = status ?: "Active",
-                    minimumPurchase = minimumPurchase,
-                    maximumDiscount = maximumDiscount,
-                    isPriority = isPriority,
-                    paymentMethod = paymentMethod,
-                    usageLimit = usageLimit,
-                    usageCount = 0,
-                    reminderDate = currentReminderDate,
-                    platformType = platformType
-                )
-                couponId = repository.insertCoupon(coupon)
+                if (isEditMode) {
+                    val existingCoupon = originalCoupon
+                        ?: repository.getCouponById(couponId)
+                        ?: throw IllegalStateException("Coupon to edit not found")
+
+                    val updatedCoupon = existingCoupon.copy(
+                        storeName = storeName,
+                        description = description,
+                        expiryDate = currentExpiryDate,
+                        cashbackAmount = cashbackAmount,
+                        redeemCode = redeemCode ?: existingCoupon.redeemCode,
+                        imageUri = persistedImageUri ?: existingCoupon.imageUri,
+                        category = category ?: existingCoupon.category,
+                        rating = rating ?: existingCoupon.rating,
+                        status = status ?: existingCoupon.status,
+                        minimumPurchase = minimumPurchase,
+                        maximumDiscount = maximumDiscount,
+                        isPriority = isPriority,
+                        paymentMethod = paymentMethod ?: existingCoupon.paymentMethod,
+                        usageLimit = usageLimit ?: existingCoupon.usageLimit,
+                        reminderDate = currentReminderDate,
+                        platformType = platformType ?: existingCoupon.platformType,
+                        updatedAt = Date()
+                    )
+
+                    repository.updateCoupon(updatedCoupon)
+                    originalCoupon = updatedCoupon
+                    couponId = updatedCoupon.id
+                    _couponForEdit.value = updatedCoupon
+                } else {
+                    val coupon = Coupon(
+                        storeName = storeName,
+                        description = description,
+                        expiryDate = currentExpiryDate,
+                        cashbackAmount = cashbackAmount,
+                        redeemCode = redeemCode,
+                        imageUri = persistedImageUri,
+                        category = category,
+                        rating = rating,
+                        status = status ?: "Active",
+                        minimumPurchase = minimumPurchase,
+                        maximumDiscount = maximumDiscount,
+                        isPriority = isPriority,
+                        paymentMethod = paymentMethod,
+                        usageLimit = usageLimit,
+                        usageCount = 0,
+                        reminderDate = currentReminderDate,
+                        platformType = platformType
+                    )
+                    couponId = repository.insertCoupon(coupon)
+                }
+
                 _couponSaved.value = true
                 _savingState.value = SavingState.Success
             } catch (e: Exception) {

--- a/app/src/main/kotlin/com/example/coupontracker/util/CouponInputManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/CouponInputManager.kt
@@ -880,6 +880,34 @@ class CouponInputManager(
     }
 
     /**
+     * Convert a stored [Coupon] into a [CouponInfo] snapshot for form prefilling.
+     */
+    fun toCouponInfo(coupon: Coupon): CouponInfo {
+        val numericCashback = coupon.getCashbackNumericValue()
+        val cashbackAmount = when {
+            numericCashback > 0 -> numericCashback
+            coupon.cashbackAmount > 0 -> coupon.cashbackAmount
+            else -> null
+        }
+
+        return CouponInfo(
+            storeName = coupon.storeName,
+            description = coupon.description,
+            expiryDate = coupon.expiryDate,
+            cashbackAmount = cashbackAmount,
+            redeemCode = coupon.redeemCode,
+            category = coupon.category,
+            rating = coupon.rating,
+            status = coupon.status,
+            minimumPurchase = coupon.minimumPurchase,
+            maximumDiscount = coupon.maximumDiscount,
+            paymentMethod = coupon.paymentMethod,
+            platformType = coupon.platformType,
+            usageLimit = coupon.usageLimit
+        )
+    }
+
+    /**
      * Clean up resources
      */
     fun cleanup() {

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -41,6 +41,10 @@
             app:argType="string"
             app:nullable="true"
             android:defaultValue="@null" />
+        <argument
+            android:name="couponId"
+            app:argType="long"
+            android:defaultValue="-1" />
     </fragment>
 
     <fragment
@@ -69,23 +73,8 @@
             android:name="couponId"
             app:argType="long" />
         <action
-            android:id="@+id/actionDetailFragmentToEditFragment"
-            app:destination="@id/editFragment" />
-    </fragment>
-
-    <fragment
-        android:id="@+id/editFragment"
-        android:name="com.example.coupontracker.ui.fragment.EditFragment"
-        android:label="Edit Coupon"
-        tools:layout="@layout/fragment_add">
-        <argument
-            android:name="couponId"
-            app:argType="long" />
-        <action
-            android:id="@+id/actionEditToDetail"
-            app:destination="@id/detailFragment"
-            app:popUpTo="@id/detailFragment"
-            app:popUpToInclusive="true" />
+            android:id="@+id/actionDetailFragmentToEdit"
+            app:destination="@id/addFragment" />
     </fragment>
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="redeem_code">Redeem Code</string>
     <string name="category">Category</string>
     <string name="save">Save</string>
+    <string name="update_coupon">Update Coupon</string>
     <string name="cancel">Cancel</string>
     <string name="search_coupons">Search Coupons</string>
     <string name="sort_by">Sort By</string>


### PR DESCRIPTION
## Summary
- reuse the existing AddFragment in an edit mode that pre-fills coupon fields, updates titles, and skips camera setup when editing
- extend AddCouponViewModel and CouponInputManager to load/update stored coupons and expose edit state to the UI
- update navigation to pass coupon ids, provide helper/test activity for Hilt scenarios, and add an instrumentation test covering the edit flow

## Testing
- `./gradlew test` *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f734f968108328aad6df1175845f59