### PR TITLE
Preserve multi-currency cashback symbols

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/data/model/CashbackInfo.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/model/CashbackInfo.kt
@@ -1,5 +1,7 @@
 package com.example.coupontracker.data.model
 
+import com.example.coupontracker.data.util.CurrencyUtils
+
 /**
  * Represents typed cashback information to distinguish between percentages, amounts, and text.
  * This prevents UI confusion like showing "75%" as "₹75".
@@ -15,7 +17,7 @@ data class CashbackInfo(
     fun getDisplayText(): String {
         return when (type) {
             CashbackType.PERCENT -> "${valueNum.toInt()}%"
-            CashbackType.AMOUNT -> "₹${valueNum.toInt()}"
+            CashbackType.AMOUNT -> "${CurrencyUtils.resolveSymbol(currency)}${valueNum.toInt()}"
             CashbackType.TEXT -> valueNum.toString() // Fallback, should use offer_text
         }
     }
@@ -58,18 +60,23 @@ data class CashbackInfo(
             }
             
             // Check for amount (₹, Rs, INR, etc.)
-            val amountMatch = Regex("(?:₹|RS\\.?|INR)\\s*(\\d+(?:,\\d{3})*(?:\\.\\d{2})?)").find(cleanText)
+            val amountMatch = Regex("(?:₹|RS\\.?|INR|USD|EUR|GBP|\\$|€|£)\\s*(\\d+(?:,\\d{3})*(?:\\.\\d{2})?)").find(cleanText)
             if (amountMatch != null) {
                 val value = amountMatch.groupValues[1].replace(",", "").toDoubleOrNull() ?: 0.0
-                return CashbackInfo(CashbackType.AMOUNT, value)
+                val symbol = CurrencyUtils.detectSymbol(amountMatch.value)
+                return CashbackInfo(CashbackType.AMOUNT, value, symbol ?: "INR")
             }
-            
+
             // Check for plain number followed by "OFF" or similar
             val numberMatch = Regex("(\\d+(?:\\.\\d+)?)\\s*(?:OFF|BACK|CASHBACK|DISCOUNT)").find(cleanText)
             if (numberMatch != null) {
                 val value = numberMatch.groupValues[1].toDoubleOrNull() ?: 0.0
                 // If it's a small number, likely percentage; if large, likely amount
                 val type = if (value <= 100) CashbackType.PERCENT else CashbackType.AMOUNT
+                if (type == CashbackType.AMOUNT) {
+                    val symbol = CurrencyUtils.detectSymbol(cleanText)
+                    return CashbackInfo(type, value, symbol ?: "INR")
+                }
                 return CashbackInfo(type, value)
             }
             

--- a/app/src/main/kotlin/com/example/coupontracker/data/model/Coupon.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/model/Coupon.kt
@@ -3,6 +3,7 @@ package com.example.coupontracker.data.model
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.example.coupontracker.data.util.CouponDedupUtils
+import com.example.coupontracker.data.util.CurrencyUtils
 import com.example.coupontracker.data.util.DescriptionUtils
 import java.util.Date
 
@@ -77,10 +78,11 @@ data class Coupon(
 
     fun getCashbackInfo(): CashbackInfo {
         val display = getCashbackDisplayText()
+        val currencySymbol = CurrencyUtils.detectSymbol(display)
         return when {
             display.contains("%", ignoreCase = true) -> CashbackInfo(CashbackType.PERCENT, getCashbackNumericValue())
-            display.contains("₹") || display.contains("$") || display.contains("€") || display.contains("£") ->
-                CashbackInfo(CashbackType.AMOUNT, getCashbackNumericValue())
+            currencySymbol != null ->
+                CashbackInfo(CashbackType.AMOUNT, getCashbackNumericValue(), currencySymbol)
             display.isNotBlank() -> CashbackInfo(CashbackType.TEXT, 0.0)
             else -> CashbackInfo(CashbackType.TEXT, 0.0)
         }

--- a/app/src/main/kotlin/com/example/coupontracker/data/util/CurrencyUtils.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/util/CurrencyUtils.kt
@@ -1,0 +1,62 @@
+package com.example.coupontracker.data.util
+
+import java.util.Locale
+
+/**
+ * Utility helpers for working with currency tokens inside extracted coupon text.
+ *
+ * The extractor historically normalised everything to INR which caused offers
+ * detected in USD/EUR to be displayed as ₹ amounts. These helpers retain the
+ * detected symbol/code so the UI and persistence layers can surface the
+ * original currency without guessing.
+ */
+object CurrencyUtils {
+
+    private val CURRENCY_SYMBOLS = setOf("₹", "$", "€", "£")
+
+    private val CODE_TO_SYMBOL = mapOf(
+        "₹" to "₹",
+        "INR" to "₹",
+        "RS" to "₹",
+        "RS." to "₹",
+        "US$" to "$",
+        "USD" to "$",
+        "$" to "$",
+        "EUR" to "€",
+        "€" to "€",
+        "GBP" to "£",
+        "£" to "£"
+    )
+
+    private val CODE_REGEX = Regex("\\b(USD|EUR|GBP|INR|RS\\.?)\\b", RegexOption.IGNORE_CASE)
+
+    /**
+     * Resolve a human friendly currency symbol for display.
+     */
+    fun resolveSymbol(currency: String?): String {
+        val trimmed = currency?.trim()?.takeIf { it.isNotEmpty() } ?: return "₹"
+        CODE_TO_SYMBOL[trimmed.uppercase(Locale.ROOT)]?.let { return it }
+        if (trimmed.length == 1 && CURRENCY_SYMBOLS.contains(trimmed)) {
+            return trimmed
+        }
+        return trimmed
+    }
+
+    /**
+     * Detect a currency symbol (₹, $, €, £) or common ISO/alias codes from raw text.
+     * Returns the resolved display symbol when a match is found.
+     */
+    fun detectSymbol(raw: String?): String? {
+        if (raw.isNullOrBlank()) return null
+
+        CURRENCY_SYMBOLS.firstOrNull { raw.contains(it) }?.let { return it }
+
+        if (raw.contains("US$", ignoreCase = true)) {
+            return "$"
+        }
+
+        val codeMatch = CODE_REGEX.find(raw)
+        return codeMatch?.let { resolveSymbol(it.value) }
+    }
+}
+

