### PR TITLE
Normalize OCR prompt building and telemetry

### DIFF
--- a/app/src/main/kotlin/com/example/coupontracker/analytics/TelemetryClient.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/analytics/TelemetryClient.kt
@@ -1,0 +1,113 @@
+package com.example.coupontracker.analytics
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import com.example.coupontracker.util.AnalyticsTracker
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Lightweight telemetry client that records counter-style metrics to SharedPreferences
+ * and mirrors the counts into the analytics event log for dashboard ingestion.
+ */
+class TelemetryClient private constructor(
+    private val appContext: Context,
+    private val analyticsTracker: AnalyticsTracker
+) {
+
+    companion object {
+        private const val TAG = "TelemetryClient"
+        private const val PREFS_NAME = "telemetry_counters"
+        private const val KEY_PREFIX = "counter_"
+        private const val ANALYTICS_EVENT = "telemetry_counter"
+
+        @Volatile
+        private var INSTANCE: TelemetryClient? = null
+
+        /**
+         * Obtain the shared instance. Falls back to constructing its own AnalyticsTracker
+         * when one is not provided (e.g., legacy manual construction paths).
+         */
+        fun getInstance(
+            context: Context,
+            analyticsTracker: AnalyticsTracker? = null
+        ): TelemetryClient {
+            val applicationContext = context.applicationContext
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: TelemetryClient(
+                    applicationContext,
+                    analyticsTracker ?: AnalyticsTracker(applicationContext)
+                ).also { INSTANCE = it }
+            }
+        }
+    }
+
+    private val prefs: SharedPreferences =
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val inMemoryCounts = ConcurrentHashMap<String, AtomicLong>()
+
+    /**
+     * Increment a named counter and emit an analytics event describing the new value.
+     */
+    fun incrementCounter(name: String, metadata: Map<String, Any?> = emptyMap()) {
+        val key = name.trim()
+        if (key.isEmpty()) {
+            Log.w(TAG, "Ignoring telemetry increment with blank name")
+            return
+        }
+
+        val sanitizedMetadata = metadata
+            .filterValues { it != null }
+            .mapValues { (_, value) -> value.toString() }
+
+        val newValue = incrementPersistedCounter(key)
+        Log.i(
+            TAG,
+            String.format(
+                Locale.US,
+                "telemetry_counter name=%s count=%d metadata=%s",
+                key,
+                newValue,
+                sanitizedMetadata
+            )
+        )
+
+        scope.launch {
+            runCatching {
+                analyticsTracker.trackEvent(
+                    ANALYTICS_EVENT,
+                    buildMap {
+                        put("name", key)
+                        put("count", newValue.toString())
+                        putAll(sanitizedMetadata)
+                    }
+                )
+            }.onFailure { error ->
+                Log.w(TAG, "Unable to record telemetry counter analytics event", error)
+            }
+        }
+    }
+
+    /**
+     * Read the current value of a counter.
+     */
+    fun getCounterValue(name: String): Long {
+        val key = name.trim()
+        if (key.isEmpty()) return 0
+        return inMemoryCounts[key]?.get() ?: prefs.getLong(KEY_PREFIX + key, 0L)
+    }
+
+    private fun incrementPersistedCounter(name: String): Long {
+        val atomic = inMemoryCounts.getOrPut(name) { AtomicLong(prefs.getLong(KEY_PREFIX + name, 0L)) }
+        val newValue = atomic.incrementAndGet()
+        prefs.edit().putLong(KEY_PREFIX + name, newValue).apply()
+        return newValue
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/di/AnalyticsModule.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/di/AnalyticsModule.kt
@@ -1,6 +1,7 @@
 package com.example.coupontracker.di
 
 import android.content.Context
+import com.example.coupontracker.analytics.TelemetryClient
 import com.example.coupontracker.util.AnalyticsTracker
 import dagger.Module
 import dagger.Provides
@@ -23,5 +24,14 @@ object AnalyticsModule {
     @Singleton
     fun provideAnalyticsTracker(@ApplicationContext context: Context): AnalyticsTracker {
         return AnalyticsTracker(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideTelemetryClient(
+        @ApplicationContext context: Context,
+        analyticsTracker: AnalyticsTracker
+    ): TelemetryClient {
+        return TelemetryClient.getInstance(context, analyticsTracker)
     }
 }

--- a/app/src/main/kotlin/com/example/coupontracker/di/LlmModule.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/di/LlmModule.kt
@@ -1,6 +1,7 @@
 package com.example.coupontracker.di
 
 import android.content.Context
+import com.example.coupontracker.analytics.TelemetryClient
 import com.example.coupontracker.feedback.ValidatorFeedbackRecorder
 import com.example.coupontracker.llm.LlmRuntimeManager
 import com.example.coupontracker.llm.LlmTelemetryService
@@ -56,9 +57,16 @@ object LlmModule {
         @ApplicationContext context: Context,
         ocrEngine: com.example.coupontracker.ocr.OcrEngine,
         llmRuntimeManager: LlmRuntimeManager,
-        validatorFeedbackRecorder: ValidatorFeedbackRecorder
+        validatorFeedbackRecorder: ValidatorFeedbackRecorder,
+        telemetryClient: TelemetryClient
     ): LocalLlmOcrService {
-        return LocalLlmOcrService(context, ocrEngine, llmRuntimeManager, validatorFeedbackRecorder = validatorFeedbackRecorder)
+        return LocalLlmOcrService(
+            context = context,
+            ocrEngine = ocrEngine,
+            injectedLlmRuntimeManager = llmRuntimeManager,
+            validatorFeedbackRecorder = validatorFeedbackRecorder,
+            injectedTelemetryClient = telemetryClient
+        )
     }
 
     @Provides

--- a/app/src/main/kotlin/com/example/coupontracker/ocr/OcrResultProcessor.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/ocr/OcrResultProcessor.kt
@@ -1,0 +1,186 @@
+package com.example.coupontracker.ocr
+
+import android.graphics.Rect
+import android.graphics.RectF
+import android.util.Log
+import com.example.coupontracker.util.OcrTextCleaner
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Normalizes raw OCR output (tiles + text) before it is fed to the LLM prompt builder.
+ * Handles deskewing (sorting by geometry), merging adjacent tiles into lines, and
+ * removing obvious UI noise. Emits quality metrics for observability.
+ */
+class OcrResultProcessor {
+
+    data class OcrTile(
+        val text: String,
+        val bounds: RectF?,
+        val confidence: Float
+    )
+
+    data class ProcessedOcrResult(
+        val normalizedText: String,
+        val mergedLines: List<String>,
+        val averageConfidence: Float,
+        val unknownGlyphRate: Float,
+        val tileCount: Int,
+        val removedNoiseLines: Int,
+        val alphanumericCharCount: Int,
+        val rawCharCount: Int
+    ) {
+        fun meetsQualityThreshold(
+            minAverageConfidence: Float,
+            maxUnknownGlyphRate: Float,
+            minAlphaNumericChars: Int
+        ): Boolean {
+            val confidenceGate = averageConfidence == 0f || averageConfidence >= minAverageConfidence
+            val glyphGate = unknownGlyphRate <= maxUnknownGlyphRate
+            val lengthGate = alphanumericCharCount >= minAlphaNumericChars
+            return confidenceGate && glyphGate && lengthGate && normalizedText.isNotBlank()
+        }
+    }
+
+    companion object {
+        private const val TAG = "OcrResultProcessor"
+        private val UNKNOWN_GLYPH_PATTERN = Regex("[\\uFFFD\\u25A1?]")
+    }
+
+    fun process(rawText: String, tiles: List<OcrTile> = emptyList()): ProcessedOcrResult {
+        val sanitizedTiles = sanitizeTiles(tiles)
+        val (mergedLines, removedNoise) = mergeAndCleanLines(rawText, sanitizedTiles)
+        val cleanedText = mergedLines.joinToString(separator = "\n").trim()
+        val cleanedWithFallback = if (cleanedText.isBlank()) rawText.trim() else cleanedText
+        val cleanedResult = OcrTextCleaner.cleanForLlmExtraction(cleanedWithFallback)
+        val normalizedText = cleanedResult.cleanedText.ifBlank { cleanedWithFallback }
+
+        val alphanumericChars = normalizedText.count { it.isLetterOrDigit() }
+        val avgConfidence = calculateAverageConfidence(sanitizedTiles)
+        val unknownGlyphRate = calculateUnknownGlyphRate(normalizedText)
+
+        Log.i(
+            TAG,
+            String.format(
+                Locale.US,
+                "ocr-quality avg_conf=%.3f unknown_rate=%.3f tiles=%d lines=%d removed_noise=%d raw_chars=%d normalized_chars=%d",
+                avgConfidence,
+                unknownGlyphRate,
+                sanitizedTiles.size,
+                mergedLines.size,
+                removedNoise,
+                rawText.length,
+                normalizedText.length
+            )
+        )
+
+        return ProcessedOcrResult(
+            normalizedText = normalizedText,
+            mergedLines = mergedLines,
+            averageConfidence = avgConfidence,
+            unknownGlyphRate = unknownGlyphRate,
+            tileCount = sanitizedTiles.size,
+            removedNoiseLines = removedNoise,
+            alphanumericCharCount = alphanumericChars,
+            rawCharCount = rawText.length
+        )
+    }
+
+    private fun sanitizeTiles(tiles: List<OcrTile>): List<OcrTile> {
+        return tiles
+            .filter { it.text.isNotBlank() }
+            .map { tile ->
+                val clampedConfidence = tile.confidence.coerceIn(0f, 1f)
+                val bounds = tile.bounds ?: RectF()
+                tile.copy(text = tile.text.trim(), bounds = bounds, confidence = clampedConfidence)
+            }
+    }
+
+    private fun mergeAndCleanLines(
+        rawText: String,
+        tiles: List<OcrTile>
+    ): Pair<List<String>, Int> {
+        if (tiles.isEmpty()) {
+            val rawLines = rawText.lines().map { it.trim() }
+            val cleaned = rawLines.filterNot { OcrTextCleaner.isUiChrome(it) }.filter { it.isNotBlank() }
+            return cleaned to (rawLines.size - cleaned.size)
+        }
+
+        val sortedTiles = tiles.sortedWith(
+            compareBy<OcrTile> { it.bounds?.centerY() ?: Float.MAX_VALUE }
+                .thenBy { it.bounds?.left ?: Float.MIN_VALUE }
+        )
+
+        val rows = mutableListOf<MutableList<OcrTile>>()
+        for (tile in sortedTiles) {
+            val currentRow = rows.lastOrNull()
+            if (currentRow == null) {
+                rows.add(mutableListOf(tile))
+                continue
+            }
+
+            val currentCenter = averageCenterY(currentRow)
+            val targetCenter = tile.bounds?.centerY()
+            val threshold = rowMergeThreshold(currentRow, tile)
+            if (currentCenter != null && targetCenter != null && abs(targetCenter - currentCenter) <= threshold) {
+                currentRow.add(tile)
+            } else {
+                rows.add(mutableListOf(tile))
+            }
+        }
+
+        val mergedLines = rows.map { row ->
+            row.sortedBy { it.bounds?.left ?: 0f }
+                .joinToString(separator = " ") { normalizeToken(it.text) }
+                .replace("  ", " ")
+                .trim()
+        }
+
+        val cleanedLines = mergedLines.filterNot { OcrTextCleaner.isUiChrome(it) }.filter { it.isNotBlank() }
+        val removedNoise = mergedLines.count { it.isBlank() || OcrTextCleaner.isUiChrome(it) }
+        return cleanedLines to removedNoise
+    }
+
+    private fun averageCenterY(row: List<OcrTile>): Float? {
+        val centers = row.mapNotNull { it.bounds?.centerY() }
+        if (centers.isEmpty()) return null
+        return centers.average().toFloat()
+    }
+
+    private fun rowMergeThreshold(currentRow: List<OcrTile>, candidate: OcrTile): Float {
+        val heights = currentRow.mapNotNull { it.bounds?.height() }
+        val candidateHeight = candidate.bounds?.height()
+        val avgHeight = when {
+            heights.isNotEmpty() -> heights.average().toFloat()
+            candidateHeight != null -> candidateHeight
+            else -> 24f
+        }
+        return max(8f, avgHeight * 0.6f)
+    }
+
+    private fun normalizeToken(text: String): String {
+        val trimmed = text.trim()
+        return when {
+            trimmed.endsWith("-") -> trimmed.dropLast(1)
+            else -> trimmed
+        }
+    }
+
+    private fun calculateAverageConfidence(tiles: List<OcrTile>): Float {
+        if (tiles.isEmpty()) return 0f
+        val confidences = tiles.map { it.confidence }.filter { it > 0f }
+        if (confidences.isEmpty()) return 0f
+        val sum = confidences.sum()
+        return (sum / confidences.size).coerceIn(0f, 1f)
+    }
+
+    private fun calculateUnknownGlyphRate(text: String): Float {
+        if (text.isEmpty()) return 0f
+        val unknownCount = UNKNOWN_GLYPH_PATTERN.findAll(text).count()
+        return min(1f, unknownCount.toFloat() / text.length.toFloat())
+    }
+}
+
+private fun Rect.toRectF(): RectF = RectF(this)

--- a/app/src/main/kotlin/com/example/coupontracker/prompt/PromptBuilder.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/prompt/PromptBuilder.kt
@@ -1,0 +1,210 @@
+package com.example.coupontracker.prompt
+
+import com.example.coupontracker.ocr.OcrResultProcessor
+import com.example.coupontracker.ocr.OcrResultProcessor.OcrTile
+import com.example.coupontracker.schema.CouponSchema
+import com.example.coupontracker.schema.FieldType
+import com.example.coupontracker.schema.Schema
+import com.example.coupontracker.schema.SchemaField
+import com.example.coupontracker.schema.PromptGenerator
+import java.util.Locale
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Builds LLM prompts from OCR output while applying normalization and schema guardrails.
+ */
+class PromptBuilder(
+    private val schema: Schema = CouponSchema.SCHEMA,
+    private val ocrResultProcessor: OcrResultProcessor = OcrResultProcessor()
+) {
+
+    data class Result(
+        val prompt: String,
+        val systemPrompt: String,
+        val userPrompt: String,
+        val assistantPrimer: String,
+        val processedOcr: OcrResultProcessor.ProcessedOcrResult,
+        val truncatedOcrForPrompt: String
+    )
+
+    companion object {
+        private const val MAX_OCR_CHARS = 1_200
+    }
+
+    fun build(rawOcrText: String, tiles: List<OcrTile> = emptyList()): Result {
+        val processed = ocrResultProcessor.process(rawOcrText, tiles)
+        val truncatedOcr = PromptGenerator.sanitizeOcrSnippet(processed.normalizedText, MAX_OCR_CHARS)
+        val system = buildSystemPrompt(processed)
+        val user = buildUserPrompt(truncatedOcr, processed)
+        val assistant = "<|im_start|>assistant\n{"
+        val prompt = listOf(system, user, assistant).joinToString(separator = "\n\n")
+        return Result(
+            prompt = prompt,
+            systemPrompt = system,
+            userPrompt = user,
+            assistantPrimer = assistant,
+            processedOcr = processed,
+            truncatedOcrForPrompt = truncatedOcr
+        )
+    }
+
+    private fun buildSystemPrompt(processed: OcrResultProcessor.ProcessedOcrResult): String {
+        val guardrails = buildJsonSchema(schema)
+        val requiredFields = schema.getRequiredFields().joinToString { it.name }
+        val confidenceSummary = String.format(
+            Locale.US,
+            "Average OCR confidence: %.2f | Unknown glyph rate: %.2f | Tiles: %d",
+            processed.averageConfidence,
+            processed.unknownGlyphRate,
+            processed.tileCount
+        )
+        val qualityHint = "OCR normalization applied (deskewed, merged lines, UI noise removed). $confidenceSummary"
+        return buildString {
+            appendLine("<|im_start|>system")
+            appendLine("You are a contractual JSON generator. Emit exactly one JSON object that validates against the schema below.")
+            appendLine("Never include commentary before or after the JSON payload.")
+            appendLine()
+            appendLine("Schema version: ${schema.version}")
+            appendLine("JSON Schema:")
+            appendLine(guardrails)
+            appendLine()
+            appendLine("Rules:")
+            appendLine("- Required keys: $requiredFields")
+            appendLine("- Use null (without quotes) when a field is absent.")
+            appendLine("- Preserve wording verbatim; never add arithmetic or commentary.")
+            appendLine("- Additional properties are forbidden (must not appear in output).")
+            appendLine()
+            appendLine(qualityHint)
+            append("<|im_end|>")
+        }
+    }
+
+    private fun buildUserPrompt(
+        truncatedOcr: String,
+        processed: OcrResultProcessor.ProcessedOcrResult
+    ): String {
+        val metrics = String.format(
+            Locale.US,
+            "metrics: avg_conf=%.2f unknown_rate=%.2f", processed.averageConfidence, processed.unknownGlyphRate
+        )
+        return buildString {
+            appendLine("<|im_start|>user")
+            appendLine("Structure the following OCR text into JSON (quality $metrics). Only respond with JSON:")
+            appendLine(truncatedOcr)
+            append("<|im_end|>")
+        }
+    }
+
+    private fun buildJsonSchema(schema: Schema): String {
+        val json = JSONObject()
+        json.put("\$schema", "https://json-schema.org/draft/2020-12/schema")
+        json.put("title", "${schema.name}Response")
+        json.put("type", "object")
+        json.put("additionalProperties", false)
+
+        val properties = JSONObject()
+        schema.fields.forEach { field ->
+            properties.put(field.name, buildFieldSchema(field))
+        }
+        json.put("properties", properties)
+
+        val required = schema.getRequiredFields()
+        if (required.isNotEmpty()) {
+            json.put("required", JSONArray(required.map { it.name }))
+        }
+
+        return json.toString(2)
+    }
+
+    private fun buildFieldSchema(field: SchemaField): JSONObject {
+        return when (val type = field.type) {
+            FieldType.StringType, FieldType.DateType -> baseSchema("string", field)
+            FieldType.NumberType -> baseSchema("number", field)
+            FieldType.BooleanType -> baseSchema("boolean", field)
+            is FieldType.EnumType -> baseSchema("string", field).apply {
+                put("enum", JSONArray(type.allowedValues))
+            }
+            is FieldType.ArrayType -> JSONObject().apply {
+                put("type", "array")
+                put("items", buildNestedType(type.itemType))
+                applyNullability(this, field)
+            }
+            is FieldType.ObjectType -> JSONObject().apply {
+                put("type", "object")
+                val nestedProps = JSONObject()
+                type.properties.values.forEach { nestedField ->
+                    nestedProps.put(nestedField.name, buildFieldSchema(nestedField))
+                }
+                put("properties", nestedProps)
+                val nestedRequired = type.properties.values.filter { it.required }
+                if (nestedRequired.isNotEmpty()) {
+                    put("required", JSONArray(nestedRequired.map { it.name }))
+                }
+                put("additionalProperties", false)
+                applyNullability(this, field)
+            }
+            FieldType.NullableType -> JSONObject().apply {
+                put("type", JSONArray(listOf("null", "string")))
+            }
+        }
+    }
+
+    private fun buildNestedType(type: FieldType): JSONObject {
+        return when (type) {
+            FieldType.StringType, FieldType.DateType -> JSONObject().put("type", "string")
+            FieldType.NumberType -> JSONObject().put("type", "number")
+            FieldType.BooleanType -> JSONObject().put("type", "boolean")
+            is FieldType.EnumType -> JSONObject().apply {
+                put("type", "string")
+                put("enum", JSONArray(type.allowedValues))
+            }
+            is FieldType.ArrayType -> JSONObject().apply {
+                put("type", "array")
+                put("items", buildNestedType(type.itemType))
+            }
+            is FieldType.ObjectType -> JSONObject().apply {
+                put("type", "object")
+                val nestedProps = JSONObject()
+                type.properties.values.forEach { nestedField ->
+                    nestedProps.put(nestedField.name, buildFieldSchema(nestedField))
+                }
+                put("properties", nestedProps)
+                val nestedRequired = type.properties.values.filter { it.required }
+                if (nestedRequired.isNotEmpty()) {
+                    put("required", JSONArray(nestedRequired.map { it.name }))
+                }
+                put("additionalProperties", false)
+            }
+            FieldType.NullableType -> JSONObject().put("type", JSONArray(listOf("null", "string")))
+        }
+    }
+
+    private fun baseSchema(typeName: String, field: SchemaField): JSONObject {
+        return JSONObject().apply {
+            put("type", typeName)
+            applyNullability(this, field)
+        }
+    }
+
+    private fun applyNullability(target: JSONObject, field: SchemaField) {
+        if (!field.required) {
+            val existing = target.opt("type")
+            when (existing) {
+                is JSONArray -> {
+                    val values = mutableListOf<String>()
+                    for (i in 0 until existing.length()) {
+                        values.add(existing.getString(i))
+                    }
+                    if (!values.contains("null")) {
+                        values.add("null")
+                    }
+                    target.put("type", JSONArray(values))
+                }
+                is String -> {
+                    target.put("type", JSONArray(listOf(existing, "null")))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
+++ b/app/src/main/kotlin/com/example/coupontracker/util/LocalLlmOcrService.kt
@@ -2,7 +2,9 @@ package com.example.coupontracker.util
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.RectF
 import android.util.Log
+import com.example.coupontracker.analytics.TelemetryClient
 import com.example.coupontracker.data.model.FieldType
 import com.example.coupontracker.extraction.ExtractionContext
 import com.example.coupontracker.extraction.FieldCandidate
@@ -17,9 +19,12 @@ import com.example.coupontracker.extraction.validation.ValidationEventLogger
 import com.example.coupontracker.llm.LlmRuntimeManager
 import com.example.coupontracker.llm.LlmTelemetryService
 import com.example.coupontracker.ocr.OcrEngine
+import com.example.coupontracker.ocr.OcrResultProcessor
+import com.example.coupontracker.ocr.OcrResultProcessor.OcrTile
+import com.example.coupontracker.ocr.OcrTextSpan
 import com.example.coupontracker.feedback.ValidatorFeedbackRecorder
+import com.example.coupontracker.prompt.PromptBuilder
 import com.example.coupontracker.schema.CouponSchema
-import com.example.coupontracker.schema.PromptGenerator
 import com.example.coupontracker.schema.SchemaValidator
 import com.example.coupontracker.schema.ValidationResult
 import com.example.coupontracker.llm.ModelInfo
@@ -53,7 +58,9 @@ class LocalLlmOcrService(
     private val injectedLlmRuntimeManager: LlmRuntimeManager? = null,
     private val injectedTelemetryService: LlmTelemetryService? = null,
     private val customOcrTextProvider: (suspend (Bitmap) -> String?)? = null,
-    private val validatorFeedbackRecorder: ValidatorFeedbackRecorder? = null
+    private val validatorFeedbackRecorder: ValidatorFeedbackRecorder? = null,
+    private val injectedPromptBuilder: PromptBuilder? = null,
+    private val injectedTelemetryClient: TelemetryClient? = null
 ) {
     
     companion object {
@@ -69,17 +76,15 @@ class LocalLlmOcrService(
         private const val SERVICE_VERSION = "1.4.0"  // Qwen2.5 migration
         private const val SUPPORTED_MODEL_VERSION = "qwen25_1.5b_instruct_q4"
 
-        // Shorten OCR snippet to keep prompts under ~300 tokens and reduce latency on Qwen
-        private const val OCR_SNIPPET_MAX_CHARS = 1200
-        
-        // Feature flags for schema-driven architecture
-        // Set to true to enable schema-driven prompts/validation, false to use manual/legacy
-        private const val USE_SCHEMA_PROMPTS = true
-        private const val USE_SCHEMA_VALIDATION = true
+        private const val MIN_AVG_CONFIDENCE_FOR_PASS_ONE = 0.38f
+        private const val MAX_UNKNOWN_GLYPH_RATE_FOR_PASS_ONE = 0.18f
+        private const val MIN_ALPHANUMERIC_CHARS_FOR_PASS_ONE = 24
 
-        // Prompt optimization: Use compact prompts to reduce token count (920 → ~350 tokens)
-        // Compact prompts rely on grammar enforcement for structure, reducing verbosity
-        private const val USE_COMPACT_PROMPTS = true
+        private const val TELEMETRY_PASS_ONE_SUCCESS = "PassOneSuccess"
+        private const val TELEMETRY_FALLBACK_MOCK = "FallbackDueToMock"
+        private const val TELEMETRY_FALLBACK_LOW_OCR = "FallbackDueToLowOcr"
+        
+        private const val USE_SCHEMA_VALIDATION = true
 
         private const val MAX_LLM_ATTEMPTS = 2
 
@@ -169,6 +174,11 @@ class LocalLlmOcrService(
         val memoryUsageMb: Long
     )
 
+    private data class PreparedPrompt(
+        val rawText: String?,
+        val prompt: PromptBuilder.Result
+    )
+
     private fun CouponInfo.toCanonicalContract(): CouponInfo {
         return copy(
             category = null,
@@ -185,6 +195,8 @@ class LocalLlmOcrService(
     // Dependencies
     private val llmRuntime = injectedLlmRuntimeManager ?: LlmRuntimeManager.getInstance(context)
     private val telemetryService = injectedTelemetryService ?: LlmTelemetryService.getInstance(context)
+    private val promptBuilder = injectedPromptBuilder ?: PromptBuilder()
+    private val telemetryClient = injectedTelemetryClient ?: TelemetryClient.getInstance(context)
     private val imagePreprocessor = ImagePreprocessor()
     private val textExtractor = TextExtractor() // Fallback
     private val structuredFieldExtractor = StructuredFieldExtractor()
@@ -545,14 +557,13 @@ class LocalLlmOcrService(
 
             ensureModelWarm("typed_inference", progressCallback)
 
-            // Step 3: Capture OCR text (used for prompt and post-processing)
             notifyProgress(
                 stage = LlmProgressStage.OCR,
                 percent = 30,
                 message = "Reading coupon text…",
                 progressCallback = progressCallback
             )
-            val rawOcrText = captureRawOcrText(bitmap)?.takeIf { it.isNotBlank() }
+            val preparedPrompt = preparePrompt(bitmap)
                 ?: run {
                     notifyProgress(
                         stage = LlmProgressStage.FAILED,
@@ -565,16 +576,65 @@ class LocalLlmOcrService(
                         error = IllegalStateException("OCR returned blank text; cannot build prompt")
                     )
                 }
+            val promptResult = preparedPrompt.prompt
+            val metrics = promptResult.processedOcr
+
+            if (!metrics.meetsQualityThreshold(
+                    MIN_AVG_CONFIDENCE_FOR_PASS_ONE,
+                    MAX_UNKNOWN_GLYPH_RATE_FOR_PASS_ONE,
+                    MIN_ALPHANUMERIC_CHARS_FOR_PASS_ONE
+                )
+            ) {
+                telemetryClient.incrementCounter(
+                    TELEMETRY_FALLBACK_LOW_OCR,
+                    mapOf(
+                        "avgConfidence" to metrics.averageConfidence,
+                        "unknownRate" to metrics.unknownGlyphRate,
+                        "tiles" to metrics.tileCount,
+                        "entry" to "typed"
+                    )
+                )
+
+                notifyProgress(
+                    stage = LlmProgressStage.FAILED,
+                    percent = 100,
+                    message = "OCR quality too low – using fallback",
+                    progressCallback = progressCallback
+                )
+
+                val fallbackInfo = runCatching { fallbackToTraditionalOCR(bitmap, captureTimestamp) }
+                    .onFailure { Log.w(TAG, "Fallback OCR failed after low-quality detection", it) }
+                    .getOrElse { CouponInfo() }
+
+                val signals = ExtractionSignals(
+                    qualityScore = 0,
+                    fieldConfidences = emptyMap(),
+                    processingTimeMs = System.currentTimeMillis() - startTime,
+                    memoryUsageMB = memoryUsage.toFloat(),
+                    stage = ExtractionStage.LLM,
+                    nativeAvailable = llmRuntime.isModelAvailable(),
+                    modelVersion = SUPPORTED_MODEL_VERSION
+                )
+
+                return@coroutineScope ExtractResult.LowQuality(
+                    info = fallbackInfo,
+                    reason = QualityReason.LOW_QUALITY_EXTRACTION,
+                    signals = signals
+                )
+            }
+
             notifyProgress(
                 stage = LlmProgressStage.PROMPTING,
                 percent = 45,
                 message = "Asking the AI to structure the coupon…",
                 progressCallback = progressCallback
             )
-            val prompt = createCouponExtractionPrompt(rawOcrText)
+
+            val normalizedOcr = promptResult.processedOcr.normalizedText
+            val rawOcrText = preparedPrompt.rawText ?: normalizedOcr
             val extractionContext = ExtractionContext(
                 imageUri = "inline://llm",
-                ocrText = rawOcrText,
+                ocrText = normalizedOcr,
                 captureTimestamp = captureTimestamp
             )
             val structuredCandidatesDeferred = async(Dispatchers.Default) {
@@ -588,7 +648,7 @@ class LocalLlmOcrService(
                 message = "Running on-device AI…",
                 progressCallback = progressCallback
             )
-            val llmOutcome = runLlmInferenceWithRetry(rawOcrText, prompt, progressCallback)
+            val llmOutcome = runLlmInferenceWithRetry(normalizedOcr, promptResult.prompt, progressCallback)
             memoryUsage = llmOutcome.memoryUsageMb
             val llmResponse = llmOutcome.response
 
@@ -655,7 +715,18 @@ class LocalLlmOcrService(
                 
                 // Determine result based on quality
                 return@coroutineScope when {
-                    qualityScore >= 70 -> ExtractResult.Good(couponInfo, signals)
+                    qualityScore >= 70 -> {
+                        telemetryClient.incrementCounter(
+                            TELEMETRY_PASS_ONE_SUCCESS,
+                            mapOf(
+                                "avgConfidence" to metrics.averageConfidence,
+                                "unknownRate" to metrics.unknownGlyphRate,
+                                "tiles" to metrics.tileCount,
+                                "entry" to "typed"
+                            )
+                        )
+                        ExtractResult.Good(couponInfo, signals)
+                    }
                     qualityScore >= 40 -> {
                         val reason = determineQualityReason(couponInfo)
                         ExtractResult.LowQuality(couponInfo, reason, signals)
@@ -723,42 +794,76 @@ class LocalLlmOcrService(
         var memoryUsage = 0L
         var extractedFieldCount = 0
         var fallbackUsed: String? = null
-        
+
         try {
             Log.d(TAG, "Processing coupon with Qwen2-1.5B (text-only)")
-            
-            // Step 1: Validate input
+
             if (bitmap.isRecycled) {
                 throw IllegalArgumentException("Input bitmap is recycled")
             }
-            
-            // Step 2: Check service availability
+
             if (!isServiceAvailable()) {
                 throw IllegalStateException("LLM model not available on device")
             }
 
             ensureModelWarm("legacy_entry", null)
 
-            // Step 3: Extract OCR text from image
-            Log.d(TAG, "Extracting OCR text from image...")
-            val ocrText = captureRawOcrText(bitmap)
-            if (ocrText.isNullOrBlank()) {
-                throw IllegalStateException("OCR text extraction failed or returned empty text")
+            val preparedPrompt = preparePrompt(bitmap)
+                ?: throw IllegalStateException("OCR text extraction failed or returned empty text")
+            val promptResult = preparedPrompt.prompt
+            val metrics = promptResult.processedOcr
+
+            Log.d(
+                TAG,
+                "OCR normalization: raw_chars=${preparedPrompt.rawText?.length ?: 0} cleaned_chars=${promptResult.processedOcr.normalizedText.length} lines=${metrics.mergedLines.size}"
+            )
+
+            if (!metrics.meetsQualityThreshold(
+                    MIN_AVG_CONFIDENCE_FOR_PASS_ONE,
+                    MAX_UNKNOWN_GLYPH_RATE_FOR_PASS_ONE,
+                    MIN_ALPHANUMERIC_CHARS_FOR_PASS_ONE
+                )
+            ) {
+                Log.w(
+                    TAG,
+                    "Bypassing LLM due to low OCR quality (avg_conf=${metrics.averageConfidence}, unknown_rate=${metrics.unknownGlyphRate}, alnum=${metrics.alphanumericCharCount})"
+                )
+                telemetryClient.incrementCounter(
+                    TELEMETRY_FALLBACK_LOW_OCR,
+                    mapOf(
+                        "avgConfidence" to metrics.averageConfidence,
+                        "unknownRate" to metrics.unknownGlyphRate,
+                        "tiles" to metrics.tileCount,
+                        "alnumChars" to metrics.alphanumericCharCount
+                    )
+                )
+
+                val fallbackResult = fallbackToTraditionalOCR(bitmap, captureTimestamp)
+                fallbackUsed = "LOW_OCR"
+                extractedFieldCount = countExtractedFields(fallbackResult)
+                val duration = System.currentTimeMillis() - startTime
+                telemetryService.recordInference(
+                    durationMs = duration,
+                    success = false,
+                    errorType = "LOW_OCR_QUALITY",
+                    fallbackUsed = fallbackUsed,
+                    extractedFieldCount = extractedFieldCount,
+                    memoryUsageMB = memoryUsage
+                )
+                return@coroutineScope fallbackResult
             }
-            Log.d(TAG, "OCR extracted ${ocrText.length} chars: ${ocrText.take(200)}...")
-            
-            // Step 4: Create structured extraction prompt
-            val prompt = createCouponExtractionPrompt(ocrText)
+
+            val normalizedOcr = promptResult.processedOcr.normalizedText
+            val rawOcrText = preparedPrompt.rawText ?: normalizedOcr
             val extractionContext = ExtractionContext(
                 imageUri = "inline://llm",
-                ocrText = ocrText,
+                ocrText = normalizedOcr,
                 captureTimestamp = captureTimestamp
             )
             val structuredCandidatesDeferred = async(Dispatchers.Default) {
                 structuredFieldExtractor.detectFieldsStructured(extractionContext)
             }
-            
-            // Step 5: Run TEXT-ONLY LLM inference with OCR text
+
             Log.d(TAG, "========================================")
             Log.d(TAG, "🤖 Running Qwen text-only inference...")
             Log.d(TAG, "⏱️  First run: ~60s (model warmup)")
@@ -766,47 +871,51 @@ class LocalLlmOcrService(
             Log.d(TAG, "⏳ Please wait... (max ${INFERENCE_TIMEOUT_MS / 1000}s)")
             Log.d(TAG, "========================================")
             val inferenceStartTime = System.currentTimeMillis()
-            val llmOutcome = runLlmInferenceWithRetry(ocrText, prompt, progressCallback = null)
+            val llmOutcome = runLlmInferenceWithRetry(normalizedOcr, promptResult.prompt, progressCallback = null)
             val inferenceElapsed = System.currentTimeMillis() - inferenceStartTime
             memoryUsage = llmOutcome.memoryUsageMb
             val llmResponse = llmOutcome.response
             Log.d(TAG, "⏱️  Inference completed in ${inferenceElapsed / 1000}s")
 
-            // Step 6: Parse and validate response
             val couponInfo = if (llmResponse != null) {
-                // We already have OCR text from Step 3, no need to extract again
                 val structuredCandidates = runCatching { structuredCandidatesDeferred.await() }
                     .onFailure { error ->
                         Log.w(TAG, "Structured extraction failed: ${error.message}", error)
                     }
                     .getOrElse { emptyMap() }
+
                 val parsedInfo = parseLlmResponseToCouponInfo(
                     llmResponse,
-                    ocrText,
+                    rawOcrText,
                     captureTimestamp,
                     structuredCandidates
                 )
-                
-                // CRITICAL: Detect mock responses and fall back to OCR
+
                 if (MockLlmResponseDetector.isMockResponse(parsedInfo)) {
                     Log.w(TAG, "Mock response signature: store='${parsedInfo.storeName}', code='${parsedInfo.redeemCode}', desc='${parsedInfo.description}'")
                     Log.w(TAG, "⚠️ MOCK LLM RESPONSE DETECTED - Falling back to OCR")
+                    telemetryClient.incrementCounter(
+                        TELEMETRY_FALLBACK_MOCK,
+                        mapOf(
+                            "entry" to "typed",
+                            "avgConfidence" to metrics.averageConfidence,
+                            "unknownRate" to metrics.unknownGlyphRate,
+                            "tiles" to metrics.tileCount
+                        )
+                    )
                     throw IllegalStateException("Mock LLM response detected (placeholder runtime output)")
                 }
-                
+
                 parsedInfo
             } else {
-                // Record timeout and throw
                 val duration = System.currentTimeMillis() - startTime
                 telemetryService.recordTimeout(duration, memoryUsage)
                 throw Exception("LLM inference timed out or returned null")
             }
-            
-            // Step 7: Validate extraction quality and count fields
+
             validateExtractionQuality(couponInfo)
             extractedFieldCount = countExtractedFields(couponInfo)
-            
-            // Record successful inference
+
             val duration = System.currentTimeMillis() - startTime
             telemetryService.recordInference(
                 durationMs = duration,
@@ -814,14 +923,23 @@ class LocalLlmOcrService(
                 extractedFieldCount = extractedFieldCount,
                 memoryUsageMB = memoryUsage
             )
-            
+
+            telemetryClient.incrementCounter(
+                TELEMETRY_PASS_ONE_SUCCESS,
+                mapOf(
+                    "avgConfidence" to metrics.averageConfidence,
+                    "unknownRate" to metrics.unknownGlyphRate,
+                    "tiles" to metrics.tileCount,
+                    "durationMs" to duration
+                )
+            )
+
             Log.d(TAG, "Qwen extraction completed successfully in ${duration}ms")
             couponInfo
-            
+
         } catch (e: Exception) {
             Log.e(TAG, "LLM processing failed: ${e.message}", e)
 
-            // Record failure
             val duration = System.currentTimeMillis() - startTime
             val errorType = when {
                 e.message?.contains("too short", ignoreCase = true) == true -> "SHORT_RESPONSE"
@@ -845,11 +963,8 @@ class LocalLlmOcrService(
 
             Log.d(TAG, "Falling back to traditional OCR after invalid LLM response")
             val fallbackResult = fallbackToTraditionalOCR(bitmap, captureTimestamp)
-            // TODO: revisit ML Kit fallback semantics now that LLm path is the primary extractor
 
-            // Determine which fallback was used based on result quality
-            fallbackUsed = if (fallbackResult.storeName != "Unknown Store" ||
-                             !fallbackResult.redeemCode.isNullOrBlank()) {
+            fallbackUsed = if (fallbackResult.storeName != "Unknown Store" || !fallbackResult.redeemCode.isNullOrBlank()) {
                 "ML_KIT"
             } else {
                 "MODEL_BASED"
@@ -883,88 +998,23 @@ class LocalLlmOcrService(
      * Detect mock/placeholder responses from stub JNI
      * Returns true if the response matches known mock patterns
      */
-    /**
-     * Create optimized structured prompt for coupon extraction with strict schema that funnels savings into description only
-     */
-    private fun createCouponExtractionPrompt(ocrText: String): String {
-        // CRITICAL: Clean OCR text first to remove UI chrome (battery, signal, status bar)
-        val cleanedOcr = com.example.coupontracker.util.OcrTextCleaner.cleanOcrText(ocrText)
-        val finalOcr = cleanedOcr.ifBlank { ocrText }  // Fallback to raw if cleaning too aggressive
-        
-        val sanitizedOcr = sanitizeOcrSnippet(finalOcr)
-        return if (USE_SCHEMA_PROMPTS) {
-            // Schema-driven prompt generation
-            if (USE_COMPACT_PROMPTS) {
-                // Compact: ~350 tokens (relies on grammar for structure)
-                com.example.coupontracker.schema.CompactPromptGenerator.generateCompletePrompt(
-                    CouponSchema.SCHEMA, 
-                    sanitizedOcr
-                )
-            } else {
-                // Verbose: ~920 tokens (includes all examples and hints)
-                PromptGenerator.generateCompletePrompt(CouponSchema.SCHEMA, sanitizedOcr)
-            }
-        } else {
-            // Manual prompt (legacy)
-            buildQwenPromptManual(sanitizedOcr)
-        }
+    private suspend fun preparePrompt(bitmap: Bitmap): PreparedPrompt? {
+        val tiles = runCatching { ocrEngine.recognizeWithBoxes(bitmap) }
+            .onFailure { error -> Log.w(TAG, "Failed to capture OCR tiles", error) }
+            .getOrElse { emptyList() }
+            .map { it.toPromptTile() }
+            .filter { it.text.isNotBlank() }
+
+        val rawText = captureRawOcrText(bitmap)
+        val effectiveText = when {
+            !rawText.isNullOrBlank() -> rawText
+            tiles.isNotEmpty() -> tiles.joinToString(separator = "\n") { it.text }
+            else -> null
+        } ?: return null
+
+        val promptResult = promptBuilder.build(effectiveText, tiles)
+        return PreparedPrompt(rawText = rawText, prompt = promptResult)
     }
-
-    /**
-     * Qwen2.5-optimized prompt for structured JSON extraction (MANUAL/LEGACY)
-     * Qwen2.5 has better instruction-following than Qwen2
-     * 
-     * NOTE: This is the manual/legacy prompt. When USE_SCHEMA_PROMPTS=true,
-     * the prompt is generated from CouponSchema instead.
-     */
-    private fun buildQwenPromptManual(sanitizedOcr: String): String = """
-<|im_start|>system
-You are a JSON extractor. Extract coupon data and output ONLY valid JSON.
-
-🚨 REQUIRED JSON KEYS (always include these four keys):
-1. "storeName" - Store/brand name exactly from the coupon
-2. "redeemCode" - Coupon/promo code. Use null if no code is present
-3. "expiryDate" - Expiry date text exactly as written (no reformatting)
-4. "description" - Offer description verbatim, no extra math or commentary
-
-CRITICAL RULES:
-1. Output ONLY these four keys. No additional fields are allowed.
-2. If data is missing, output null (never invent values or placeholders).
-3. Preserve the coupon wording: do NOT add numbers together or rewrite text.
-4. Do not change date formats. Copy the characters exactly as seen.
-5. Output ONLY the JSON object. No explanations before or after the JSON.
-
-Schema:
-{"storeName":str|null,"redeemCode":str|null,"expiryDate":str|null,"description":str|null}
-
-EXTRACTION GUIDE:
-
-storeName:
-- Brand name only (e.g., "PUMA", "Amazon", "Flipkart")
-- Ignore partner logos or watermarks.
-
-redeemCode:
-- Search for "Code:", "Coupon:", or standalone alphanumeric codes.
-- Strip prefixes and whitespace. Example: "Code: SAVE50" → "SAVE50".
-- Use null when no code is visible.
-
-expiryDate:
-- Copy the date text exactly (e.g., "31 May 2025", "2025-12-31").
-- If the coupon only says "Expires in 5 days", return null (the app will compute it).
-- Never invent months or days.
-
-description:
-- Use the main offer sentence exactly as printed.
-- Keep symbols like "₹", "+", "%".
-- Do NOT append helper text like "(Hybrid)" or perform arithmetic.
-
-Provide the JSON object now.
-<|im_end|>
-<|im_start|>user
-OCR_TEXT:
-$sanitizedOcr
-<|im_end|>
-""".trimIndent()
 
     private suspend fun captureRawOcrText(bitmap: Bitmap): String? {
         customOcrTextProvider?.let { provider ->
@@ -997,11 +1047,17 @@ $sanitizedOcr
         }
     }
 
-    private fun sanitizeOcrSnippet(ocrText: String): String {
-        if (ocrText.isBlank()) return "(no OCR text captured)"
-        val normalized = ocrText.trim().replace("\r", "")
-        return if (normalized.length <= OCR_SNIPPET_MAX_CHARS) normalized
-        else normalized.substring(0, OCR_SNIPPET_MAX_CHARS).trimEnd() + "…"
+    private fun OcrTextSpan.toPromptTile(): OcrTile {
+        val bounds = try {
+            RectF(boundingBox)
+        } catch (_: Throwable) {
+            RectF()
+        }
+        return OcrTile(
+            text = text,
+            bounds = bounds,
+            confidence = confidence.coerceIn(0f, 1f)
+        )
     }
 
     private fun extractJsonSlice(text: String): String? {


### PR DESCRIPTION
## Summary
- add a telemetry client helper and wire it into Hilt so structured OCR runs can emit counters
- normalize OCR output tiles before prompt creation and include schema guardrails in a new prompt builder
- record OCR quality metrics and bypass the LLM pass when confidence is low while logging fallback reasons

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: plugin repository unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_69065341d5dc8328af568d27ed6c29ac