### PR TITLE
Avoid surfacing raw numeric amount context

### DIFF
--- a/enhanced_field_extractor.py
+++ b/enhanced_field_extractor.py
@@ -42,6 +42,28 @@ class EnhancedCouponFieldExtractor:
         re.IGNORECASE | re.VERBOSE,
     )
 
+    AMOUNT_WITH_CURRENCY_PATTERN = re.compile(
+        r"""
+        (?P<context>
+            (?:(?:up\s*to|upto|flat|save|extra|get|worth|value|mrp|only|just|pay)\s*)?
+        )
+        (?P<currency>₹|rs\.?|inr|rupees)
+        [\s₹]*
+        (?P<number>\d[\d,]*(?:\.\d+)?)
+        (?:\s*(?:off|cashback|discount|only|deal|each|/-))?
+        """,
+        re.IGNORECASE | re.VERBOSE,
+    )
+
+    AMOUNT_NUMERIC_CONTEXT_PATTERN = re.compile(
+        r"""
+        (?P<context>(?:up\s*to|upto|flat|save|extra|get|worth|value|mrp|only|just|pay)\s*)
+        (?P<number>\d[\d,]*(?:\.\d+)?)
+        (?:\s*(?:off|cashback|discount|only|deal|each|/-))?
+        """,
+        re.IGNORECASE | re.VERBOSE,
+    )
+
     DATE_PATTERN = re.compile(
         r"\b\d{1,2}\s+[A-Za-z]{3,9},\s+\d{4}(?:,\s*\d{1,2}:\d{2}\s*(?:AM|PM))?",
         re.IGNORECASE,
@@ -181,3 +203,62 @@ class EnhancedCouponFieldExtractor:
     def extract_expiry_date(self, text: str) -> Dict[str, Optional[object]]:
         cleaned = self._clean_text(text)
         return self._extract_expiry_date(cleaned)
+
+    def _extract_amount(self, cleaned_text: str) -> Dict[str, Optional[object]]:
+        confident_matches: List[Dict[str, object]] = []
+
+        for match in self.AMOUNT_WITH_CURRENCY_PATTERN.finditer(cleaned_text):
+            number = match.group("number")
+            if not number:
+                continue
+            numeric_value = self._parse_amount_numeric(number)
+            if numeric_value <= 0:
+                continue
+            formatted = self._normalise_amount_value(number)
+            confident_matches.append(
+                {
+                    "type": "currency_amount",
+                    "value": formatted,
+                    "raw_text": match.group(0).strip(),
+                    "confidence": True,
+                    "_numeric": numeric_value,
+                }
+            )
+
+        if confident_matches:
+            best = max(confident_matches, key=lambda candidate: candidate["_numeric"])
+            best.pop("_numeric", None)
+            return best
+
+        numeric_match = self.AMOUNT_NUMERIC_CONTEXT_PATTERN.search(cleaned_text)
+        if numeric_match:
+            return {
+                "type": "numeric_context",
+                "value": None,
+                "raw_text": None,
+                "confidence": False,
+            }
+
+        return {
+            "type": "not_found",
+            "value": None,
+            "raw_text": None,
+            "confidence": False,
+        }
+
+    @staticmethod
+    def _parse_amount_numeric(number: str) -> float:
+        cleaned = number.replace(",", "").strip()
+        try:
+            return float(cleaned)
+        except ValueError:
+            return 0.0
+
+    @staticmethod
+    def _normalise_amount_value(number: str) -> str:
+        cleaned = number.replace(",", "").strip()
+        return f"₹{cleaned}"
+
+    def extract_amount(self, text: str) -> Dict[str, Optional[object]]:
+        cleaned = self._clean_text(text)
+        return self._extract_amount(cleaned)

--- a/tests/extraction/test_amount.py
+++ b/tests/extraction/test_amount.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from enhanced_field_extractor import EnhancedCouponFieldExtractor
+from utils.ocr_helper import EnhancedOCRHelper
+
+
+def test_currency_amount_has_confidence() -> None:
+    extractor = EnhancedCouponFieldExtractor()
+    result = extractor.extract_amount("Flat ₹200 off on footwear")
+
+    assert result["confidence"] is True
+    assert result["value"] == "₹200"
+
+
+def test_plain_flat_number_is_low_confidence() -> None:
+    extractor = EnhancedCouponFieldExtractor()
+    result = extractor.extract_amount("Flat 200 off on footwear")
+
+    assert result["confidence"] is False
+    assert result["type"] == "numeric_context"
+    assert result["raw_text"] is None
+
+
+def test_helper_ignores_low_confidence_amount() -> None:
+    helper = EnhancedOCRHelper()
+
+    regenerated = helper.regenerate_amount("Flat 200 off on footwear", {})
+
+    assert regenerated is None
+
+
+def test_helper_respects_amount_removed_flag() -> None:
+    helper = EnhancedOCRHelper()
+
+    regenerated = helper.regenerate_amount(
+        "Flat ₹200 off on footwear",
+        {"amount": None, "amount_removed": True},
+    )
+
+    assert regenerated is None
+
+
+def test_helper_regenerates_confident_amount_when_allowed() -> None:
+    helper = EnhancedOCRHelper()
+
+    regenerated = helper.regenerate_amount("Extra ₹500 cashback on travel", {"amount": None})
+
+    assert regenerated == "₹500"

--- a/utils/ocr_helper.py
+++ b/utils/ocr_helper.py
@@ -1,0 +1,35 @@
+"""Utility helpers for post-processing OCR extraction results."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from enhanced_field_extractor import EnhancedCouponFieldExtractor
+
+
+class EnhancedOCRHelper:
+    """Helper that orchestrates field regeneration from OCR output."""
+
+    def __init__(self, field_extractor: Optional[EnhancedCouponFieldExtractor] = None) -> None:
+        self._field_extractor = field_extractor or EnhancedCouponFieldExtractor()
+
+    def regenerate_amount(
+        self,
+        ocr_text: str,
+        structured_record: Optional[Dict[str, object]] = None,
+    ) -> Optional[str]:
+        """Return a regenerated amount if the OCR text produces a confident value."""
+
+        record = structured_record or {}
+        if record.get("amount_removed"):
+            return None
+
+        amount_info = self._field_extractor.extract_amount(ocr_text)
+        if amount_info.get("confidence"):
+            return amount_info.get("value")  # type: ignore[return-value]
+        return None
+
+    def extract_amount_info(self, ocr_text: str) -> Dict[str, Optional[object]]:
+        """Expose raw amount extraction details for diagnostics and testing."""
+
+        return self._field_extractor.extract_amount(ocr_text)


### PR DESCRIPTION
## Summary
- stop returning raw numeric snippets for low-confidence amount matches so they are not displayed
- remove the unused numeric candidate helper from the field extractor
- update the amount extraction test to assert no raw text leaks for plain numbers

## Testing
- pytest tests/extraction/test_amount.py

------
https://chatgpt.com/codex/tasks/task_e_69041e9c7c8883289356a2c415ce151b