--- a/app/src/main/kotlin/com/example/coupontracker/data/util/DescriptionUtils.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/util/DescriptionUtils.kt
@@ -1,5 +1,6 @@
 package com.example.coupontracker.data.util
 
+import com.example.coupontracker.util.IndianCurrencyParser
 import java.util.Locale
 
 object DescriptionUtils {
@@ -35,7 +36,10 @@ object DescriptionUtils {
         return when (normalizedType) {
             "percent", "percentage" -> "Cashback: ${amount.toInt()}% off"
             "text" -> null
-            else -> "Cashback: ${currencySymbol(currency)}${amount.toInt()} off"
+            else -> {
+                val symbol = CurrencyUtils.resolveSymbol(currency)
+                "Cashback: ${symbol}${amount.toInt()} off"
+            }
         }
     }
 
@@ -43,13 +47,30 @@ object DescriptionUtils {
         val text = rawText?.trim().orEmpty()
         if (text.isEmpty()) return null
         val normalized = text.lowercase(Locale.ROOT)
-        val formatted = when {
-            normalized.matches(Regex("\\d+%")) -> "Cashback: ${text.uppercase(Locale.ROOT)} off"
-            normalized.matches(Regex("₹?\\d+")) -> "Cashback: ₹${text.filter { it.isDigit() }} off"
-            normalized.contains("cashback", ignoreCase = true) -> text
-            else -> "Cashback: $text"
+        if (normalized.matches(Regex("\\d+%"))) {
+            return "Cashback: ${text.uppercase(Locale.ROOT)} off"
         }
-        return formatted.trim()
+
+        val detectedSymbol = CurrencyUtils.detectSymbol(text)
+        if (detectedSymbol != null) {
+            val parsedAmount = IndianCurrencyParser.parseAmount(text)
+            if (parsedAmount != null && parsedAmount > 0) {
+                return formatCashbackDetail(parsedAmount, "amount", detectedSymbol)
+            }
+        }
+
+        val digitsOnly = normalized.matches(Regex("₹?\\d+"))
+        if (digitsOnly) {
+            val amountDigits = text.filter { it.isDigit() }
+            val symbol = CurrencyUtils.resolveSymbol(null)
+            return "Cashback: ${symbol}${amountDigits} off"
+        }
+
+        if (normalized.contains("cashback", ignoreCase = true)) {
+            return text.trim()
+        }
+
+        return "Cashback: $text".trim()
     }
 
     fun extractCashbackLine(description: String): String? {
@@ -59,13 +80,4 @@ object DescriptionUtils {
             .firstOrNull { it.startsWith("Cashback:", ignoreCase = true) }
     }
 
-    private fun currencySymbol(currency: String?): String {
-        return when (currency?.uppercase(Locale.ROOT)) {
-            null, "", "INR", "₹", "RS", "RS." -> "₹"
-            "USD", "$" -> "$"
-            "EUR", "€" -> "€"
-            "GBP", "£" -> "£"
-            else -> "${currency.uppercase(Locale.ROOT)} "
-        }
-    }
 }

--- a/app/src/main/kotlin/com/example/coupontracker/util/RegionBasedExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/RegionBasedExtractor.kt
@@ -3,6 +3,7 @@ package com.example.coupontracker.util
 import android.graphics.Bitmap
 import android.graphics.Rect
 import android.util.Log
+import com.example.coupontracker.data.util.CurrencyUtils
 import com.example.coupontracker.data.util.DescriptionUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -376,18 +377,23 @@ class RegionBasedExtractor(
 
             // Then try fixed amount patterns
             val amountPatterns = listOf(
-                Pattern.compile("(?:Rs\\.?|₹)\\s*(\\d+)\\s+off", Pattern.CASE_INSENSITIVE),
-                Pattern.compile("(?:flat|get|upto)\\s+(?:Rs\\.?|₹)\\s*(\\d+)", Pattern.CASE_INSENSITIVE),
-                Pattern.compile("(?:cashback|save)\\s+(?:of|up to)?\\s+(?:Rs\\.?|₹)\\s*(\\d+)", Pattern.CASE_INSENSITIVE)
+                Pattern.compile("(?:₹|\\$|€|£|Rs\\.?|INR|USD|EUR|GBP)\\s*([0-9,]+(?:\\.[0-9]{1,2})?)\\s+off", Pattern.CASE_INSENSITIVE),
+                Pattern.compile("(?:flat|get|upto)\\s+(?:₹|\\$|€|£|Rs\\.?|INR|USD|EUR|GBP)\\s*([0-9,]+(?:\\.[0-9]{1,2})?)", Pattern.CASE_INSENSITIVE),
+                Pattern.compile("(?:cashback|save)\\s+(?:of|up to)?\\s+(?:₹|\\$|€|£|Rs\\.?|INR|USD|EUR|GBP)\\s*([0-9,]+(?:\\.[0-9]{1,2})?)", Pattern.CASE_INSENSITIVE)
             )
 
             for (pattern in amountPatterns) {
                 val matcher = pattern.matcher(fullText)
                 if (matcher.find()) {
-                    val amount = matcher.group(1)?.toDoubleOrNull()
+                    val amount = matcher.group(1)?.replace(",", "")?.toDoubleOrNull()
                     if (amount != null && amount > 0) {
-                        val formatted = DescriptionUtils.formatCashbackDetail(amount, "amount", "INR")
-                            ?: "Cashback: ₹${amount.toInt()} off"
+                        val raw = matcher.group(0)
+                        val currency = CurrencyUtils.detectSymbol(raw)
+                        val formatted = DescriptionUtils.formatCashbackDetail(amount, "amount", currency)
+                            ?: run {
+                                val symbol = CurrencyUtils.resolveSymbol(currency)
+                                "Cashback: ${symbol}${amount.toInt()} off"
+                            }
                         Log.d(TAG, "Found fixed amount discount detail: $formatted")
                         return formatted
                     }

--- a/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/TextExtractor.kt
@@ -1,6 +1,7 @@
 package com.example.coupontracker.util
 
 import android.util.Log
+import com.example.coupontracker.data.util.CurrencyUtils
 import com.example.coupontracker.data.util.DescriptionUtils
 import java.io.Serializable
 import java.text.ParseException
@@ -874,23 +875,26 @@ class TextExtractor {
 
         // Now check for currency amount patterns
         val amountPatterns = listOf(
-            Pattern.compile("(?i)(?:upto|up to|flat|get)\\s*(?:Rs\\.?|₹)\\s*(\\d+(?:\\.\\d+)?)"),
-            Pattern.compile("(?i)(?:Rs\\.?|₹)\\s*(\\d+(?:\\.\\d+)?)\\s*(?:off|cashback)"),
-            Pattern.compile("(?i)(?:save|discount of)\\s*(?:Rs\\.?|₹)\\s*(\\d+(?:\\.\\d+)?)")
+            Regex("(?i)(?:upto|up\\s+to|flat|get)\\s*((?:₹|\\$|€|£|Rs\\.?|INR|USD|EUR|GBP)\\s*)?(\\d+(?:[.,]\\d+)?)"),
+            Regex("(?i)((?:₹|\\$|€|£|Rs\\.?|INR|USD|EUR|GBP))\\s*(\\d+(?:[.,]\\d+)?)\\s*(?:off|cashback|back|discount)"),
+            Regex("(?i)(?:save|discount of)\\s*((?:₹|\\$|€|£|Rs\\.?|INR|USD|EUR|GBP))\\s*(\\d+(?:[.,]\\d+)?)")
         )
 
         for (pattern in amountPatterns) {
-            val matcher = pattern.matcher(text)
-            if (matcher.find()) {
+            val matches = pattern.findAll(text)
+            for (match in matches) {
                 try {
-                    val raw = matcher.group(0)
-                    val amount = matcher.group(1)?.toDoubleOrNull()
-                    if (!raw.isNullOrBlank()) {
+                    val raw = match.value
+                    val amountText = match.groupValues.getOrNull(2)?.replace(",", "")?.takeIf { it.isNotBlank() }
+                    val amount = amountText?.toDoubleOrNull()
+                    if (raw.isNotBlank()) {
                         safeLogDebug(TAG) { "Found fixed currency amount text: $raw" }
                         DescriptionUtils.formatCashbackDetail(raw)?.let { return it }
                     }
                     if (amount != null) {
-                        DescriptionUtils.formatCashbackDetail(amount, "amount", "INR")?.let { return it }
+                        val currencyToken = match.groupValues.getOrNull(1)?.trim()?.takeIf { it.isNotEmpty() }
+                        val currency = CurrencyUtils.detectSymbol(currencyToken) ?: CurrencyUtils.detectSymbol(raw)
+                        DescriptionUtils.formatCashbackDetail(amount, "amount", currency)?.let { return it }
                     }
                 } catch (e: Exception) {
                     safeLogError(TAG, "Error parsing amount", e)

--- a/app/src/test/kotlin/com/example/coupontracker/data/model/CouponCashbackInfoTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/data/model/CouponCashbackInfoTest.kt
@@ -1,0 +1,58 @@
+package com.example.coupontracker.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CouponCashbackInfoTest {
+
+    @Test
+    fun `coupon cashback info retains usd currency`() {
+        val coupon = Coupon(
+            storeName = "Global Store",
+            description = "Cashback: ${'$'}40 off",
+            redeemCode = null,
+            imageUri = null
+        )
+
+        val info = coupon.getCashbackInfo()
+
+        assertEquals(CashbackType.AMOUNT, info.type)
+        assertEquals(40.0, info.valueNum, 0.0)
+        assertEquals("\$", info.currency)
+        assertEquals("\$40", info.getDisplayText())
+    }
+
+    @Test
+    fun `coupon cashback info retains eur currency`() {
+        val coupon = Coupon(
+            storeName = "Euro Shop",
+            description = "Holiday Deals\nCashback: €25 off",
+            redeemCode = null,
+            imageUri = null
+        )
+
+        val info = coupon.getCashbackInfo()
+
+        assertEquals(CashbackType.AMOUNT, info.type)
+        assertEquals(25.0, info.valueNum, 0.0)
+        assertEquals("€", info.currency)
+        assertEquals("€25", info.getDisplayText())
+    }
+
+    @Test
+    fun `coupon cashback info defaults to text when no currency`() {
+        val coupon = Coupon(
+            storeName = "Mystery Store",
+            description = "Exclusive reward",
+            redeemCode = null,
+            imageUri = null
+        )
+
+        val info = coupon.getCashbackInfo()
+
+        assertEquals(CashbackType.TEXT, info.type)
+        assertTrue(info.getDisplayText().isNotEmpty())
+    }
+}
+

--- a/app/src/test/kotlin/com/example/coupontracker/util/TextExtractorCurrencyTest.kt
+++ b/app/src/test/kotlin/com/example/coupontracker/util/TextExtractorCurrencyTest.kt
@@ -1,0 +1,36 @@
+package com.example.coupontracker.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TextExtractorCurrencyTest {
+
+    private val extractor = TextExtractor()
+
+    @Test
+    fun `extract cashback detail retains usd symbol`() {
+        val text = """
+            Mega Sale
+            Get ${'$'}50 cashback on all electronics
+            Code: SAVE50
+        """.trimIndent()
+
+        val detail = extractor.extractCashbackDetail(text)
+
+        assertEquals("Cashback: ${'$'}50 off", detail)
+    }
+
+    @Test
+    fun `extract cashback detail retains eur symbol`() {
+        val text = """
+            Weekend Promo
+            Enjoy €20 discount on hotel bookings
+            Use code EURO20
+        """.trimIndent()
+
+        val detail = extractor.extractCashbackDetail(text)
+
+        assertEquals("Cashback: €20 off", detail)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a shared currency utility to resolve and detect symbols without defaulting to INR
- update cashback formatters and extractors to carry the detected symbol through to stored data
- add regression coverage ensuring USD and EUR cashback strings round-trip with the correct symbol

## Testing
- ./gradlew test (fails: Gradle plugin repository unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690420d238048328b27938ce32adb017