### PR TITLE
feat: centralize build versioning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,20 @@
+import com.android.build.gradle.api.ApplicationVariant
+import com.android.build.gradle.api.BaseVariantOutput
+import com.android.build.gradle.internal.api.BaseVariantOutputImpl
+import org.gradle.api.Action
+import com.example.build.VersionInfo
+import com.example.build.Versioning
+
+val versionInfo = rootProject.extra["appVersionInfo"] as VersionInfo
+
+fun parseBooleanProperty(value: String?): Boolean = value?.equals("true", ignoreCase = true) == true
+
+val includeGitHash = parseBooleanProperty(project.findProperty("includeGitHash") as? String)
+    || parseBooleanProperty(System.getenv("INCLUDE_GIT_HASH"))
+val gitHash = if (includeGitHash) Versioning.currentGitHash(project) else null
+val resolvedVersionName = versionInfo.formatted(versionInfo.metadata, gitHash)
+val sanitizedVersionName = Versioning.sanitizeForFilename(resolvedVersionName)
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -15,8 +32,9 @@ android {
         applicationId = "com.example.coupontracker"
         minSdk = 24
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = versionInfo.versionCode()
+        versionName = resolvedVersionName
+        buildConfigField("String", "APP_VERSION", "\"$resolvedVersionName\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -98,6 +116,7 @@ android {
         viewBinding = true
         compose = true
         dataBinding = true
+        buildConfig = true
     }
 
     compileOptions {
@@ -183,6 +202,21 @@ android {
 
     // Note: Modern Android applications use the renderscript-toolkit library
     // instead of the deprecated renderscript support mode
+    applicationVariants.all(
+        Action<ApplicationVariant> {
+            val buildType = this.buildType.name.lowercase()
+            val versionForFiles = sanitizedVersionName
+            this.outputs.all(
+                Action<BaseVariantOutput> {
+                    val output = this as BaseVariantOutputImpl
+                    val abi = output.filters.firstOrNull()?.identifier ?: "universal"
+                    val extension = output.outputFileName.substringAfterLast('.', "")
+                    val baseName = listOf("app", abi, buildType, "v$versionForFiles").joinToString(separator = "-")
+                    output.outputFileName = if (extension.isNotEmpty()) "$baseName.$extension" else baseName
+                }
+            )
+        }
+    )
 }
 
 dependencies {

--- a/app/src/main/kotlin/com/example/coupontracker/ui/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ui/screen/SettingsScreen.kt
@@ -57,6 +57,7 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import com.example.coupontracker.R
+import com.example.coupontracker.BuildConfig
 
 // Using keys from SecurePreferencesManager
 
@@ -410,20 +411,33 @@ fun SettingsScreen(
 
                     Spacer(modifier = Modifier.height(12.dp))
 
+                    val commitHash = remember(BuildConfig.APP_VERSION) {
+                        BuildConfig.APP_VERSION.split("-").firstOrNull { it.startsWith("g") }?.removePrefix("g")
+                    }
+
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Text(
-                            text = "Version:",
+                            text = stringResource(id = R.string.settings_app_version_label) + ":",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
 
                         Text(
-                            text = "2.0.0",
+                            text = BuildConfig.APP_VERSION,
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.Bold
+                        )
+                    }
+
+                    if (commitHash != null) {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = stringResource(id = R.string.settings_build_commit, commitHash),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,4 +86,6 @@
     <string name="settings_data_safety_title">Private by design</string>
     <string name="settings_data_safety_summary">Screenshots never leave your device. Download the on-device reader for faster, offline extraction.</string>
     <string name="settings_data_safety_button">View data safety details</string>
+    <string name="settings_app_version_label">Version</string>
+    <string name="settings_build_commit">Commit %1$s</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.example.build.BumpVersionTask
+import com.example.build.Versioning
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
@@ -21,3 +24,11 @@ plugins {
 tasks.register("clean", Delete::class) {
     delete(rootProject.buildDir)
 }
+
+val versionInfo = Versioning.load(project)
+
+extra["appVersionInfo"] = versionInfo
+extra["appVersionCode"] = versionInfo.versionCode()
+extra["appVersionName"] = versionInfo.formatted()
+
+tasks.register<BumpVersionTask>("bumpVersion")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    `java-library`
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(gradleApi())
+}

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,0 +1,4 @@
+major=1
+minor=1
+patch=2
+metadata=

--- a/scripts/package_dmg.sh
+++ b/scripts/package_dmg.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") <path-to-dmg> [--arch <architecture>] [--build-type <buildType>] [--include-git-hash]
+
+Renames the provided DMG so it follows the unified naming scheme, e.g.
+  app-universal-debug-v1.1.2.dmg
+
+Arguments:
+  <path-to-dmg>          Path to the DMG produced by the build system.
+  --arch <architecture>  Target architecture segment (default: universal).
+  --build-type <type>    Build type segment such as debug or release (default: debug).
+  --include-git-hash     Append the current git commit hash to the version portion.
+USAGE
+}
+
+if [[ ${#} -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+DMG_PATH=$1
+shift || true
+
+ARCH="universal"
+BUILD_TYPE="debug"
+INCLUDE_GIT_HASH=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arch)
+      ARCH=${2:-}
+      shift 2
+      ;;
+    --build-type)
+      BUILD_TYPE=${2:-}
+      shift 2
+      ;;
+    --include-git-hash)
+      INCLUDE_GIT_HASH=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -f "$DMG_PATH" ]]; then
+  echo "DMG not found: $DMG_PATH" >&2
+  exit 1
+fi
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+VERSION_FILE="$ROOT_DIR/config/version.properties"
+
+if [[ ! -f "$VERSION_FILE" ]]; then
+  echo "Version file missing at $VERSION_FILE" >&2
+  exit 1
+fi
+
+major=$(grep '^major=' "$VERSION_FILE" | cut -d'=' -f2)
+minor=$(grep '^minor=' "$VERSION_FILE" | cut -d'=' -f2)
+patch=$(grep '^patch=' "$VERSION_FILE" | cut -d'=' -f2)
+metadata=$(grep '^metadata=' "$VERSION_FILE" | cut -d'=' -f2-)
+
+version_base="${major}.${minor}.${patch}"
+metadata_clean=$(echo "$metadata" | tr -d '\n')
+version="$version_base"
+
+if [[ -n "$metadata_clean" ]]; then
+  version+="-$(echo "$metadata_clean" | sed 's/[^A-Za-z0-9._-]/-/g')"
+fi
+
+if [[ "$INCLUDE_GIT_HASH" == "true" ]]; then
+  if git -C "$ROOT_DIR" rev-parse --short HEAD >/dev/null 2>&1; then
+    git_hash=$(git -C "$ROOT_DIR" rev-parse --short HEAD)
+    version+="-g$git_hash"
+  else
+    echo "Warning: Unable to determine git hash; continuing without it" >&2
+  fi
+fi
+
+filename="app-${ARCH}-${BUILD_TYPE}-v$(echo "$version" | sed 's/[^A-Za-z0-9._-]/-/g').dmg"
+
+output_path="$(dirname "$DMG_PATH")/$filename"
+
+mv "$DMG_PATH" "$output_path"
+
+echo "Renamed DMG to $output_path"


### PR DESCRIPTION
## Summary
- add buildSrc utilities and config/version.properties to make semantic versioning a single source of truth with a bumpVersion task
- read the centralized version in the Android module to expose BuildConfig.APP_VERSION, support optional git hash suffixes, and rename generated artifacts
- surface the build version and commit hash in the Settings UI and add a macOS DMG packaging helper that reuses the shared metadata

## Testing
- `./gradlew -q help` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f491d40384832894d148d9a1de9d22