### PR TITLE
Ensure mlc native runtime loads from packaged binaries

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,8 @@ android {
     namespace = "com.example.coupontracker"
     compileSdk = 34
 
+    val supportedAbis = listOf("arm64-v8a", "armeabi-v7a", "x86_64")
+
     defaultConfig {
         applicationId = "com.example.coupontracker"
         minSdk = 24
@@ -40,7 +42,8 @@ android {
 
         // Native library configuration
         ndk {
-            abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")
+            abiFilters.clear()
+            abiFilters += supportedAbis
         }
 
         // CMake configuration for llama.cpp vision
@@ -161,7 +164,7 @@ android {
 
     sourceSets {
         getByName("main") {
-            jniLibs.srcDirs("libs/mlc_llm/lib")
+            jniLibs.setSrcDirs(listOf("libs/mlc_llm/lib", "src/main/jniLibs"))
         }
         getByName("test") {
             java.srcDir("tests")
@@ -220,7 +223,7 @@ android {
         abi {
             isEnable = true
             reset()
-            include("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+            include(*supportedAbis.toTypedArray())
             isUniversalApk = true
         }
     }

--- a/app/src/androidTest/java/com/example/coupontracker/llm/MlcLlmNativeAvailabilityTest.kt
+++ b/app/src/androidTest/java/com/example/coupontracker/llm/MlcLlmNativeAvailabilityTest.kt
@@ -1,0 +1,45 @@
+package com.example.coupontracker.llm
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.example.coupontracker.BuildConfig
+import com.example.coupontracker.ui.activity.MainActivity
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MlcLlmNativeAvailabilityTest {
+
+    @Test
+    fun packagedNativeLibraryIsAvailable() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val appContext = instrumentation.targetContext.applicationContext
+
+        MlcLlmNative.resetForTests()
+
+        val scenario = ActivityScenario.launch(MainActivity::class.java)
+        try {
+            val loadResult = try {
+                MlcLlmNative.loadLibrary(appContext)
+            } catch (error: Throwable) {
+                throw AssertionError(
+                    "Failed to load mlc_llm_android native library from the packaged application",
+                    error
+                )
+            }
+
+            assertTrue("Native LLM library must load successfully", loadResult)
+
+            if (!BuildConfig.DEBUG) {
+                assertTrue(
+                    "Native LLM library must be reported as available in production builds",
+                    MlcLlmNative.isAvailable()
+                )
+            }
+        } finally {
+            scenario.close()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/llm/MlcLlmNative.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/MlcLlmNative.kt
@@ -36,54 +36,31 @@ class MlcLlmNative {
         }
 
         /**
-         * Load the native llama.cpp-based library
+         * Load the native llama.cpp-based library.
+         *
+         * The call now surfaces a hard failure when the packaged binary cannot
+         * be loaded so production builds fail fast instead of silently
+         * degrading to runtime fallbacks.
          */
+        @Suppress("UNUSED_PARAMETER")
         fun loadLibrary(context: Context? = null): Boolean {
             if (isLibraryLoaded) return true
 
             synchronized(this) {
                 if (isLibraryLoaded) return true
 
-                val loadErrors = mutableListOf<Throwable>()
-
-                try {
+                return try {
                     libraryLoader.loadLibrary(LIBRARY_NAME)
                     isLibraryLoaded = true
                     Log.i(TAG, "Native LLM library loaded from application package")
-                    return true
-                } catch (e: Throwable) {
-                    loadErrors.add(e)
-                    Log.w(TAG, "Packaged native library unavailable, attempting downloaded artifacts", e)
-                }
+                    true
+                } catch (error: Throwable) {
+                    val failureMessage =
+                        "Unable to load native LLM library '$LIBRARY_NAME' from the application package"
+                    Log.e(TAG, failureMessage, error)
 
-                val candidateContext = context?.applicationContext ?: context
-                if (candidateContext != null) {
-                    val candidates = ModelDownloadManager.getNativeLibraryCandidates(candidateContext)
-                    for (candidate in candidates) {
-                        try {
-                            libraryLoader.load(candidate.absolutePath)
-                            isLibraryLoaded = true
-                            Log.i(TAG, "Loaded native LLM library from ${candidate.absolutePath}")
-                            return true
-                        } catch (fallbackError: Throwable) {
-                            loadErrors.add(fallbackError)
-                            Log.e(
-                                TAG,
-                                "Failed to load native library from ${candidate.absolutePath}",
-                                fallbackError
-                            )
-                        }
-                    }
+                    throw IllegalStateException(failureMessage, error)
                 }
-
-                val primaryError = loadErrors.firstOrNull()
-                if (primaryError != null) {
-                    Log.e(TAG, "Failed to load native LLM library", primaryError)
-                } else {
-                    Log.e(TAG, "Failed to load native LLM library: no candidates found")
-                }
-
-                return false
             }
         }
 


### PR DESCRIPTION
## Summary
- align the Android ABI and jniLibs configuration with the packaged mlc runtime binaries
- make the native loader throw when the packaged mlc_llm_android library cannot be loaded
- add an instrumentation test that launches the app and asserts the native runtime is available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690630c654188328814d32fd0d865e9f