### PR TITLE
Add LLM warmup telemetry and disable pass-one after warmup failures

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/extraction/PassOneUnavailableException.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/PassOneUnavailableException.kt
@@ -1,0 +1,13 @@
+package com.example.coupontracker.extraction
+
+/**
+ * Signals that the primary LLM-first pass cannot be executed (warmup or init failure).
+ *
+ * The progressive pipeline should catch this exception and continue with downstream
+ * passes without attempting the LLM-first path again until the failure is cleared.
+ */
+class PassOneUnavailableException(
+    message: String,
+    cause: Throwable? = null
+) : Exception(message, cause)
+

--- a/app/src/main/kotlin/com/example/coupontracker/extraction/ProgressiveExtractionService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/extraction/ProgressiveExtractionService.kt
@@ -18,6 +18,7 @@ import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.*
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -49,6 +50,7 @@ class ProgressiveExtractionService @Inject constructor(
     // V2: Validation components for multi-coupon extraction
     private val confidenceScorer = ConfidenceScorer()
     private val extractionValidator = ExtractionValidator(confidenceScorer)
+    private val llmPassEnabled = AtomicBoolean(true)
     
     companion object {
         private const val TAG = "ProgressiveExtractionService"
@@ -142,37 +144,42 @@ class ProgressiveExtractionService @Inject constructor(
         var miniCpmConfidence = 0f
         var passesUsed = 1
         
-        if (llmService != null) {
+        if (llmService == null) {
+            Log.w(TAG, "⚠️  Qwen LLM NOT available - using pattern-based extraction")
+        } else if (!llmPassEnabled.get()) {
+            Log.w(TAG, "⚠️  Qwen warmup previously failed - skipping LLM-first pass")
+        } else {
             try {
                 Log.d(TAG, "✅ Qwen2.5 LLM available - running primary text extraction")
                 val llmInfo = llmService.processCouponImage(image, effectiveCaptureTimestamp)
-                
+
                 if (llmInfo != null) {
                     // Convert ALL fields from Qwen (not just missing ones)
                     val llmResults = convertCouponInfoToFieldCandidates(llmInfo, FieldType.values().toSet())
                     mergeResults(extractedFields, llmResults, replaceIfBetter = true)
-                    
+
                     miniCpmConfidence = calculateOverallConfidence(extractedFields)
                     Log.d(TAG, "  Qwen extracted ${extractedFields.size} fields (confidence: $miniCpmConfidence)")
                     logPassResults(1, extractedFields)
-                    
+
                     // HIGH CONFIDENCE? We're done! 🎯
                     if (miniCpmConfidence >= 0.85f && CRITICAL_FIELDS.all { it in extractedFields }) {
                         Log.d(TAG, "✅ HIGH confidence from Qwen (${miniCpmConfidence}) - stopping here!")
                         return@withContext finishExtraction(context, extractedFields, image, imageUri, passesUsed, "Qwen2.5 Text LLM")
                     }
-                    
+
                     // Medium confidence - continue to supplement with patterns
                     Log.d(TAG, "  Medium confidence from Qwen - supplementing with pattern-based extraction")
                 } else {
                     Log.w(TAG, "⚠️  Qwen returned null - falling back to patterns")
                 }
-                
-            } catch (e: Exception) {
-                Log.e(TAG, "❌ Qwen error: ${e.message} - falling back to patterns", e)
+
+            } catch (error: PassOneUnavailableException) {
+                llmPassEnabled.set(false)
+                Log.w(TAG, "⚠️  Disabling Pass 1 after warmup failure: ${error.message}")
+            } catch (error: Exception) {
+                Log.e(TAG, "❌ Qwen error: ${error.message} - falling back to patterns", error)
             }
-        } else {
-            Log.w(TAG, "⚠️  Qwen LLM NOT available - using pattern-based extraction")
         }
         
         // ====== PASS 2: Structured Pattern Matching (Fallback/Supplement) ======

--- a/app/src/main/kotlin/com/example/coupontracker/llm/LlmRuntimeManager.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/LlmRuntimeManager.kt
@@ -2,6 +2,7 @@ package com.example.coupontracker.llm
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.util.Log
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Mutex
@@ -194,7 +195,9 @@ class LlmRuntimeManager private constructor(private val context: Context) {
         }
 
         if (missingFiles.isNotEmpty()) {
-            Log.d(TAG, "Missing or empty model files: ${missingFiles.joinToString(", ")}")
+            val reason = "Missing or empty model files: ${missingFiles.joinToString(", ")}"
+            Log.d(TAG, reason)
+            StartupMetricsLogger.logModelFilesValidated(success = false, message = reason)
             return false
         }
 
@@ -203,6 +206,12 @@ class LlmRuntimeManager private constructor(private val context: Context) {
         }
 
         Log.d(TAG, "✅ All required model files are present and valid ($modelName)")
+        val sentinelMessage = if (missingSentinel) {
+            "$modelName (sentinel missing)"
+        } else {
+            modelName
+        }
+        StartupMetricsLogger.logModelFilesValidated(success = true, message = sentinelMessage)
         return true
     }
     
@@ -335,9 +344,15 @@ class LlmRuntimeManager private constructor(private val context: Context) {
 
         // Load native library
         if (!MlcLlmNative.loadLibrary(context)) {
+            StartupMetricsLogger.logNativeLlmLoaded(
+                success = false,
+                message = "mlc_llm_android.so unavailable"
+            )
             throw IllegalStateException("Failed to load native LLM library")
         }
-        
+
+        StartupMetricsLogger.logNativeLlmLoaded(success = true, message = "mlc_llm_android.so")
+
         Log.d(TAG, "Initializing $modelName model...")
         
         // Initialize model through native interface
@@ -645,7 +660,9 @@ class LlmRuntimeManager private constructor(private val context: Context) {
                 configFile = configPath,
                 tokenizerFile = tokenizerPath,
                 maxTokens = MAX_TOKENS
-            )
+            ).also { engine ->
+                runVisionWarmupPrompt(engine)
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to create MLC engine", e)
             null
@@ -814,6 +831,58 @@ private class MLCEngineReal(
             result[index++] = (pixel and 0xFF).toByte()
         }
         return result
+    }
+
+    private fun runVisionWarmupPrompt(engine: MLCEngine) {
+        val warmupImage = createWarmupImage()
+        val warmupPrompt = "Warm up vision model with a quick classification. Return the word WARM.".trim()
+
+        runCatching {
+            val start = System.currentTimeMillis()
+            val response = engine.generate(
+                prompt = warmupPrompt,
+                image = warmupImage,
+                maxTokens = 32,
+                temperature = 0.2f,
+                timeoutMs = 5_000L
+            ) ?: throw IllegalStateException("Warmup prompt returned null response")
+
+            val duration = System.currentTimeMillis() - start
+            val tokenCount = countTokens(warmupPrompt, response)
+            val tokensPerSecond = if (duration > 0) tokenCount / (duration / 1000.0) else 0.0
+
+            Log.i(
+                TAG,
+                "✅ Vision warmup prompt succeeded in ${duration}ms (~${"%.2f".format(tokensPerSecond)} tokens/sec)"
+            )
+            StartupMetricsLogger.logWarmupComplete(
+                success = true,
+                durationMs = duration,
+                tokensPerSecond = tokensPerSecond,
+                message = "Vision warmup prompt"
+            )
+        }.onFailure { error ->
+            Log.w(TAG, "Vision warmup prompt failed", error)
+            StartupMetricsLogger.logWarmupComplete(
+                success = false,
+                message = "Vision warmup prompt failed",
+                throwable = error
+            )
+        }
+    }
+
+    private fun createWarmupImage(): ProcessedImage {
+        val size = 16
+        val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        bitmap.eraseColor(Color.BLACK)
+        return ProcessedImage(bitmap, size, size, 3)
+    }
+
+    private fun countTokens(vararg segments: String?): Int {
+        return segments.filterNotNull()
+            .flatMap { it.split(Regex("\\s+")) }
+            .count { it.isNotBlank() }
+            .coerceAtLeast(1)
     }
 }
 

--- a/app/src/main/kotlin/com/example/coupontracker/llm/StartupMetricsLogger.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/llm/StartupMetricsLogger.kt
@@ -1,0 +1,77 @@
+package com.example.coupontracker.llm
+
+import android.util.Log
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Lightweight logger that emits one-time startup telemetry about the native LLM state.
+ *
+ * Logs are designed to be human-readable in logcat while also acting as structured
+ * breadcrumbs for automated startup diagnostics.
+ */
+object StartupMetricsLogger {
+
+    private const val TAG = "StartupMetrics"
+
+    private val nativeLogged = AtomicBoolean(false)
+    private val modelValidationLogged = AtomicBoolean(false)
+    private val warmupLogged = AtomicBoolean(false)
+
+    fun logNativeLlmLoaded(success: Boolean, message: String? = null, throwable: Throwable? = null) {
+        if (success) {
+            if (nativeLogged.compareAndSet(false, true)) {
+                Log.i(TAG, formatSuccess("✅ Native LLM loaded", message))
+            }
+            return
+        }
+
+        nativeLogged.set(false)
+        Log.e(TAG, formatFailure("❌ Native LLM load failed", message), throwable)
+    }
+
+    fun logModelFilesValidated(success: Boolean, message: String? = null) {
+        if (success) {
+            if (modelValidationLogged.compareAndSet(false, true)) {
+                Log.i(TAG, formatSuccess("✅ Model files validated", message))
+            }
+            return
+        }
+
+        modelValidationLogged.set(false)
+        Log.w(TAG, formatFailure("⚠️ Model file validation failed", message))
+    }
+
+    fun logWarmupComplete(
+        success: Boolean,
+        durationMs: Long? = null,
+        tokensPerSecond: Double? = null,
+        message: String? = null,
+        throwable: Throwable? = null
+    ) {
+        if (success) {
+            val details = buildList {
+                durationMs?.let { add("${it}ms") }
+                tokensPerSecond?.let { add(String.format("%.2f tokens/sec", it)) }
+                message?.let { add(it) }
+            }.joinToString(separator = ", ").takeIf { it.isNotBlank() }
+
+            if (warmupLogged.compareAndSet(false, true)) {
+                val suffix = details?.let { " ($it)" } ?: ""
+                Log.i(TAG, "✅ LLM warmup complete$suffix")
+            }
+            return
+        }
+
+        warmupLogged.set(false)
+        Log.e(TAG, formatFailure("❌ LLM warmup failed", message), throwable)
+    }
+
+    private fun formatSuccess(prefix: String, message: String?): String {
+        return if (message.isNullOrBlank()) prefix else "$prefix - $message"
+    }
+
+    private fun formatFailure(prefix: String, message: String?): String {
+        return if (message.isNullOrBlank()) prefix else "$prefix: $message"
+    }
+}
+

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import com.example.coupontracker.data.model.FieldType
 import com.example.coupontracker.extraction.ExtractionContext
 import com.example.coupontracker.extraction.FieldCandidate
+import com.example.coupontracker.extraction.PassOneUnavailableException
 import com.example.coupontracker.extraction.StructuredFieldExtractor
 import com.example.coupontracker.extraction.validation.BrandLexicon
 import com.example.coupontracker.extraction.validation.FieldValidationCoordinator
@@ -23,6 +24,7 @@ import com.example.coupontracker.schema.PromptGenerator
 import com.example.coupontracker.schema.SchemaValidator
 import com.example.coupontracker.schema.ValidationResult
 import com.example.coupontracker.llm.ModelInfo
+import com.example.coupontracker.llm.StartupMetricsLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -292,34 +294,100 @@ class LocalLlmOcrService(
                 return
             }
 
-            notifyProgress(
-                stage = LlmProgressStage.WARMING_UP,
-                percent = 20,
-                message = "Loading AI model…",
-                progressCallback = progressCallback
-            )
+            try {
+                notifyProgress(
+                    stage = LlmProgressStage.WARMING_UP,
+                    percent = 20,
+                    message = "Loading AI model…",
+                    progressCallback = progressCallback
+                )
 
-            val warmupStart = System.currentTimeMillis()
-            val warmed = warmUpModel()
-            val warmupDuration = System.currentTimeMillis() - warmupStart
+                val warmupDuration = warmUpModel()
+                val warmupMetrics = runTextWarmupPrompt()
 
-            if (!warmed) {
+                val readyMessage = "AI model ready in ${(warmupDuration / 1000).coerceAtLeast(1)}s @ ${"%.2f".format(warmupMetrics.tokensPerSecond)} tok/s"
+                notifyProgress(
+                    stage = LlmProgressStage.WARMING_UP,
+                    percent = 25,
+                    message = readyMessage,
+                    progressCallback = progressCallback
+                )
+            } catch (error: PassOneUnavailableException) {
                 notifyProgress(
                     stage = LlmProgressStage.FAILED,
                     percent = 100,
-                    message = "AI model warmup failed",
+                    message = error.message ?: "AI model warmup failed",
                     progressCallback = progressCallback
                 )
-                throw IllegalStateException("Failed to warm up LLM model ($reason)")
+                throw error
+            } catch (error: Exception) {
+                val unavailable = PassOneUnavailableException(
+                    "Failed to warm up LLM model ($reason)",
+                    error
+                )
+                notifyProgress(
+                    stage = LlmProgressStage.FAILED,
+                    percent = 100,
+                    message = unavailable.message ?: "AI model warmup failed",
+                    progressCallback = progressCallback
+                )
+                throw unavailable
             }
-
-            notifyProgress(
-                stage = LlmProgressStage.WARMING_UP,
-                percent = 25,
-                message = "AI model ready in ${(warmupDuration / 1000).coerceAtLeast(1)}s",
-                progressCallback = progressCallback
-            )
         }
+    }
+
+    private data class WarmupPromptMetrics(
+        val durationMs: Long,
+        val tokensPerSecond: Double,
+        val tokenCount: Int
+    )
+
+    private suspend fun runTextWarmupPrompt(): WarmupPromptMetrics {
+        val warmupPrompt = "Extract a JSON object with storeName and code from the text. Respond with valid JSON only."
+        val warmupOcr = "Warmup coupon: Store WarmupCo offers 5% off with code WARMUP5 until 31 Dec 2025."
+
+        val start = System.currentTimeMillis()
+        return try {
+            val response = llmRuntime.runTextInference(
+                ocrText = warmupOcr,
+                prompt = warmupPrompt,
+                keepLoaded = true
+            ) ?: throw IllegalStateException("Warmup prompt returned null response")
+
+            val duration = System.currentTimeMillis() - start
+            val tokenCount = countTokens(warmupPrompt, warmupOcr, response)
+            val tokensPerSecond = if (duration > 0) tokenCount / (duration / 1000.0) else 0.0
+
+            Log.i(
+                TAG,
+                "✅ Text warmup prompt completed in ${duration}ms (~${"%.2f".format(tokensPerSecond)} tokens/sec, $tokenCount tokens)"
+            )
+            StartupMetricsLogger.logWarmupComplete(
+                success = true,
+                durationMs = duration,
+                tokensPerSecond = tokensPerSecond,
+                message = "Text warmup prompt"
+            )
+
+            WarmupPromptMetrics(duration, tokensPerSecond, tokenCount)
+        } catch (error: Exception) {
+            val duration = System.currentTimeMillis() - start
+            StartupMetricsLogger.logWarmupComplete(
+                success = false,
+                durationMs = duration,
+                message = "Text warmup prompt failed",
+                throwable = error
+            )
+            Log.e(TAG, "Warmup prompt failed", error)
+            throw PassOneUnavailableException("Warmup prompt failed", error)
+        }
+    }
+
+    private fun countTokens(vararg segments: String?): Int {
+        return segments.filterNotNull()
+            .flatMap { it.split(Regex("\\s+")) }
+            .count { it.isNotBlank() }
+            .coerceAtLeast(1)
     }
 
     private fun maybeScheduleNativeSmokeTest(modelInfo: ModelInfo) {
@@ -1750,23 +1818,41 @@ $sanitizedOcr
     /**
      * Warm up the model (preload for faster inference)
      */
-    suspend fun warmUpModel(): Boolean {
+    suspend fun warmUpModel(): Long {
         val warmupStart = System.currentTimeMillis()
-        return try {
-            Log.d(TAG, "Warming up LLM model...")
+        Log.d(TAG, "Warming up LLM model...")
+
+        try {
             val loaded = llmRuntime.loadModel()
             val warmupDuration = System.currentTimeMillis() - warmupStart
             telemetryService.recordModelLoad(loaded, warmupDuration)
-            if (loaded) {
-                modelPinned = true
-                Log.d(TAG, "LLM model pinned in memory for reuse (warmup ${warmupDuration}ms)")
+
+            if (!loaded) {
+                val message = "loadModel() returned false"
+                StartupMetricsLogger.logWarmupComplete(
+                    success = false,
+                    durationMs = warmupDuration,
+                    message = message
+                )
+                throw PassOneUnavailableException(message)
             }
-            loaded
-        } catch (e: Exception) {
+
+            modelPinned = true
+            Log.d(TAG, "LLM model pinned in memory for reuse (warmup ${warmupDuration}ms)")
+            return warmupDuration
+        } catch (error: PassOneUnavailableException) {
+            throw error
+        } catch (error: Exception) {
             val warmupDuration = System.currentTimeMillis() - warmupStart
             telemetryService.recordModelLoad(false, warmupDuration)
-            Log.e(TAG, "Failed to warm up model", e)
-            false
+            Log.e(TAG, "Failed to warm up model", error)
+            StartupMetricsLogger.logWarmupComplete(
+                success = false,
+                durationMs = warmupDuration,
+                message = error.message,
+                throwable = error
+            )
+            throw PassOneUnavailableException("Failed to warm up model", error)
         }
     }
     


### PR DESCRIPTION
## Summary
- add a StartupMetricsLogger that emits native load, model validation, and warmup status breadcrumbs
- run lightweight warmup prompts in LlmRuntimeManager and LocalLlmOcrService, capturing timing and tokens/sec
- introduce PassOneUnavailableException and gate the progressive Pass 1 when warmup fails so LLM-first can be skipped safely

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: plugin org.jetbrains.kotlin.jvm:1.9.22 missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6906386cc4dc8328b632c70999f4fdb1