### PR TITLE
Improve mock LLM detection heuristics and handling

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -610,13 +610,43 @@ class LocalLlmOcrService(
                         Log.w(TAG, "Structured extraction failed: ${error.message}", error)
                     }
                     .getOrElse { emptyMap() }
-                val couponInfo = parseLlmResponseToCouponInfo(
-                    llmResponse,
-                    rawOcrText,
-                    captureTimestamp,
-                    structuredCandidates
-                )
-                
+                val couponInfo = try {
+                    parseLlmResponseToCouponInfo(
+                        llmResponse,
+                        rawOcrText,
+                        captureTimestamp,
+                        structuredCandidates
+                    )
+                } catch (schemaError: IllegalArgumentException) {
+                    if (schemaError.message?.contains("invalid json schema", ignoreCase = true) == true) {
+                        notifyProgress(
+                            stage = LlmProgressStage.FAILED,
+                            percent = 100,
+                            message = "AI returned invalid schema",
+                            progressCallback = progressCallback
+                        )
+                        return@coroutineScope ExtractResult.Failed(
+                            stage = ExtractionStage.LLM,
+                            error = schemaError
+                        )
+                    }
+                    throw schemaError
+                } catch (jsonError: IllegalStateException) {
+                    if (jsonError.message?.contains("invalid json", ignoreCase = true) == true) {
+                        notifyProgress(
+                            stage = LlmProgressStage.FAILED,
+                            percent = 100,
+                            message = "AI response was not valid JSON",
+                            progressCallback = progressCallback
+                        )
+                        return@coroutineScope ExtractResult.Failed(
+                            stage = ExtractionStage.LLM,
+                            error = jsonError
+                        )
+                    }
+                    throw jsonError
+                }
+
                 // CRITICAL: Detect mock responses and reject them
                 if (MockLlmResponseDetector.isMockResponse(couponInfo)) {
                     Log.w(TAG, "Mock response signature: store='${couponInfo.storeName}', code='${couponInfo.redeemCode}', desc='${couponInfo.description}'")

--- a/app/src/main/kotlin/com/example/coupontracker/util/MockLlmResponseDetector.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/MockLlmResponseDetector.kt
@@ -20,6 +20,7 @@ internal object MockLlmResponseDetector {
         Regex("^mock\\s+store$", RegexOption.IGNORE_CASE),
         Regex("^example\\s+store$", RegexOption.IGNORE_CASE),
         Regex("^sample\\s+store$", RegexOption.IGNORE_CASE),
+        Regex("^demo\\s+store$", RegexOption.IGNORE_CASE)
     )
 
     private val MOCK_CODE_PATTERNS = listOf(
@@ -31,8 +32,13 @@ internal object MockLlmResponseDetector {
         Regex("mock\\s+coupon\\s+offer", RegexOption.IGNORE_CASE),
         Regex("placeholder\\s+offer", RegexOption.IGNORE_CASE),
         Regex("sample\\s+coupon", RegexOption.IGNORE_CASE),
-        Regex("example\\s+coupon", RegexOption.IGNORE_CASE)
+        Regex("example\\s+coupon", RegexOption.IGNORE_CASE),
+        Regex("demo\\s+coupon", RegexOption.IGNORE_CASE)
     )
+
+    private val MOCK_TOKEN_REGEX = Regex("\\bmock(?:ed)?\\b", RegexOption.IGNORE_CASE)
+    private val PLACEHOLDER_REGEX = Regex("\\b(?:placeholder|sample|demo|example)\\b", RegexOption.IGNORE_CASE)
+    private val STUB_SOURCE_HINTS = listOf("stub", "mock", "placeholder")
 
     /**
      * Returns true when the coupon info clearly matches a mock response.
@@ -57,6 +63,36 @@ internal object MockLlmResponseDetector {
             lowerDesc.startsWith("mock ") || lowerDesc.contains("mock coupon")
         }
 
+        val hasMockTokens = sequenceOf(
+            store,
+            description,
+            couponInfo.cashbackDetail,
+            couponInfo.category,
+            couponInfo.status,
+            couponInfo.discountType
+        )
+            .filterNotNull()
+            .any { MOCK_TOKEN_REGEX.containsMatchIn(it) }
+
+        val placeholderLanguage = listOf(store, description)
+            .any { value -> PLACEHOLDER_REGEX.containsMatchIn(value) }
+
+        val stubSource = couponInfo.storeNameSource
+            ?.let { source -> STUB_SOURCE_HINTS.any { hint -> source.contains(hint, ignoreCase = true) } }
+            ?: false
+
+        val evidenceHints = couponInfo.storeNameEvidence.any { evidence ->
+            STUB_SOURCE_HINTS.any { hint -> evidence.contains(hint, ignoreCase = true) } ||
+                MOCK_TOKEN_REGEX.containsMatchIn(evidence)
+        }
+
+        val lowConfidenceSignals = couponInfo.needsAttention &&
+            (couponInfo.storeNameEvidence.isEmpty() || stubSource)
+
+        val normalizedStore = store.normalizeForComparison()
+        val normalizedCode = code.normalizeForComparison()
+        val identicalStoreAndCode = normalizedStore.isNotEmpty() && normalizedStore == normalizedCode
+
         val stubSignature = store.equals("mock store", ignoreCase = true) &&
             code.equals("MOCK50", ignoreCase = true) &&
             description.contains("50%", ignoreCase = true)
@@ -65,10 +101,20 @@ internal object MockLlmResponseDetector {
             isMockStore,
             isMockCode,
             isMockDescription,
-            stubSignature
+            stubSignature,
+            hasMockTokens,
+            placeholderLanguage,
+            stubSource,
+            evidenceHints,
+            lowConfidenceSignals,
+            identicalStoreAndCode
         )
 
         return indicators.count { it } >= 2
+    }
+
+    private fun String.normalizeForComparison(): String {
+        return filter { it.isLetterOrDigit() }.lowercase(Locale.ROOT)
     }
 }
 

--- a/tests/llm/MockLlmResponseDetectorHeuristicsTest.kt
+++ b/tests/llm/MockLlmResponseDetectorHeuristicsTest.kt
@@ -1,0 +1,46 @@
+package com.example.coupontracker.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MockLlmResponseDetectorHeuristicsTest {
+
+    @Test
+    fun `flags stub metadata with low confidence`() {
+        val stubCoupon = CouponInfo(
+            storeName = "Retail Demo",
+            description = "Limited time placeholder offer",
+            redeemCode = "SAVE10",
+            needsAttention = true,
+            storeNameSource = "stub_runtime",
+            storeNameEvidence = emptyList()
+        )
+
+        assertTrue(MockLlmResponseDetector.isMockResponse(stubCoupon))
+    }
+
+    @Test
+    fun `flags identical store and code pairs`() {
+        val duplicatedCoupon = CouponInfo(
+            storeName = "MOCK100",
+            description = "Copy this code to save",
+            redeemCode = "MOCK100"
+        )
+
+        assertTrue(MockLlmResponseDetector.isMockResponse(duplicatedCoupon))
+    }
+
+    @Test
+    fun `allows real coupon samples`() {
+        val realCoupon = CouponInfo(
+            storeName = "Flipkart",
+            description = "Extra 15% off on electronics above ₹999",
+            redeemCode = "FLIP15",
+            needsAttention = false,
+            storeNameEvidence = listOf("Flipkart app header")
+        )
+
+        assertFalse(MockLlmResponseDetector.isMockResponse(realCoupon))
+    }
+}


### PR DESCRIPTION
## Summary
- expand the mock response detector with additional heuristics for placeholder metadata, duplicate values, and mock wording
- surface JSON schema violations from the LLM extraction flow as `ExtractResult.Failed` so downstream stages fall back immediately
- add unit coverage under `tests/llm/` to ensure stubbed responses are blocked while real samples continue to pass

## Testing
- ./gradlew test --tests "*MockLlmResponseDetector*" *(fails: Gradle cannot download the kotlin-jvm plugin in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_69065341a18483289b50a4f2703cedea