### PR TITLE
Add model asset verification helper and deployment publisher

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/di/LlmModule.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/di/LlmModule.kt
@@ -36,9 +36,18 @@ object LlmModule {
     @Singleton
     fun provideModelDownloadManager(
         @ApplicationContext context: Context,
-        securePreferencesManager: SecurePreferencesManager
+        securePreferencesManager: SecurePreferencesManager,
+        modelAssetManager: com.example.coupontracker.llm.ModelAssetManager
     ): ModelDownloadManager {
-        return ModelDownloadManager(context, securePreferencesManager)
+        return ModelDownloadManager(context, securePreferencesManager, modelAssetManager)
+    }
+
+    @Provides
+    @Singleton
+    fun provideModelAssetManager(
+        @ApplicationContext context: Context
+    ): com.example.coupontracker.llm.ModelAssetManager {
+        return com.example.coupontracker.llm.ModelAssetManager(context)
     }
 
     @Provides

--- a/app/src/main/kotlin/com/example/coupontracker/llm/ModelAssetManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/ModelAssetManager.kt
@@ -1,0 +1,252 @@
+package com.example.coupontracker.llm
+
+import android.content.Context
+import android.util.Log
+import com.example.coupontracker.model.ModelPaths
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.io.FileInputStream
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Thrown when the expected model assets cannot be located or fail validation.
+ */
+class MissingModelAssetsException(message: String) : IllegalStateException(message)
+
+/**
+ * Descriptor for a single file that should live inside a model directory.
+ */
+data class ModelAssetDescriptor(
+    val relativePath: String,
+    val description: String,
+    val minSizeBytes: Long,
+    val expectedSha256: String? = null,
+    val optional: Boolean = false
+)
+
+/**
+ * Result emitted after verifying a model directory.
+ */
+data class ModelAssetVerificationResult(
+    val modelId: String,
+    val directory: File,
+    val checksums: Map<String, String>
+)
+
+@Singleton
+class ModelAssetManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private const val TAG = "ModelAssetManager"
+
+        private val LEGACY_MINICPM_LAYOUT = listOf(
+            ModelAssetDescriptor(
+                relativePath = "minicpm_llm_q4f16_1.so",
+                description = "MiniCPM native library",
+                minSizeBytes = 4_000_000L,
+                expectedSha256 = "65d9139e97c5a196b48ae08facc468bcc41fef82ef1325ecab2c32e85e1fbbde"
+            ),
+            ModelAssetDescriptor(
+                relativePath = "model.bin",
+                description = "MiniCPM model weights",
+                minSizeBytes = 3_500_000L,
+                expectedSha256 = "94d7d225fbf28a20ec30534207ec1a0ea017a20cf25674cde166a6d4f0c7bad1"
+            ),
+            ModelAssetDescriptor(
+                relativePath = "vision_config.json",
+                description = "MiniCPM vision configuration",
+                minSizeBytes = 512L,
+                expectedSha256 = "a1e7efdfb761c86a3b1a323b3e859eb61718babb036ce66574d75528c33ebb6c"
+            ),
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.CONFIG_FILE,
+                description = "MLC runtime configuration",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_MINICPM, ModelPaths.CONFIG_FILE),
+                expectedSha256 = "c039de2a0c0ec44016207af64a896f7cd3b6940962709c3e49c9321d6c666ff6"
+            ),
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.TOKENIZER_MODEL,
+                description = "Tokenizer model",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_MINICPM, ModelPaths.TOKENIZER_MODEL),
+                expectedSha256 = "fd635c2e01878a509339a2d4a269c3600531d0e2c8757b553ab4dee59a215869"
+            ),
+            ModelAssetDescriptor(
+                relativePath = ".verified",
+                description = "Verification sentinel",
+                minSizeBytes = 1L
+            )
+        )
+    }
+
+    private val defaultLayouts: Map<String, List<ModelAssetDescriptor>> = mapOf(
+        ModelPaths.MODEL_ID_QWEN25 to listOf(
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.QWEN25_MODEL_FILE,
+                description = "Qwen2.5 GGUF weights",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_QWEN25, ModelPaths.QWEN25_MODEL_FILE)
+            ),
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.CONFIG_FILE,
+                description = "MLC runtime configuration",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_QWEN25, ModelPaths.CONFIG_FILE)
+            ),
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.TOKENIZER_JSON,
+                description = "Tokenizer vocabulary",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_QWEN25, ModelPaths.TOKENIZER_JSON)
+            ),
+            ModelAssetDescriptor(
+                relativePath = "coupon_schema.gbnf",
+                description = "JSON grammar",
+                minSizeBytes = 256L,
+                optional = true
+            ),
+            ModelAssetDescriptor(
+                relativePath = ".verified",
+                description = "Verification sentinel",
+                minSizeBytes = 1L
+            )
+        ),
+        ModelPaths.MODEL_ID_QWEN2 to listOf(
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.QWEN2_MODEL_FILE,
+                description = "Qwen2 GGUF weights",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_QWEN2, ModelPaths.QWEN2_MODEL_FILE)
+            ),
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.CONFIG_FILE,
+                description = "MLC runtime configuration",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_QWEN2, ModelPaths.CONFIG_FILE)
+            ),
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.TOKENIZER_JSON,
+                description = "Tokenizer vocabulary",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_QWEN2, ModelPaths.TOKENIZER_JSON)
+            ),
+            ModelAssetDescriptor(
+                relativePath = ".verified",
+                description = "Verification sentinel",
+                minSizeBytes = 1L
+            )
+        ),
+        ModelPaths.MODEL_ID_MINICPM to listOf(
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.MINICPM_MODEL_FILE,
+                description = "MiniCPM GGUF weights",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_MINICPM, ModelPaths.MINICPM_MODEL_FILE)
+            ),
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.MINICPM_MMPROJ_FILE,
+                description = "MiniCPM vision projector",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_MINICPM, ModelPaths.MINICPM_MMPROJ_FILE)
+            ),
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.CONFIG_FILE,
+                description = "MLC runtime configuration",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_MINICPM, ModelPaths.CONFIG_FILE)
+            ),
+            ModelAssetDescriptor(
+                relativePath = ModelPaths.TOKENIZER_MODEL,
+                description = "Tokenizer model",
+                minSizeBytes = ModelPaths.getMinFileSize(ModelPaths.MODEL_ID_MINICPM, ModelPaths.TOKENIZER_MODEL)
+            ),
+            ModelAssetDescriptor(
+                relativePath = ".verified",
+                description = "Verification sentinel",
+                minSizeBytes = 1L
+            )
+        )
+    )
+
+    fun getExpectedAssets(modelId: String, useLegacyMiniLayout: Boolean = false): List<ModelAssetDescriptor> {
+        return if (useLegacyMiniLayout && modelId == ModelPaths.MODEL_ID_MINICPM) {
+            LEGACY_MINICPM_LAYOUT
+        } else {
+            defaultLayouts[modelId] ?: emptyList()
+        }
+    }
+
+    fun verifyModelAssets(
+        modelId: String = ModelPaths.DEFAULT_MODEL_ID,
+        directory: File = ModelPaths.modelDir(context, modelId),
+        expectedChecksums: Map<String, String>? = null,
+        useLegacyMiniLayout: Boolean = false
+    ): ModelAssetVerificationResult {
+        val layout = getExpectedAssets(modelId, useLegacyMiniLayout)
+        if (layout.isEmpty()) {
+            throw MissingModelAssetsException("No asset layout defined for modelId=$modelId")
+        }
+
+        if (!directory.exists() || !directory.isDirectory) {
+            throw MissingModelAssetsException(
+                "Model directory missing for $modelId: ${directory.absolutePath}"
+            )
+        }
+
+        val checksums = mutableMapOf<String, String>()
+        layout.forEach { descriptor ->
+            val assetFile = File(directory, descriptor.relativePath)
+
+            if (!assetFile.exists()) {
+                if (descriptor.optional) {
+                    Log.d(TAG, "Optional asset missing for $modelId: ${descriptor.relativePath}")
+                    return@forEach
+                }
+                throw MissingModelAssetsException(
+                    "Missing ${descriptor.description} (${descriptor.relativePath}) for $modelId"
+                )
+            }
+
+            val length = assetFile.length()
+            if (length < descriptor.minSizeBytes) {
+                throw MissingModelAssetsException(
+                    "${descriptor.description} (${descriptor.relativePath}) is too small: " +
+                        "${formatBytes(length)} < ${formatBytes(descriptor.minSizeBytes)}"
+                )
+            }
+
+            val sha256 = calculateSha256(assetFile)
+            checksums[descriptor.relativePath] = sha256
+
+            val expected = descriptor.expectedSha256 ?: expectedChecksums?.get(descriptor.relativePath)
+            if (expected != null && !sha256.equals(expected, ignoreCase = true)) {
+                throw MissingModelAssetsException(
+                    "Checksum mismatch for ${descriptor.relativePath}: expected $expected but found $sha256"
+                )
+            }
+        }
+
+        return ModelAssetVerificationResult(
+            modelId = modelId,
+            directory = directory,
+            checksums = checksums
+        )
+    }
+
+    private fun calculateSha256(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        FileInputStream(file).use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read == -1) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { byte ->
+            "%02x".format(byte)
+        }
+    }
+
+    private fun formatBytes(bytes: Long): String {
+        return when {
+            bytes >= 1024 * 1024 * 1024 -> "%.2f GB".format(bytes / (1024.0 * 1024.0 * 1024.0))
+            bytes >= 1024 * 1024 -> "%.2f MB".format(bytes / (1024.0 * 1024.0))
+            bytes >= 1024 -> "%.2f KB".format(bytes / 1024.0)
+            else -> "$bytes B"
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/ModelDownloadManager.kt
@@ -32,6 +32,7 @@ import javax.net.ssl.SSLException
 class ModelDownloadManager(
     private val context: Context,
     private val securePrefs: SecurePreferencesManager,
+    private val modelAssetManager: ModelAssetManager,
     private val verificationDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
     
@@ -70,12 +71,12 @@ class ModelDownloadManager(
 
         // Expected model files with their individual checksums
         private val REQUIRED_FILES = mapOf(
-        "minicpm_llm_q4f16_1.so" to "65d9139e97c5a196b48ae08facc468bcc41fef82ef1325ecab2c32e85e1fbbde",
-        "model.bin" to "94d7d225fbf28a20ec30534207ec1a0ea017a20cf25674cde166a6d4f0c7bad1",
-        "vision_config.json" to "a1e7efdfb761c86a3b1a323b3e859eb61718babb036ce66574d75528c33ebb6c",
-        "mlc-chat-config.json" to "c039de2a0c0ec44016207af64a896f7cd3b6940962709c3e49c9321d6c666ff6",
-        "tokenizer.model" to "fd635c2e01878a509339a2d4a269c3600531d0e2c8757b553ab4dee59a215869"
-    )
+            "minicpm_llm_q4f16_1.so" to "65d9139e97c5a196b48ae08facc468bcc41fef82ef1325ecab2c32e85e1fbbde",
+            "model.bin" to "94d7d225fbf28a20ec30534207ec1a0ea017a20cf25674cde166a6d4f0c7bad1",
+            "vision_config.json" to "a1e7efdfb761c86a3b1a323b3e859eb61718babb036ce66574d75528c33ebb6c",
+            "mlc-chat-config.json" to "c039de2a0c0ec44016207af64a896f7cd3b6940962709c3e49c9321d6c666ff6",
+            "tokenizer.model" to "fd635c2e01878a509339a2d4a269c3600531d0e2c8757b553ab4dee59a215869"
+        )
         
         // GGUF model files (NEW for vision support)
         private val REQUIRED_GGUF_FILES = mapOf(
@@ -310,7 +311,20 @@ class ModelDownloadManager(
             val verifiedMarker = File(modelDir, ".verified")
             verifiedMarker.writeText("Model verified: $MODEL_VERSION\nTimestamp: ${System.currentTimeMillis()}")
             Log.d(TAG, "Created .verified marker: ${verifiedMarker.absolutePath}")
-            
+
+            runCatching {
+                modelAssetManager.verifyModelAssets(
+                    modelId = ModelPaths.MODEL_ID_MINICPM,
+                    directory = modelDir,
+                    expectedChecksums = REQUIRED_FILES,
+                    useLegacyMiniLayout = true
+                )
+            }.onFailure { error ->
+                val message = "Model asset verification failed: ${error.message}"
+                Log.e(TAG, message, error)
+                return@withContext DownloadResult.Error(message)
+            }
+
             // Update preferences
             val modelSizeMB = getModelSizeMB()
             securePrefs.setLlmModelDownloaded(true)
@@ -421,7 +435,18 @@ class ModelDownloadManager(
             val verifiedMarker = File(modelDir, ".verified")
             verifiedMarker.writeText("GGUF Model with Vision verified: $MODEL_VERSION\nTimestamp: ${System.currentTimeMillis()}\nFiles: $MODEL_FILE, $MMPROJ_FILE")
             Log.d(TAG, "Created .verified marker with vision support")
-            
+
+            runCatching {
+                modelAssetManager.verifyModelAssets(
+                    modelId = ModelPaths.MODEL_ID_MINICPM,
+                    directory = modelDir
+                )
+            }.onFailure { error ->
+                val message = "MiniCPM GGUF asset verification failed: ${error.message}"
+                Log.e(TAG, message, error)
+                return@withContext DownloadResult.Error(message)
+            }
+
             // Update preferences
             val totalSizeMB = (totalDownloaded / (1024f * 1024f))
             securePrefs.setLlmModelDownloaded(true)
@@ -574,7 +599,18 @@ class ModelDownloadManager(
                 }
             )
             Log.d(TAG, "Created .verified marker for Qwen2.5")
-            
+
+            runCatching {
+                modelAssetManager.verifyModelAssets(
+                    modelId = modelId,
+                    directory = modelDir
+                )
+            }.onFailure { error ->
+                val message = "Qwen2.5 asset verification failed: ${error.message}"
+                Log.e(TAG, message, error)
+                return@withContext DownloadResult.Error(message)
+            }
+
             // Update preferences
             val sizeMB = (modelFile.length() / (1024f * 1024f))
             securePrefs.setLlmModelDownloaded(true)
@@ -836,40 +872,19 @@ class ModelDownloadManager(
      * Verify all required model files are present and have correct checksums
      */
     private fun verifyModelFiles(): Boolean {
-        val presentFiles = modelDir.walkTopDown()
-            .filter { it.isFile }
-            .groupBy { it.name }
-
-        val missingFiles = REQUIRED_FILES.keys.filter { required ->
-            presentFiles[required].isNullOrEmpty()
+        return try {
+            modelAssetManager.verifyModelAssets(
+                modelId = ModelPaths.MODEL_ID_MINICPM,
+                directory = modelDir,
+                expectedChecksums = REQUIRED_FILES,
+                useLegacyMiniLayout = true
+            )
+            Log.d(TAG, "All required model files present and verified")
+            true
+        } catch (error: MissingModelAssetsException) {
+            Log.w(TAG, "Model asset verification failed: ${error.message}")
+            false
         }
-
-        if (missingFiles.isNotEmpty()) {
-            Log.w(TAG, "Missing model files: $missingFiles")
-            return false
-        }
-
-        // Verify checksums of present files
-        for ((filename, expectedChecksum) in REQUIRED_FILES) {
-            val candidateFile = presentFiles[filename]?.firstOrNull()
-            if (candidateFile != null) {
-                try {
-                    val actualChecksum = calculateFileChecksum(candidateFile)
-                    if (!actualChecksum.equals(expectedChecksum, ignoreCase = true)) {
-                        Log.e(TAG, "Checksum mismatch for $filename:")
-                        Log.e(TAG, "Expected: $expectedChecksum")
-                        Log.e(TAG, "Actual:   $actualChecksum")
-                        return false
-                    }
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to verify checksum for $filename", e)
-                    return false
-                }
-            }
-        }
-        
-        Log.d(TAG, "All required model files present and verified")
-        return true
     }
 
     private fun ensureNativeLibraryAlias() {

--- a/scripts/publish_model_bundle.py
+++ b/scripts/publish_model_bundle.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Publish verified model bundles to a connected Android device via adb.
+
+The script performs the following steps:
+1. Validates that the local bundle directory contains the expected assets.
+2. Confirms the `.verified` sentinel exists and is non-empty.
+3. Computes checksums for logging and confirmation.
+4. Pushes the assets to `/data/data/<package>/files/models/<model_id>` using `adb`.
+
+Example:
+    python scripts/publish_model_bundle.py \
+        --bundle android_models/qwen25_package \
+        --model-id qwen25_1.5b_instruct_q4
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+PACKAGE_NAME = "com.example.coupontracker"
+DEFAULT_MODEL_ID = "qwen25_1.5b_instruct_q4"
+ADB_COMMAND = os.environ.get("ADB", "adb")
+
+
+@dataclass(frozen=True)
+class AssetSpec:
+    relative_path: str
+    min_size_bytes: int
+    description: str
+    optional: bool = False
+
+
+MODEL_LAYOUTS: Dict[str, List[AssetSpec]] = {
+    "qwen25_1.5b_instruct_q4": [
+        AssetSpec("Qwen2.5-1.5B-Instruct-Q4_K_M.gguf", 900_000_000, "Qwen2.5 GGUF weights"),
+        AssetSpec("mlc-chat-config.json", 1_024, "Runtime configuration"),
+        AssetSpec("tokenizer.json", 10_000, "Tokenizer"),
+        AssetSpec("coupon_schema.gbnf", 128, "JSON grammar", optional=True),
+        AssetSpec(".verified", 1, "Verification sentinel"),
+    ],
+    "qwen2_1.5b_instruct_q4": [
+        AssetSpec("qwen2-1_5b-instruct-q4_k_m.gguf", 900_000_000, "Qwen2 GGUF weights"),
+        AssetSpec("mlc-chat-config.json", 1_024, "Runtime configuration"),
+        AssetSpec("tokenizer.json", 10_000, "Tokenizer"),
+        AssetSpec(".verified", 1, "Verification sentinel"),
+    ],
+    "minicpm_llama3_v25_q4": [
+        AssetSpec("ggml-model-Q4_K_M.gguf", 4_500_000_000, "MiniCPM GGUF weights"),
+        AssetSpec("mmproj-model-f16.gguf", 800_000_000, "MiniCPM vision projector"),
+        AssetSpec("mlc-chat-config.json", 1_024, "Runtime configuration"),
+        AssetSpec("tokenizer.model", 100_000, "Tokenizer"),
+        AssetSpec(".verified", 1, "Verification sentinel"),
+    ],
+}
+
+
+class PublishError(RuntimeError):
+    """Raised when the bundle cannot be published."""
+
+
+def run_command(command: Iterable[str], *, capture_output: bool = False) -> subprocess.CompletedProcess:
+    """Run an external command and raise a helpful error if it fails."""
+    command = list(command)
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=capture_output,
+            text=True,
+        )
+        return result
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - manual invocations
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        raise PublishError(
+            f"Command {' '.join(command)} failed with exit code {exc.returncode}\n"
+            f"stdout: {stdout}\n"
+            f"stderr: {stderr}"
+        ) from exc
+
+
+def compute_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_bundle(bundle_dir: Path, model_id: str) -> Dict[str, str]:
+    if model_id not in MODEL_LAYOUTS:
+        raise PublishError(f"Unknown model id '{model_id}'. Known ids: {', '.join(sorted(MODEL_LAYOUTS))}")
+
+    if not bundle_dir.exists() or not bundle_dir.is_dir():
+        raise PublishError(f"Bundle directory does not exist: {bundle_dir}")
+
+    checksums: Dict[str, str] = {}
+    for spec in MODEL_LAYOUTS[model_id]:
+        asset_path = bundle_dir / spec.relative_path
+        if not asset_path.exists():
+            if spec.optional:
+                continue
+            raise PublishError(
+                f"Missing required asset '{spec.relative_path}' ({spec.description})"
+            )
+        size = asset_path.stat().st_size
+        if size < spec.min_size_bytes:
+            raise PublishError(
+                f"Asset '{spec.relative_path}' is too small: {size} bytes (expected >= {spec.min_size_bytes})"
+            )
+        if asset_path.is_file() and size > 0:
+            checksums[spec.relative_path] = compute_sha256(asset_path)
+    return checksums
+
+
+def adb_push_file(local_path: Path, remote_path: str) -> None:
+    run_command([ADB_COMMAND, "push", str(local_path), remote_path])
+
+
+def adb_run_as(package: str, *args: str) -> None:
+    run_command([ADB_COMMAND, "shell", "run-as", package, *args])
+
+
+def publish_bundle(bundle_dir: Path, model_id: str, package: str) -> None:
+    print(f"📦 Publishing bundle for model '{model_id}' from {bundle_dir}")
+    checksums = validate_bundle(bundle_dir, model_id)
+    print("✅ Local bundle validated")
+
+    remote_model_dir = f"files/models/{model_id}"
+    staging_root = f"/data/local/tmp/{model_id}_bundle"
+
+    # Prepare staging directory on device
+    run_command([ADB_COMMAND, "shell", "rm", "-rf", staging_root])
+    run_command([ADB_COMMAND, "shell", "mkdir", "-p", staging_root])
+
+    # Push files to staging root
+    for asset in MODEL_LAYOUTS[model_id]:
+        if asset.optional:
+            optional_path = bundle_dir / asset.relative_path
+            if not optional_path.exists():
+                continue
+        local_path = bundle_dir / asset.relative_path
+        remote_temp = f"{staging_root}/{asset.relative_path.replace('/', '_')}"
+        adb_push_file(local_path, remote_temp)
+
+    # Create target directory inside the app sandbox
+    adb_run_as(package, "rm", "-rf", remote_model_dir)
+    adb_run_as(package, "mkdir", "-p", remote_model_dir)
+
+    # Move staged files into the sandbox
+    for asset in MODEL_LAYOUTS[model_id]:
+        local_exists = (bundle_dir / asset.relative_path).exists()
+        if asset.optional and not local_exists:
+            continue
+        remote_temp = f"{staging_root}/{asset.relative_path.replace('/', '_')}"
+        parent = os.path.dirname(asset.relative_path)
+        if parent:
+            adb_run_as(package, "mkdir", "-p", f"{remote_model_dir}/{parent}")
+        adb_run_as(
+            package,
+            "cp",
+            remote_temp,
+            f"{remote_model_dir}/{asset.relative_path}"
+        )
+
+    # Clean up staging directory
+    run_command([ADB_COMMAND, "shell", "rm", "-rf", staging_root])
+
+    # Log remote directory listing
+    listing = run_command(
+        [
+            ADB_COMMAND,
+            "shell",
+            "run-as",
+            package,
+            "ls",
+            "-l",
+            remote_model_dir,
+        ],
+        capture_output=True,
+    )
+    print("📂 Remote directory contents:")
+    print(listing.stdout.strip())
+
+    # Print checksums for confirmation
+    print("\n🔐 Local asset checksums:")
+    for path, checksum in checksums.items():
+        print(f"  {path}: {checksum}")
+
+    print("\n🚀 Bundle published successfully.")
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Publish verified model bundle via adb")
+    parser.add_argument(
+        "--bundle",
+        required=True,
+        help="Path to the local directory containing verified model assets",
+    )
+    parser.add_argument(
+        "--model-id",
+        default=DEFAULT_MODEL_ID,
+        help="Model identifier (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--package",
+        default=PACKAGE_NAME,
+        help="Android application id (default: %(default)s)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str]) -> int:
+    try:
+        args = parse_args(argv)
+        publish_bundle(Path(args.bundle).resolve(), args.model_id, args.package)
+        return 0
+    except PublishError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 1
+    except FileNotFoundError as exc:
+        print(f"❌ Missing file: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- introduce a ModelAssetManager helper that codifies the on-device model layout and performs checksum & size verification
- wire ModelDownloadManager through the new helper so downloads fail fast when required assets are missing or truncated
- add a publish_model_bundle.py deployment utility that validates a verified bundle (including the .verified sentinel) and pushes it to devices via adb

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Gradle cannot resolve org.jetbrains.kotlin.jvm plugin in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690635c6d0588328a957300e1fd0686a