### PR TITLE
Improve store validation and savings detail sanitization

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/data/model/Coupon.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/model/Coupon.kt
@@ -60,7 +60,7 @@ data class Coupon(
 
     fun getCashbackDisplayText(): String {
         val detail = DescriptionUtils.extractCashbackLine(description) ?: return ""
-        return detail.removePrefix("Cashback:").trim()
+        return detail.substringAfter(":", "").trim()
     }
 
     fun getCashbackNumericValue(): Double {

--- a/app/src/main/kotlin/com/example/coupontracker/data/util/DescriptionUtils.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/data/util/DescriptionUtils.kt
@@ -5,23 +5,58 @@ import java.util.Locale
 
 object DescriptionUtils {
 
+    private val helperTextPatterns = listOf(
+        Regex("(?i)copy exact wording"),
+        Regex("(?i)return null if none"),
+        Regex("(?i)preserve provenance"),
+        Regex("(?i)never promote cta"),
+        Regex("(?i)output only the keys"),
+        Regex("(?i)storeName must not be null")
+    )
+
+    private val savingsPrefixRegex = Regex("^(cashback|discount|savings)\\s*:", RegexOption.IGNORE_CASE)
+
     fun appendDetails(base: String, vararg details: String?): String {
         val lines = mutableListOf<String>()
-        val baseTrimmed = base.trim()
-        if (baseTrimmed.isNotEmpty()) {
-            lines += baseTrimmed
+        val seenKeys = mutableSetOf<String>()
+
+        fun normalizeKey(text: String): String {
+            return text.lowercase(Locale.ROOT)
+                .replace(Regex("[^a-z0-9%₹]+"), " ")
+                .replace(Regex("\\s+"), " ")
+                .trim()
         }
-        details.mapNotNull { it?.trim()?.takeIf { text -> text.isNotEmpty() } }
-            .forEach { detail ->
-                if (detail !in lines) {
-                    lines += detail
-                }
+
+        fun addLine(raw: String?) {
+            val sanitized = sanitizeLine(raw) ?: return
+            val key = normalizeKey(sanitized)
+            if (key.isNotEmpty() && seenKeys.add(key)) {
+                lines += sanitized
             }
+        }
+
+        base.lines().forEach { addLine(it) }
+        details.forEach { detail ->
+            detail?.lines()?.forEach { addLine(it) }
+        }
+
         return if (lines.isEmpty()) {
             "Coupon offer"
         } else {
             lines.joinToString(separator = "\n")
         }
+    }
+
+    private fun sanitizeLine(raw: String?): String? {
+        val initial = raw?.trim() ?: return null
+        if (initial.isEmpty()) return null
+        if (helperTextPatterns.any { it.containsMatchIn(initial) }) {
+            return null
+        }
+
+        val cleaned = initial.trimEnd('.', ' ').replace(Regex("\\s+"), " ")
+        if (cleaned.equals("copy exact wording", ignoreCase = true)) return null
+        return cleaned.takeIf { it.isNotEmpty() }
     }
 
     fun formatCashbackDetail(
@@ -47,8 +82,9 @@ object DescriptionUtils {
         val text = rawText?.trim().orEmpty()
         if (text.isEmpty()) return null
         val normalized = text.lowercase(Locale.ROOT)
+        val label = determineSavingsLabel(normalized)
         if (normalized.matches(Regex("\\d+%"))) {
-            return "Cashback: ${text.uppercase(Locale.ROOT)} off"
+            return "$label: ${text.uppercase(Locale.ROOT)} off"
         }
 
         if (normalized.contains("cashback", ignoreCase = true)) {
@@ -59,7 +95,7 @@ object DescriptionUtils {
                     if (ch.isLowerCase()) ch.titlecase(Locale.ROOT) else ch.toString()
                 }
             } else {
-                "Cashback: $trimmed"
+                "$label: $trimmed"
             }
         }
 
@@ -67,7 +103,8 @@ object DescriptionUtils {
         if (detectedSymbol != null) {
             val parsedAmount = IndianCurrencyParser.parseAmount(text)
             if (parsedAmount != null && parsedAmount > 0) {
-                return formatCashbackDetail(parsedAmount, "amount", detectedSymbol)
+                val symbol = CurrencyUtils.resolveSymbol(detectedSymbol)
+                return "$label: ${symbol}${parsedAmount.toInt()} off"
             }
         }
 
@@ -75,17 +112,24 @@ object DescriptionUtils {
         if (digitsOnly) {
             val amountDigits = text.filter { it.isDigit() }
             val symbol = CurrencyUtils.resolveSymbol(null)
-            return "Cashback: ${symbol}${amountDigits} off"
+            return "$label: ${symbol}${amountDigits} off"
         }
 
-        return "Cashback: $text".trim()
+        return "$label: $text".trim()
     }
 
     fun extractCashbackLine(description: String): String? {
         return description
             .lines()
             .map { it.trim() }
-            .firstOrNull { it.startsWith("Cashback:", ignoreCase = true) }
+            .firstOrNull { line -> savingsPrefixRegex.containsMatchIn(line) }
     }
 
+    private fun determineSavingsLabel(normalized: String): String {
+        return when {
+            normalized.contains("cashback") || normalized.contains("cash back") -> "Cashback"
+            normalized.contains("discount") || normalized.contains("off") || normalized.contains("save") -> "Discount"
+            else -> "Savings"
+        }
+    }
 }

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/StructuredFieldExtractor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/StructuredFieldExtractor.kt
@@ -21,8 +21,11 @@ class StructuredFieldExtractor {
             "THE", "AND", "FOR", "YOU", "GET", "WITH", "FROM", "EXPIRES", "CODE",
             "COUPON", "OFFER", "VALID", "UPTO", "FLAT", "OFF", "CASHBACK", "THIS",
             "THAT", "YOUR", "USE", "APPLY", "SAVE", "DISCOUNT", "VIA", "PAY", "ONLY",
-            "WON", "WIN", "NEXT", "ORDER", "PURCHASE", "BUY", "DETAILS", "NOW", "NEW"
+            "WON", "WIN", "NEXT", "ORDER", "PURCHASE", "BUY", "DETAILS", "NOW", "NEW",
+            "MINIMUM", "VALUE", "MIN", "VALIDITY"
         )
+
+        private val LAYOUT_TOKENS = setOf("minimum", "order", "value", "validity", "details")
 
         // Payment methods - NOT store names
         private val PAYMENT_METHODS = setOf(
@@ -142,10 +145,12 @@ class StructuredFieldExtractor {
             val storeName = match.value
             val words = storeName.split("\\s+".toRegex())
             val wordCount = words.size
-            
+
             // Skip if all words are common
             val isAllCommon = words.all { it.uppercase() in COMMON_WORDS }
             if (isAllCommon) return@forEach
+
+            if (words.any { LAYOUT_TOKENS.contains(it.lowercase(Locale.ROOT)) }) return@forEach
             
             // Validate brand name quality (reject OCR garbage like "Pastm Patm")
             if (!isValidBrandName(storeName) || isLikelyWatermark(storeName)) return@forEach
@@ -509,6 +514,9 @@ class StructuredFieldExtractor {
      */
     private fun isValidBrandName(name: String): Boolean {
         val cleanName = name.trim()
+        val lower = cleanName.lowercase(Locale.ROOT)
+
+        if (LAYOUT_TOKENS.any { lower.contains(it) }) return false
 
         // Too short or too long
         if (cleanName.length < 3 || cleanName.length > 25) return false

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidators.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/validation/FieldValidators.kt
@@ -48,6 +48,8 @@ internal class StoreNameValidator(
     private val ctaStopwords: Set<String> =
         if (brandLexicon.ctaStopwords.isEmpty()) DEFAULT_CTA_STOPWORDS else brandLexicon.ctaStopwords
 
+    private val layoutStopwords = setOf("minimum", "order", "value", "validity", "details")
+
     fun assessCandidate(
         value: String?,
         description: String?,
@@ -66,9 +68,13 @@ internal class StoreNameValidator(
             return assessment
         }
 
-        val lower = trimmed.lowercase()
+        val lower = trimmed.lowercase(Locale.ROOT)
         if (ctaStopwords.any { lower.contains(it) }) {
             issues += "cta_stopword"
+        }
+
+        if (layoutStopwords.any { lower.contains(it) }) {
+            issues += "layout_token"
         }
 
         if (trimmed.length < 3) issues += "too_short"

--- a/app/src/main/kotlin/com/example/coupontracker/universal/UniversalExtractionService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/universal/UniversalExtractionService.kt
@@ -14,6 +14,7 @@ import com.example.coupontracker.util.OcrTextCleaner
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.time.LocalTime
 import java.time.ZoneId
 import java.util.Date
 import java.util.Locale
@@ -53,7 +54,19 @@ class UniversalExtractionService @Inject constructor(
             FieldType.EXPIRY_DATE,
             FieldType.AMOUNT
         )
-        private val GENERIC_STORE_NAMES = setOf("store", "shop", "brand", "seller")
+        private val GENERIC_STORE_NAMES = setOf(
+            "store",
+            "shop",
+            "brand",
+            "seller",
+            "minimum",
+            "minimum order",
+            "minimum order value",
+            "order value",
+            "value",
+            "validity",
+            "details"
+        )
         private val GENERIC_DESCRIPTION_PHRASES = setOf(
             "coupon offer",
             "coupon extracted",
@@ -556,7 +569,11 @@ class UniversalExtractionService @Inject constructor(
         return try {
             val parseResult = IndianDateParser.extractExpiryFromText(dateText)
             val localDate = parseResult.date ?: IndianDateParser.parseExpiryIST(dateText).date
-            localDate?.let { Date.from(it.atStartOfDay(ZoneId.of("Asia/Kolkata")).toInstant()) }
+            localDate?.let {
+                val zone = ZoneId.of("Asia/Kolkata")
+                val endOfDay = it.atTime(LocalTime.of(23, 59, 59))
+                Date.from(endOfDay.atZone(zone).toInstant())
+            }
         } catch (e: Exception) {
             Log.w(TAG, "Failed to parse expiry date: $dateText", e)
             null
@@ -649,7 +666,11 @@ class UniversalExtractionService @Inject constructor(
     private fun isGenericStoreName(name: String?): Boolean {
         if (name.isNullOrBlank()) return true
         val normalized = name.trim().lowercase(Locale.ROOT)
-        return normalized in GENERIC_STORE_NAMES || normalized.matches(Regex("store\\d*"))
+        if (normalized.matches(Regex("store\\d*"))) return true
+
+        return GENERIC_STORE_NAMES.any { generic ->
+            normalized == generic || normalized.startsWith("$generic ")
+        }
     }
 
     private fun isGenericDescription(description: String?): Boolean {


### PR DESCRIPTION
## Summary
- filter layout keywords like "Minimum" from store candidates across structured extraction, validation, and contextual fallbacks
- sanitize description merging to drop helper text, dedupe savings lines, and classify discount wording with the correct prefix
- normalize expiry dates to the end of day to avoid premature expiration flags and make cashback display parsing prefix-agnostic

## Testing
- ./gradlew test *(fails: plugin org.jetbrains.kotlin.jvm 1.9.22 unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_6904b07009548328adf05f063e57d435