### PR TITLE
Improve Tesseract initialization resilience and telemetry

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/di/LlmModule.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/di/LlmModule.kt
@@ -5,8 +5,9 @@ import com.example.coupontracker.feedback.ValidatorFeedbackRecorder
 import com.example.coupontracker.llm.LlmRuntimeManager
 import com.example.coupontracker.llm.LlmTelemetryService
 import com.example.coupontracker.llm.ModelDownloadManager
-import com.example.coupontracker.util.LocalLlmOcrService
 import com.example.coupontracker.util.ImageProcessor
+import com.example.coupontracker.util.LocalLlmOcrService
+import com.example.coupontracker.util.ExtractionTelemetryService
 import com.example.coupontracker.util.SecurePreferencesManager
 import dagger.Module
 import dagger.Provides
@@ -65,10 +66,11 @@ object LlmModule {
     fun provideImageProcessor(
         @ApplicationContext context: Context,
         ocrEngine: com.example.coupontracker.ocr.OcrEngine,
+        telemetryService: ExtractionTelemetryService,
         localLlmOcrService: LocalLlmOcrService,
         progressiveExtractionService: com.example.coupontracker.extraction.ProgressiveExtractionService
     ): ImageProcessor {
-        return ImageProcessor(context, ocrEngine, localLlmOcrService, progressiveExtractionService)
+        return ImageProcessor(context, ocrEngine, telemetryService, localLlmOcrService, progressiveExtractionService)
     }
 
     @Provides

--- a/app/src/main/kotlin/com/example/coupontracker/ocr/TessDataInstaller.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ocr/TessDataInstaller.kt
@@ -1,0 +1,118 @@
+package com.example.coupontracker.ocr
+
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.security.MessageDigest
+
+/**
+ * Installs tessdata assets into the app's writable directory while
+ * validating version sentinels and checksums.
+ */
+class TessDataInstaller(
+    private val assetOpener: () -> InputStream,
+    private val tessDataDir: File,
+    private val trainedDataFilename: String,
+    private val sentinelFilename: String,
+    private val expectedChecksum: String,
+    private val expectedVersion: String,
+    private val logger: Logger = Logger()
+) {
+
+    data class Result(
+        val file: File,
+        val assetChecksum: String,
+        val installedChecksum: String,
+        val copied: Boolean
+    )
+
+    data class Logger(
+        val debug: (String) -> Unit = {},
+        val info: (String) -> Unit = {},
+        val warn: (String) -> Unit = {},
+        val error: (String, Throwable?) -> Unit = { _, _ -> }
+    )
+
+    fun installIfNeeded(): Result {
+        tessDataDir.mkdirs()
+        val dataFile = File(tessDataDir, trainedDataFilename)
+        val sentinelFile = File(tessDataDir, sentinelFilename)
+
+        logger.debug("Ensuring tessdata at ${dataFile.absolutePath}")
+
+        val assetChecksum = assetOpener().use { input ->
+            computeSha256(input)
+        }
+        if (!assetChecksum.equals(expectedChecksum, ignoreCase = true)) {
+            logger.error(
+                "eng.traineddata checksum mismatch. Expected $expectedChecksum but asset is $assetChecksum",
+                null
+            )
+            throw IllegalStateException("Bundled eng.traineddata does not match expected checksum")
+        }
+
+        val sentinelPayload = "$expectedVersion|$assetChecksum"
+        val sentinelMatches = if (sentinelFile.exists()) {
+            sentinelFile.readText().trim() == sentinelPayload
+        } else {
+            false
+        }
+
+        val installedChecksum = if (dataFile.exists()) {
+            dataFile.inputStream().use { input -> computeSha256(input) }
+        } else {
+            null
+        }
+
+        val needsCopy = !sentinelMatches || installedChecksum == null ||
+            !installedChecksum.equals(assetChecksum, ignoreCase = true)
+
+        if (needsCopy) {
+            logger.info("Refreshing tessdata asset ($trainedDataFilename) → ${dataFile.absolutePath}")
+            assetOpener().use { input ->
+                FileOutputStream(dataFile).use { output ->
+                    input.copyTo(output)
+                }
+            }
+            sentinelFile.writeText(sentinelPayload)
+        } else {
+            logger.debug("Tessdata asset is up-to-date (checksum $assetChecksum)")
+        }
+
+        val finalChecksum = dataFile.inputStream().use { input -> computeSha256(input) }
+        if (!finalChecksum.equals(assetChecksum, ignoreCase = true)) {
+            val message = "Installed eng.traineddata checksum $finalChecksum does not match asset $assetChecksum"
+            logger.error(message, null)
+            throw IllegalStateException(message)
+        }
+
+        return Result(
+            file = dataFile,
+            assetChecksum = assetChecksum,
+            installedChecksum = finalChecksum,
+            copied = needsCopy
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        fun computeSha256(input: InputStream): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            var read: Int
+            while (true) {
+                read = input.read(buffer)
+                if (read == -1) break
+                digest.update(buffer, 0, read)
+            }
+            return digest.digest().joinToString(separator = "") { byte ->
+                "%02x".format(byte)
+            }
+        }
+
+        @JvmStatic
+        fun computeSha256(bytes: ByteArray): String {
+            return computeSha256(bytes.inputStream())
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/ocr/TesseractOcrEngine.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ocr/TesseractOcrEngine.kt
@@ -7,9 +7,10 @@ import android.util.Log
 import com.googlecode.tesseract.android.TessBaseAPI
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.io.FileOutputStream
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -26,16 +27,41 @@ class TesseractOcrEngine @Inject constructor(
         private const val TAG = "TesseractOcrEngine"
         private const val TESSDATA_DIR = "tessdata"
         private const val LANG = "eng"
-        
+        private const val TRAINED_DATA_FILE = "$LANG.traineddata"
+        private const val SENTINEL_FILE = "eng.traineddata.version"
+        private const val TRAINED_DATA_VERSION = "tess-two-9.1.0-eng"
+        private const val TRAINED_DATA_CHECKSUM = "8280aed0782fe27257a68ea10fe7ef324ca0f8d85bd2fd145d1c2b560bcb66ba"
+        private const val MAX_INIT_RETRIES = 3
+        private val RETRY_BACKOFF_MS = longArrayOf(200L, 600L, 1200L)
+
         // Shared lock for thread-safe initialization
         private val initLock = Any()
     }
-    
+
     private var tessBaseAPI: TessBaseAPI? = null
     private val tessDataDir = File(context.filesDir, TESSDATA_DIR)
+    private val tessDataInstaller = TessDataInstaller(
+        assetOpener = { context.assets.open("$TESSDATA_DIR/$TRAINED_DATA_FILE") },
+        tessDataDir = tessDataDir,
+        trainedDataFilename = TRAINED_DATA_FILE,
+        sentinelFilename = SENTINEL_FILE,
+        expectedChecksum = TRAINED_DATA_CHECKSUM,
+        expectedVersion = TRAINED_DATA_VERSION,
+        logger = TessDataInstaller.Logger(
+            debug = { message -> Log.d(TAG, message) },
+            info = { message -> Log.i(TAG, message) },
+            warn = { message -> Log.w(TAG, message) },
+            error = { message, throwable -> Log.e(TAG, message, throwable) }
+        )
+    )
+    private val nativeLogDir = File(context.filesDir, "tesseract")
+    private val nativeLogFile = File(nativeLogDir, "native.log")
+    @Volatile
+    private var lastInitStats: InitStats = InitStats()
+    private var initAttemptCounter: Int = 0
     @Volatile
     private var isInitialized = false
-    
+
     init {
         // Synchronize initialization across all threads
         synchronized(initLock) {
@@ -46,80 +72,84 @@ class TesseractOcrEngine @Inject constructor(
     }
     
     @Synchronized
-    private fun initializeTesseract() {
-        // Double-check inside synchronized block
+    private fun initializeTesseract(): Boolean {
         if (isInitialized) {
             Log.d(TAG, "Already initialized, skipping")
-            return
+            return true
         }
-        
+
+        val attemptNumber = ++initAttemptCounter
+        var installResult: TessDataInstaller.Result? = null
+
         try {
-            Log.d(TAG, "🔧 Initializing Tesseract OCR [Thread: ${Thread.currentThread().name}]...")
-            
-            // Copy tessdata from assets if not already present
-            val tessDataFile = File(tessDataDir, "$LANG.traineddata")
-            if (!tessDataFile.exists()) {
-                Log.d(TAG, "Copying tessdata from assets...")
-                tessDataDir.mkdirs()
-                
-                context.assets.open("$TESSDATA_DIR/$LANG.traineddata").use { input ->
-                    FileOutputStream(tessDataFile).use { output ->
-                        input.copyTo(output, bufferSize = 8192)
-                    }
-                }
-                Log.d(TAG, "✓ Tessdata copied: ${tessDataFile.length()} bytes")
-            } else {
-                Log.d(TAG, "Tessdata already exists: ${tessDataFile.length()} bytes")
-            }
-            
-            // Verify file is readable
-            if (!tessDataFile.canRead()) {
-                throw IllegalStateException("Tessdata file is not readable: ${tessDataFile.absolutePath}")
-            }
-            
-            // Initialize Tesseract
+            Log.d(TAG, "🔧 Initializing Tesseract OCR [attempt=$attemptNumber, thread=${Thread.currentThread().name}]")
+
+            installResult = tessDataInstaller.installIfNeeded()
+            Log.d(
+                TAG,
+                "eng.traineddata ready (copied=${installResult.copied}, checksum=${installResult.installedChecksum})"
+            )
+
+            prepareNativeLogFile()
+
             val dataPath = context.filesDir.absolutePath
-            Log.d(TAG, "Initializing with dataPath: $dataPath, lang: $LANG")
-            
             tessBaseAPI = TessBaseAPI().apply {
+                setDebug(true)
                 val success = init(dataPath, LANG)
                 if (!success) {
-                    val errorMsg = "Tesseract init() returned false. " +
-                        "Path: $dataPath, Lang: $LANG, " +
-                        "File exists: ${tessDataFile.exists()}, " +
-                        "File size: ${tessDataFile.length()}, " +
-                        "File readable: ${tessDataFile.canRead()}"
+                    val errorMsg = "Tesseract init() returned false for attempt $attemptNumber"
                     Log.e(TAG, errorMsg)
-                    Log.w(TAG, "⚠️ Tesseract native init failed - this is a known issue with tess-two library")
-                    Log.w(TAG, "   Will fall back to ML Kit Text Recognition (offline, more reliable)")
                     throw IllegalStateException(errorMsg)
                 }
-                
-                // Set page segmentation mode for better coupon recognition
-                // Try simpler mode first (PSM_AUTO instead of PSM_AUTO_OSD)
+
+                try {
+                    setVariable("debug_file", nativeLogFile.absolutePath)
+                } catch (ignored: Exception) {
+                    Log.w(TAG, "Unable to set debug_file for native logging", ignored)
+                }
+
                 pageSegMode = TessBaseAPI.PageSegMode.PSM_AUTO
-                
                 Log.d(TAG, "✅ Tesseract initialized successfully [PSM: PSM_AUTO]")
             }
-            
+
             isInitialized = true
-            
+            lastInitStats = InitStats(
+                attempt = attemptNumber,
+                success = true,
+                assetChecksum = installResult.assetChecksum,
+                installedChecksum = installResult.installedChecksum,
+                copiedTrainedData = installResult.copied,
+                nativeLogTail = readNativeLogTail()
+            )
+            return true
         } catch (e: Exception) {
+            val nativeTail = readNativeLogTail()
+            lastInitStats = InitStats(
+                attempt = attemptNumber,
+                success = false,
+                assetChecksum = installResult?.assetChecksum,
+                installedChecksum = installResult?.installedChecksum,
+                copiedTrainedData = installResult?.copied ?: false,
+                errorMessage = e.message,
+                nativeLogTail = nativeTail
+            )
             Log.e(TAG, "❌ Failed to initialize Tesseract - will use ML Kit as fallback", e)
+            nativeTail?.let { Log.e(TAG, "Native log tail:\n$it") }
             tessBaseAPI?.end()
             tessBaseAPI = null
             isInitialized = false
-            // DON'T re-throw - let the app continue with ML Kit fallback
+            return false
         }
     }
-    
+
     override suspend fun recognize(bitmap: Bitmap): String = withContext(Dispatchers.Default) {
-        val api = tessBaseAPI ?: run {
-            Log.w(TAG, "Tesseract not initialized, attempting re-init...")
-            initializeTesseract()
-            tessBaseAPI ?: throw IllegalStateException("Tesseract OCR not available")
+        val api = try {
+            requireApiWithRetry()
+        } catch (e: Exception) {
+            Log.e(TAG, "Unable to obtain Tesseract instance after retries", e)
+            throw e
         }
-        
+
         return@withContext try {
             api.setImage(bitmap)
             val text = api.utF8Text ?: ""
@@ -146,5 +176,68 @@ class TesseractOcrEngine @Inject constructor(
         isInitialized = false
         Log.d(TAG, "Tesseract resources released")
     }
+
+    fun lastInitializationStats(): InitStats = lastInitStats
+
+    private suspend fun requireApiWithRetry(): TessBaseAPI {
+        var attempt = 0
+        var lastError: String? = null
+        while (attempt < MAX_INIT_RETRIES) {
+            tessBaseAPI?.let { return it }
+            attempt++
+            withContext(Dispatchers.IO) {
+                synchronized(initLock) {
+                    if (!isInitialized) {
+                        val success = initializeTesseract()
+                        if (!success) {
+                            lastError = lastInitStats.errorMessage
+                        }
+                    }
+                }
+            }
+            tessBaseAPI?.let { return it }
+            if (attempt < MAX_INIT_RETRIES) {
+                val backoff = RETRY_BACKOFF_MS.getOrElse(attempt - 1) { RETRY_BACKOFF_MS.last() }
+                Log.w(TAG, "Tesseract unavailable (attempt=$attempt, error=$lastError). Retrying in ${backoff}ms")
+                delay(backoff)
+            }
+        }
+        throw IllegalStateException("Tesseract OCR not available after $attempt attempts. Last error: ${lastError ?: "unknown"}")
+    }
+
+    private fun prepareNativeLogFile() {
+        nativeLogDir.mkdirs()
+        if (nativeLogFile.exists()) {
+            try {
+                nativeLogFile.writeText("")
+            } catch (io: IOException) {
+                Log.w(TAG, "Unable to clear native log file", io)
+            }
+        }
+    }
+
+    private fun readNativeLogTail(maxChars: Int = 1200): String? {
+        if (!nativeLogFile.exists() || nativeLogFile.length() == 0L) {
+            return null
+        }
+        return try {
+            val content = nativeLogFile.readText()
+            if (content.length <= maxChars) content else content.takeLast(maxChars)
+        } catch (io: IOException) {
+            Log.w(TAG, "Unable to read native log file", io)
+            null
+        }
+    }
+
+    data class InitStats(
+        val attempt: Int = 0,
+        val success: Boolean = false,
+        val assetChecksum: String? = null,
+        val installedChecksum: String? = null,
+        val copiedTrainedData: Boolean = false,
+        val errorMessage: String? = null,
+        val nativeLogTail: String? = null,
+        val timestampMs: Long = System.currentTimeMillis()
+    )
 }
 

--- a/app/src/main/kotlin/com/example/coupontracker/util/ImageProcessor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/ImageProcessor.kt
@@ -10,6 +10,7 @@ import android.provider.MediaStore
 import android.util.Log
 import androidx.core.graphics.drawable.toBitmap
 import com.example.coupontracker.ocr.OcrEngine
+import com.example.coupontracker.ocr.TesseractOcrEngine
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -23,6 +24,7 @@ import java.util.Date
 class ImageProcessor(
     private val context: Context,
     private val ocrEngine: OcrEngine,
+    private val telemetryService: ExtractionTelemetryService,
     private val injectedLocalLlmOcrService: LocalLlmOcrService? = null,
     private val progressiveExtractionService: com.example.coupontracker.extraction.ProgressiveExtractionService? = null
 ) {
@@ -154,20 +156,25 @@ class ImageProcessor(
                             localLlmOcrService.processCouponImage(bitmap, captureTimestamp)
                         } catch (e: Exception) {
                             Log.e(TAG, "Local LLM failed, falling back to Model-based OCR", e)
-                            fallbackToModelBasedOcr(bitmap, captureTimestamp)
+                            fallbackToModelBasedOcr(bitmap, captureTimestamp, reason = "local_llm_exception")
                         }
                     } else {
                         Log.w(TAG, "Local LLM selected but model not downloaded, falling back to Model-based OCR")
-                        fallbackToModelBasedOcr(bitmap, captureTimestamp)
+                        fallbackToModelBasedOcr(bitmap, captureTimestamp, reason = "local_llm_not_downloaded")
                     }
                 }
                 ApiType.MODEL_BASED -> {
                     Log.d(TAG, "Using Model-based OCR service")
-                    fallbackToModelBasedOcr(bitmap, captureTimestamp)
+                    fallbackToModelBasedOcr(bitmap, captureTimestamp, reason = "model_based_selected")
                 }
                 ApiType.ML_KIT_ONLY -> {
                     Log.d(TAG, "Using ML Kit OCR only")
-                    tryMlKit(bitmap, captureTimestamp)
+                    tryMlKit(
+                        bitmap,
+                        captureTimestamp,
+                        reason = "mlkit_only_selection",
+                        attemptedEngines = listOf("MLKIT")
+                    )
                 }
             }
 
@@ -207,7 +214,11 @@ class ImageProcessor(
                 
                 if (ocrText.isBlank()) {
                     Log.w(TAG, "⚠️  OCR text is empty, falling back to legacy")
-                    return@withContext fallbackToModelBasedOcr(bitmap, captureTimestamp)
+                    return@withContext fallbackToModelBasedOcr(
+                        bitmap,
+                        captureTimestamp,
+                        reason = "progressive_empty_text"
+                    )
                 }
                 
                 // Step 2: Call progressive extraction
@@ -247,7 +258,11 @@ class ImageProcessor(
                 Log.e(TAG, "❌ Progressive extraction FAILED with exception: ${e.message}", e)
                 Log.e(TAG, "Stack trace: ${e.stackTraceToString()}")
                 Log.d(TAG, "Falling back to legacy extraction flow")
-                return@withContext fallbackToModelBasedOcr(bitmap, captureTimestamp)
+                return@withContext fallbackToModelBasedOcr(
+                    bitmap,
+                    captureTimestamp,
+                    reason = "progressive_exception"
+                )
             }
         }
     }
@@ -255,7 +270,11 @@ class ImageProcessor(
     /**
      * Fallback to model-based OCR with existing fallback chain
      */
-    private suspend fun fallbackToModelBasedOcr(bitmap: Bitmap, captureTimestamp: Date? = null): CouponInfo {
+    private suspend fun fallbackToModelBasedOcr(
+        bitmap: Bitmap,
+        captureTimestamp: Date? = null,
+        reason: String = "legacy_flow"
+    ): CouponInfo {
         return try {
             Log.d(TAG, "Using Model-based OCR service")
             modelBasedOCRService.processCouponImage(bitmap, captureTimestamp)
@@ -263,13 +282,23 @@ class ImageProcessor(
             Log.e(TAG, "Error using Model-based OCR service, falling back to Pattern Recognizer", e)
 
             // Try Pattern Recognizer as fallback
+            val attempted = mutableListOf("TESSERACT", "MODEL_BASED")
+            if (reason.startsWith("progressive")) {
+                attempted.add(1, "PROGRESSIVE")
+            }
             val result = tryPatternRecognizer(bitmap)
             if (result != null) {
                 result
             } else {
-                // Fall back to ML Kit if Pattern Recognizer fails
+                attempted.add("PATTERN_RECOGNIZER")
                 Log.d(TAG, "Pattern Recognizer failed, falling back to ML Kit")
-                tryMlKit(bitmap, captureTimestamp)
+                tryMlKit(
+                    bitmap,
+                    captureTimestamp,
+                    reason = "$reason/model_based_exception",
+                    cause = e,
+                    attemptedEngines = attempted
+                )
             }
         }
     }
@@ -280,11 +309,18 @@ class ImageProcessor(
      * @param captureTimestamp The timestamp when the image was captured (for relative date calculations)
      * @return The extracted coupon information
      */
-    private suspend fun tryMlKit(bitmap: Bitmap, captureTimestamp: Date? = null): CouponInfo = withContext(Dispatchers.IO) {
+    private suspend fun tryMlKit(
+        bitmap: Bitmap,
+        captureTimestamp: Date? = null,
+        reason: String,
+        cause: Throwable? = null,
+        attemptedEngines: List<String> = listOf("TESSERACT")
+    ): CouponInfo = withContext(Dispatchers.IO) {
+        recordMlKitFallback(reason, cause, attemptedEngines)
         try {
-            Log.d(TAG, "Trying Tesseract OCR")
+            Log.d(TAG, "Trying ML Kit fallback via ${ocrEngine.javaClass.simpleName}")
 
-            // Process with Tesseract
+            // Process with fallback OCR engine (currently Tesseract)
             val text = ocrEngine.recognize(bitmap)
 
             // Use TextExtractor to extract coupon info
@@ -296,6 +332,24 @@ class ImageProcessor(
             Log.e(TAG, "Error processing with Tesseract", e)
             return@withContext CouponInfo()
         }
+    }
+
+    private fun recordMlKitFallback(
+        reason: String,
+        cause: Throwable? = null,
+        attemptedEngines: List<String> = listOf("TESSERACT")
+    ) {
+        val initStats = (ocrEngine as? TesseractOcrEngine)?.lastInitializationStats()
+        val runPath = buildMlKitFallbackRunPath(
+            MlKitFallbackContext(
+                reason = reason,
+                cause = cause,
+                initStats = initStats,
+                ocrReady = ocrEngine.isReady(),
+                attemptedEngines = attemptedEngines
+            )
+        )
+        telemetryService.trackRunPath(runPath)
     }
 
 

--- a/app/src/main/kotlin/com/example/coupontracker/util/ImageProcessorTelemetry.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/ImageProcessorTelemetry.kt
@@ -1,0 +1,46 @@
+package com.example.coupontracker.util
+
+import com.example.coupontracker.ocr.TesseractOcrEngine
+
+/**
+ * Context describing why the pipeline fell back to ML Kit.
+ */
+data class MlKitFallbackContext(
+    val reason: String,
+    val cause: Throwable? = null,
+    val initStats: TesseractOcrEngine.InitStats? = null,
+    val ocrReady: Boolean,
+    val attemptedEngines: List<String> = listOf("TESSERACT")
+)
+
+/**
+ * Build a telemetry RunPath payload for ML Kit fallback scenarios so that
+ * observability dashboards can track real-world frequency.
+ */
+fun buildMlKitFallbackRunPath(context: MlKitFallbackContext): RunPath {
+    val reasons = mutableListOf(context.reason)
+    context.cause?.message?.let { message ->
+        if (message.isNotBlank()) {
+            reasons.add("error:${message.take(80)}")
+        }
+    }
+    context.initStats?.let { stats ->
+        stats.errorMessage?.takeIf { it.isNotBlank() }?.let { error ->
+            reasons.add("tesseract:${error.take(80)}")
+        }
+        stats.installedChecksum?.takeIf { it.isNotBlank() }?.let { checksum ->
+            reasons.add("traineddata:${checksum.take(16)}")
+        }
+        reasons.add("attempt:${stats.attempt}")
+        reasons.add("copied:${stats.copiedTrainedData}")
+    }
+
+    return RunPath(
+        strategy = "OCR_FIRST",
+        tried = context.attemptedEngines.toMutableList(),
+        final = "MLKIT",
+        reasons = reasons,
+        nativeAvailable = context.ocrReady,
+        totalTimeMs = 0L
+    )
+}

--- a/tests/ocr/MlKitFallbackRunPathTest.kt
+++ b/tests/ocr/MlKitFallbackRunPathTest.kt
@@ -1,0 +1,42 @@
+package com.example.coupontracker.util
+
+import com.example.coupontracker.ocr.TesseractOcrEngine
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MlKitFallbackRunPathTest {
+
+    @Test
+    fun `run path includes diagnostics when available`() {
+        val stats = TesseractOcrEngine.InitStats(
+            attempt = 2,
+            success = false,
+            assetChecksum = "aabbccdd",
+            installedChecksum = "ffeeddccbbaa",
+            copiedTrainedData = true,
+            errorMessage = "init failed",
+            nativeLogTail = "native error"
+        )
+
+        val context = MlKitFallbackContext(
+            reason = "progressive_exception/model_based_exception",
+            cause = IllegalStateException("tesseract unavailable"),
+            initStats = stats,
+            ocrReady = false,
+            attemptedEngines = listOf("TESSERACT", "PROGRESSIVE", "MODEL_BASED")
+        )
+
+        val runPath = buildMlKitFallbackRunPath(context)
+
+        assertEquals("OCR_FIRST", runPath.strategy)
+        assertEquals("MLKIT", runPath.final)
+        assertEquals(listOf("TESSERACT", "PROGRESSIVE", "MODEL_BASED"), runPath.tried)
+        assertTrue(runPath.reasons.contains("progressive_exception/model_based_exception"))
+        assertTrue(runPath.reasons.any { it.startsWith("error:") })
+        assertTrue(runPath.reasons.any { it.startsWith("tesseract:") })
+        assertTrue(runPath.reasons.any { it.startsWith("traineddata:") })
+        assertTrue(runPath.reasons.contains("attempt:2"))
+        assertTrue(runPath.reasons.contains("copied:true"))
+    }
+}

--- a/tests/ocr/OcrFallbackSchemaTest.kt
+++ b/tests/ocr/OcrFallbackSchemaTest.kt
@@ -1,0 +1,63 @@
+package com.example.coupontracker.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OcrFallbackSchemaTest {
+
+    @Test
+    fun `tesseract extraction yields valid coupon info`() {
+        val text = """
+            Example Store
+            Save 20% on your next order
+            Code: SAVE20
+            Cashback: 20
+            Valid till 31/12/2025
+        """.trimIndent()
+
+        val extractor = TextExtractor()
+        val info = extractor.extractCouponInfoSync(text)
+
+        assertTrue("primary extraction should produce valid coupon info", info.isValid())
+        assertEquals("Example Store", info.storeName)
+        assertEquals("SAVE20", info.redeemCode)
+    }
+
+    @Test
+    fun `fallback schema preserves populated fields`() {
+        val text = """
+            Example Store
+            Use code SAVE20 to earn ₹200 cashback on electronics
+            Offer valid through 31/12/2025
+        """.trimIndent()
+
+        val extractor = TextExtractor()
+        val primary = extractor.extractCouponInfoSync(text)
+
+        val fallback = CouponInfo(
+            storeName = "Example Store",
+            description = "Use code SAVE20 to earn ₹200 cashback on electronics",
+            cashbackAmount = 200.0,
+            redeemCode = "SAVE20",
+            expiryDate = primary.expiryDate,
+            category = primary.category
+        )
+
+        val primaryFields = presentFields(primary)
+        val fallbackFields = presentFields(fallback)
+
+        assertEquals(primaryFields, fallbackFields)
+    }
+
+    private fun presentFields(info: CouponInfo): Set<String> {
+        val fields = mutableSetOf<String>()
+        if (info.storeName.isNotBlank()) fields.add("storeName")
+        if (info.description.isNotBlank()) fields.add("description")
+        if (info.cashbackAmount != null) fields.add("cashbackAmount")
+        if (!info.redeemCode.isNullOrBlank()) fields.add("redeemCode")
+        if (info.expiryDate != null) fields.add("expiryDate")
+        if (!info.category.isNullOrBlank()) fields.add("category")
+        return fields
+    }
+}

--- a/tests/ocr/TessDataInstallerTest.kt
+++ b/tests/ocr/TessDataInstallerTest.kt
@@ -1,0 +1,93 @@
+package com.example.coupontracker.ocr
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.nio.file.Files
+
+class TessDataInstallerTest {
+
+    private val tempDirs = mutableListOf<File>()
+
+    @After
+    fun tearDown() {
+        tempDirs.forEach { it.deleteRecursively() }
+        tempDirs.clear()
+    }
+
+    @Test
+    fun `installs tessdata when assets are missing`() {
+        val workingDir = createWorkingDir()
+        val trainedData = "sample-trained-data".toByteArray()
+        val checksum = TessDataInstaller.computeSha256(trainedData)
+
+        val installer = createInstaller(workingDir, trainedData, checksum)
+
+        val result = installer.installIfNeeded()
+
+        val trainedFile = File(workingDir, "eng.traineddata")
+        val sentinelFile = File(workingDir, "eng.traineddata.version")
+
+        assertTrue("traineddata file should be created", trainedFile.exists())
+        assertTrue("sentinel should be created", sentinelFile.exists())
+        assertEquals("installed checksum must match asset", checksum, result.installedChecksum)
+        assertTrue("first install should copy asset", result.copied)
+        assertEquals(
+            "sentinel should include version and checksum",
+            "test-version|$checksum",
+            sentinelFile.readText()
+        )
+    }
+
+    @Test
+    fun `skips reinstall when checksum and sentinel match`() {
+        val workingDir = createWorkingDir()
+        val trainedData = "stable-trained-data".toByteArray()
+        val checksum = TessDataInstaller.computeSha256(trainedData)
+        val installer = createInstaller(workingDir, trainedData, checksum)
+
+        installer.installIfNeeded()
+        val secondResult = installer.installIfNeeded()
+
+        assertFalse("second run should not copy asset", secondResult.copied)
+    }
+
+    @Test
+    fun `reinstalls when traineddata is corrupted`() {
+        val workingDir = createWorkingDir()
+        val trainedData = "golden-trained-data".toByteArray()
+        val checksum = TessDataInstaller.computeSha256(trainedData)
+        val installer = createInstaller(workingDir, trainedData, checksum)
+
+        installer.installIfNeeded()
+
+        // Corrupt the installed file to simulate partial download
+        File(workingDir, "eng.traineddata").writeText("corrupted-data")
+
+        val recoveryResult = installer.installIfNeeded()
+
+        assertTrue("installer should recopy corrupted asset", recoveryResult.copied)
+        val restoredBytes = File(workingDir, "eng.traineddata").readBytes()
+        assertEquals("reinstalled file must match the original asset", trainedData.toList(), restoredBytes.toList())
+    }
+
+    private fun createInstaller(dir: File, data: ByteArray, checksum: String): TessDataInstaller {
+        return TessDataInstaller(
+            assetOpener = { ByteArrayInputStream(data) },
+            tessDataDir = dir,
+            trainedDataFilename = "eng.traineddata",
+            sentinelFilename = "eng.traineddata.version",
+            expectedChecksum = checksum,
+            expectedVersion = "test-version"
+        )
+    }
+
+    private fun createWorkingDir(): File {
+        val path = Files.createTempDirectory("tess-installer-test")
+        return path.toFile().also { tempDirs.add(it) }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated tessdata installer that validates version sentinels and checksums before initializing the tess-two engine
- harden TesseractOcrEngine with retry/backoff, native log capture, and expose init diagnostics for telemetry consumption
- wire ImageProcessor to emit ML Kit fallback telemetry and extend tests to cover tessdata handling, fallback run paths, and schema consistency

## Testing
- `./gradlew test` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.9.22'] was not found in any of the declared repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68fcf56168e88328ad4388c8d950224f