### PR TITLE
Improve MiniCPM prompt handling and JNI cancellation stubs

### DIFF
--- a/app/src/main/cpp/mlc_llm_jni_real.cpp
+++ b/app/src/main/cpp/mlc_llm_jni_real.cpp
@@ -799,19 +799,59 @@ JNIEXPORT void JNICALL
 Java_com_example_coupontracker_llm_MlcLlmNative_setInferenceParams(
     JNIEnv* env, jobject /* this */, jlong model_handle,
     jfloat temperature, jint max_tokens, jfloat top_p) {
-    
+
     (void)env;
-    
+
     std::lock_guard<std::mutex> lock(g_model_mutex);
-    
+
     auto it = g_model_handles.find(model_handle);
     if (it == g_model_handles.end()) {
         LOGE("Invalid model handle: %lld", (long long)model_handle);
         return;
     }
-    
+
     LOGI("Inference params set: temp=%.2f, max_tokens=%d, top_p=%.2f",
          temperature, max_tokens, top_p);
+}
+
+JNIEXPORT void JNICALL
+Java_com_example_coupontracker_llm_MlcLlmNative_cancelInference(
+    JNIEnv* env, jobject /* this */, jlong model_handle) {
+
+    (void)env;
+
+    std::lock_guard<std::mutex> lock(g_model_mutex);
+
+    auto it = g_model_handles.find(model_handle);
+    if (it == g_model_handles.end()) {
+        LOGW("cancelInference called with unknown handle: %lld", (long long)model_handle);
+        return;
+    }
+
+    LOGW("cancelInference requested for handle %lld, but llama.cpp backend has no cooperative cancel support; request ignored.",
+         (long long)model_handle);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_example_coupontracker_llm_MlcLlmNative_isInferenceRunning(
+    JNIEnv* env, jobject /* this */, jlong model_handle) {
+
+    (void)env;
+    (void)model_handle;
+
+    // The llama.cpp backend processes requests synchronously; no async state to report.
+    return JNI_FALSE;
+}
+
+JNIEXPORT jfloat JNICALL
+Java_com_example_coupontracker_llm_MlcLlmNative_getInferenceProgress(
+    JNIEnv* env, jobject /* this */, jlong model_handle) {
+
+    (void)env;
+    (void)model_handle;
+
+    // Progress reporting is unsupported for synchronous text inference; return 0.0.
+    return 0.0f;
 }
 
 JNIEXPORT void JNICALL

--- a/app/src/main/kotlin/com/example/coupontracker/schema/CompactPromptGenerator.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/schema/CompactPromptGenerator.kt
@@ -15,31 +15,21 @@ object CompactPromptGenerator {
      */
     fun generateSystemPrompt(schema: Schema): String {
         val schemaJson = generateCompactSchemaJson(schema)
-        
+        val fieldHints = """
+- storeName: primary merchant/app name from header or logo; never null when brand text exists.
+- redeemCode: coupon/promo code text only; null when absent.
+- expiryDate: copy exact wording for validity or return null if none.
+- description: main offer sentence verbatim with symbols.
+""".trimIndent()
+
         return """<|im_start|>system
-Extract coupon as JSON. Output ONLY valid JSON, no text.
-
+Return strict JSON with keys storeName, redeemCode, expiryDate, description.
 Schema: $schemaJson
-
 Rules:
-- All keys required (null if missing)
-- No text before/after JSON
-- Start with { end with }
-
-Key fields:
-${generateCompactFieldGuide(schema)}
+- Output JSON only (no prose).
+- All keys required; use null only if information is truly absent.
+$fieldHints
 <|im_end|>"""
-    }
-    
-    /**
-     * Generate compact field guide (1 line per field, no verbose examples)
-     */
-    private fun generateCompactFieldGuide(schema: Schema): String {
-        return schema.fields.joinToString("\n") { field ->
-            val hint = field.metadata.hints.firstOrNull() ?: field.metadata.description
-            val example = field.metadata.examples.firstOrNull()?.let { "e.g. \"$it\"" } ?: ""
-            "- ${field.name}: ${hint.take(60)} $example"
-        }
     }
     
     /**

--- a/app/src/main/kotlin/com/example/coupontracker/schema/CouponSchema.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/schema/CouponSchema.kt
@@ -28,13 +28,15 @@ object CouponSchema {
                     hints = listOf(
                         "Extract brand name only, not full company name",
                         "Prefer the issuing brand over partner or watermark text",
-                        "Use title case (e.g., 'Amazon' not 'AMAZON')"
+                        "Use title case (e.g., 'Amazon' not 'AMAZON')",
+                        "If any brand, merchant, or app name appears in OCR, choose the best match instead of returning null"
                     ),
                     extractionHints = "Usually appears at the top or as a logo. May be in large text or header.",
                     validationRules = listOf(
                         "Must not be empty or 'Unknown'",
                         "Must not contain generic terms like 'Store', 'Brand', 'Company'",
-                        "Must be 2-50 characters"
+                        "Must be 2-50 characters",
+                        "Return null only when the OCR text truly has no identifiable brand or merchant"
                     )
                 )
             ),
@@ -107,6 +109,7 @@ object CouponSchema {
         globalRules = listOf(
             "Output ONLY the keys: storeName, redeemCode, expiryDate, description",
             "Use null for any field that cannot be confidently extracted",
+            "storeName must not be null when the OCR snippet includes any brand-like word, header text, or app name",
             "Preserve the offer description verbatim without arithmetic or rephrasing",
             "If the coupon only states it expires in N days and a capture timestamp is provided, convert it to an ISO date using that timestamp",
             "Do not hallucinate additional structured fields or metadata"

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -65,7 +65,8 @@ class LocalLlmOcrService(
         private const val SERVICE_VERSION = "1.4.0"  // Qwen2.5 migration
         private const val SUPPORTED_MODEL_VERSION = "qwen25_1.5b_instruct_q4"
 
-        private const val OCR_SNIPPET_MAX_CHARS = 2000
+        // Shorten OCR snippet to keep prompts under ~300 tokens and reduce latency on MiniCPM
+        private const val OCR_SNIPPET_MAX_CHARS = 1200
         
         // Feature flags for schema-driven architecture
         // Set to true to enable schema-driven prompts/validation, false to use manual/legacy

--- a/app/src/test/java/com/example/coupontracker/schema/CompactPromptGeneratorTest.kt
+++ b/app/src/test/java/com/example/coupontracker/schema/CompactPromptGeneratorTest.kt
@@ -1,0 +1,26 @@
+package com.example.coupontracker.schema
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CompactPromptGeneratorTest {
+
+    @Test
+    fun `system prompt emphasizes non null store name`() {
+        val prompt = CompactPromptGenerator.generateSystemPrompt(CouponSchema.SCHEMA)
+
+        assertTrue(
+            prompt.contains("never null when brand text exists"),
+            "System prompt must instruct the model to emit storeName when brand text is available"
+        )
+        assertFalse(
+            prompt.contains("Key fields"),
+            "Legacy prompt framing should be removed to keep token count low"
+        )
+        assertTrue(
+            prompt.startsWith("<|im_start|>system"),
+            "Prompt should still be wrapped in the system ChatML role"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add llama.cpp JNI stubs for cancelInference, progress, and status so native calls no longer raise UnsatisfiedLinkError
- tighten the coupon extraction schema and compact prompt guidance so MiniCPM surfaces storeName instead of null while emitting less boilerplate
- reduce the OCR snippet length fed to the LLM and cover the new prompt wording with a focused unit test

## Testing
- ./gradlew test --tests com.example.coupontracker.schema.CompactPromptGeneratorTest *(fails: plugin org.jetbrains.kotlin.jvm 1.9.22 not available in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_69008059ce488328a7201e0853543d70